### PR TITLE
AutoDisable for freecam

### DIFF
--- a/src/main/java/minegame159/meteorclient/modules/render/VoidESP.java
+++ b/src/main/java/minegame159/meteorclient/modules/render/VoidESP.java
@@ -96,7 +96,6 @@ public class VoidESP extends ToggleModule {
                             ++blocksFromTop;
 
                     if (blocksFromTop >= holeHeight) voidHoles.add(topBlockPos);
-
                 }
             }
         }


### PR DESCRIPTION
Added _Auto-Disable_ for `freecam` on take damage, on death and on logout.
By suggestion from [**[ᴍᴇᴛᴇᴏʀ+] The Client**](https://discord.com/channels/689197705683140636/689202616441503870/785864225486667887) and [**MineGame -159**](https://discord.com/channels/689197705683140636/689202616441503870/786677155328425995).