### PR TITLE
Added chat protection from sending messages with coords in global chat, fixed and improved nbt command

### DIFF
--- a/src/main/java/minegame159/meteorclient/commands/CommandManager.java
+++ b/src/main/java/minegame159/meteorclient/commands/CommandManager.java
@@ -47,7 +47,7 @@ public class CommandManager {
         addCommand(new Clip());
         addCommand(new Bind());
         addCommand(new Toggle());
-        addCommand(new Nbt());
+        addCommand(new NBT());
     }
 
     public static void dispatch(String message) throws CommandSyntaxException {
@@ -78,4 +78,11 @@ public class CommandManager {
             super(null, client);
         }
     }
+
+//    public static String getCommandString(Command command, String... args) {
+//        StringBuilder base = new StringBuilder(Config.INSTANCE.getPrefix() + command.name);
+//        for (String arg : args)
+//            base.append(' ').append(arg);
+//        return base.toString();
+//    }
 }

--- a/src/main/java/minegame159/meteorclient/events/entity/player/SendMessageEvent.java
+++ b/src/main/java/minegame159/meteorclient/events/entity/player/SendMessageEvent.java
@@ -5,12 +5,15 @@
 
 package minegame159.meteorclient.events.entity.player;
 
-public class SendMessageEvent {
+import minegame159.meteorclient.events.Cancellable;
+
+public class SendMessageEvent extends Cancellable {
     private static final SendMessageEvent INSTANCE = new SendMessageEvent();
 
     public String msg;
 
     public static SendMessageEvent get(String msg) {
+        INSTANCE.setCancelled(false);
         INSTANCE.msg = msg;
         return INSTANCE;
     }

--- a/src/main/java/minegame159/meteorclient/mixin/ClientPlayerEntityMixin.java
+++ b/src/main/java/minegame159/meteorclient/mixin/ClientPlayerEntityMixin.java
@@ -45,9 +45,11 @@ public abstract class ClientPlayerEntityMixin {
             SendMessageEvent event = SendMessageEvent.get(msg);
             MeteorClient.EVENT_BUS.post(event);
 
-            ignoreChatMessage = true;
-            sendChatMessage(event.msg);
-            ignoreChatMessage = false;
+            if (!event.isCancelled()) {
+                ignoreChatMessage = true;
+                sendChatMessage(event.msg);
+                ignoreChatMessage = false;
+            }
 
             info.cancel();
             return;

--- a/src/main/java/minegame159/meteorclient/utils/player/Chat.java
+++ b/src/main/java/minegame159/meteorclient/utils/player/Chat.java
@@ -9,7 +9,9 @@ import minegame159.meteorclient.Config;
 import minegame159.meteorclient.mixininterface.IChatHud;
 import minegame159.meteorclient.modules.Module;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.text.BaseText;
 import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 
 public class Chat {
@@ -23,6 +25,12 @@ public class Chat {
     }
     public static void info(String format, Object... args) {
         info(0, null, format, args);
+    }
+    public static void info(Module module, Text msg) {
+        sendMsg(0, module, msg);
+    }
+    public static void info(Text msg) {
+        info(null, msg);
     }
 
     public static void warning(Module module, String format, Object... args) {
@@ -39,16 +47,44 @@ public class Chat {
         error(null, format, args);
     }
 
-    private static void sendMsg(int id, Module module, String msg, Formatting color) {
+    private static void sendMsg(int id, Module module, Text msg) {
         if (mc.world == null) return;
 
         if (!Config.INSTANCE.deleteChatCommandsInfo) id = 0;
 
+        BaseText message = new LiteralText("");
+        message.append(getPrefix(module));
+        message.append(msg);
+
+        ((IChatHud) mc.inGameHud.getChatHud()).add(message, id);
+    }
+
+    private static void sendMsg(int id, Module module, String msg, Formatting color) {
+        BaseText message = new LiteralText(msg);
+        message.setStyle(message.getStyle().withFormatting(color));
+
+        sendMsg(id, module, message);
+    }
+
+    private static BaseText getPrefix(Module module) {
+        BaseText meteor = new LiteralText("Meteor");
+        meteor.setStyle(meteor.getStyle().withFormatting(Formatting.BLUE));
+
+        BaseText prefix = new LiteralText("");
+        prefix.setStyle(prefix.getStyle().withFormatting(Formatting.GRAY));
+        prefix.append("[");
+        prefix.append(meteor);
+        prefix.append("] ");
+
         if (module != null) {
-            ((IChatHud) mc.inGameHud.getChatHud()).add(new LiteralText(String.format("%s[%sMeteor%s] %s[%s] %s%s", Formatting.GRAY, Formatting.BLUE,Formatting.GRAY, Formatting.AQUA, module.title, color, msg)), id);
-        } else {
-            ((IChatHud) mc.inGameHud.getChatHud()).add(new LiteralText(String.format("%s[%sMeteor%s] %s%s", Formatting.GRAY, Formatting.BLUE, Formatting.GRAY, color, msg)), id);
+            BaseText moduleTitle = new LiteralText(module.title);
+            moduleTitle.setStyle(moduleTitle.getStyle().withFormatting(Formatting.AQUA));
+            prefix.append("[");
+            prefix.append(moduleTitle);
+            prefix.append("] ");
         }
+
+        return prefix;
     }
 
     private static String formatMsg(String format, Formatting defaultColor, Object... args) {


### PR DESCRIPTION
Added chat protection from sending messages and messages with coords in global chat.
By [suggestion](https://discord.com/channels/689197705683140636/689202616441503870/793566248574386247) from `@supakeks#0001` and [suggestion](https://discord.com/channels/689197705683140636/689202616441503870/793556976503619644) from `Chompasaurus513#3571`.
![chat_protection](https://user-images.githubusercontent.com/35692622/104812250-1468cc00-5812-11eb-8721-05d3592f86bf.gif)


Also fixed `.nbt get` crash with empty nbt data. Added `.nbt copy`. Added chat button for copy in `.nbt get`.
![nbt_copy2](https://user-images.githubusercontent.com/35692622/104812252-16cb2600-5812-11eb-9070-39c112636a9d.gif)

