### PR TITLE
Fixed not-saving bug for moduleInfoModules in HUD

### DIFF
--- a/src/main/java/minegame159/meteorclient/settings/ModuleListSetting.java
+++ b/src/main/java/minegame159/meteorclient/settings/ModuleListSetting.java
@@ -71,7 +71,7 @@ public class ModuleListSetting extends Setting<List<ToggleModule>> {
 
     @Override
     public CompoundTag toTag() {
-        CompoundTag tag = new CompoundTag();
+        CompoundTag tag = saveGeneral();
 
         ListTag modulesTag = new ListTag();
         for (ToggleModule module : get()) modulesTag.add(StringTag.of(module.name));


### PR DESCRIPTION
Module list info wasn't saving before. (I hope) it fixed now

![example](https://user-images.githubusercontent.com/35692622/101557628-6e35d500-39ce-11eb-971d-f7555e717e1b.png)
