### PR TITLE
AnchorAura pause settings + WelcomeHUD improvement

### DIFF
--- a/src/main/java/minegame159/meteorclient/modules/combat/AnchorAura.java
+++ b/src/main/java/minegame159/meteorclient/modules/combat/AnchorAura.java
@@ -158,6 +158,20 @@ public class AnchorAura extends Module {
             .build()
     );
 
+    private final Setting<Boolean> pauseOnEat = sgMisc.add(new BoolSetting.Builder()
+            .name("pause-on-eat")
+            .description("Pauses Anchor Aura while eating.")
+            .defaultValue(false)
+            .build()
+    );
+
+    private final Setting<Boolean> pauseOnMine = sgMisc.add(new BoolSetting.Builder()
+            .name("pause-on-mine")
+            .description("Pauses Anchor Aura while mining blocks.")
+            .defaultValue(false)
+            .build()
+    );
+
     // Render
 
     private final Setting<Boolean> renderPlace = sgRender.add(new BoolSetting.Builder()
@@ -224,13 +238,17 @@ public class AnchorAura extends Module {
     @EventHandler
     private final Listener<TickEvent.Post> onTick = new Listener<>(event -> {
         if (mc.world.getDimension().isRespawnAnchorWorking()) {
-            ChatUtils.moduleError(this, "You are in the Nether... disabling.");
+            ChatUtils.moduleError(this, "You are in the Nether... disabling!");
             this.toggle();
             return;
         }
 
         if (!checkItems()) {
             target = null;
+            return;
+        }
+
+        if ((mc.player.isUsingItem() && (mc.player.getMainHandStack().getItem().isFood() || mc.player.getOffHandStack().isFood()) && pauseOnEat.get()) || (mc.interactionManager.isBreakingBlock() && pauseOnMine.get())) {
             return;
         }
 

--- a/src/main/java/minegame159/meteorclient/modules/combat/AnchorAura.java
+++ b/src/main/java/minegame159/meteorclient/modules/combat/AnchorAura.java
@@ -238,7 +238,7 @@ public class AnchorAura extends Module {
     @EventHandler
     private final Listener<TickEvent.Post> onTick = new Listener<>(event -> {
         if (mc.world.getDimension().isRespawnAnchorWorking()) {
-            ChatUtils.moduleError(this, "You are in the Nether... disabling!");
+            ChatUtils.moduleError(this, "You are in the Nether... disabling.");
             this.toggle();
             return;
         }

--- a/src/main/java/minegame159/meteorclient/modules/player/NameProtect.java
+++ b/src/main/java/minegame159/meteorclient/modules/player/NameProtect.java
@@ -43,8 +43,4 @@ public class NameProtect extends Module {
         if (name.get().length() > 0 && isActive()) return name.get();
         else return original;
     }
-
-    public String getValue() {
-        return name.get();
-    }
 }

--- a/src/main/java/minegame159/meteorclient/modules/player/NameProtect.java
+++ b/src/main/java/minegame159/meteorclient/modules/player/NameProtect.java
@@ -43,4 +43,8 @@ public class NameProtect extends Module {
         if (name.get().length() > 0 && isActive()) return name.get();
         else return original;
     }
+
+    public String getValue() {
+        return name.get();
+    }
 }

--- a/src/main/java/minegame159/meteorclient/modules/render/hud/modules/WelcomeHud.java
+++ b/src/main/java/minegame159/meteorclient/modules/render/hud/modules/WelcomeHud.java
@@ -24,6 +24,6 @@ public class WelcomeHud extends DoubleTextHudModule {
         MinecraftClient mc = MinecraftClient.getInstance();
         if (mc.player == null) return "UnknownPlayer!";
 
-        return nameProtect.isActive() ? nameProtect.getValue() + "!" : mc.player.getGameProfile().getName() + "!";
+        return nameProtect.getName(mc.player.getGameProfile().getName()) + "!";
     }
 }

--- a/src/main/java/minegame159/meteorclient/modules/render/hud/modules/WelcomeHud.java
+++ b/src/main/java/minegame159/meteorclient/modules/render/hud/modules/WelcomeHud.java
@@ -5,6 +5,8 @@
 
 package minegame159.meteorclient.modules.render.hud.modules;
 
+import minegame159.meteorclient.modules.ModuleManager;
+import minegame159.meteorclient.modules.player.NameProtect;
 import minegame159.meteorclient.modules.render.hud.HUD;
 import net.minecraft.client.MinecraftClient;
 
@@ -15,11 +17,13 @@ public class WelcomeHud extends DoubleTextHudModule {
         rightColor = hud.welcomeColor();
     }
 
+    NameProtect nameProtect = ModuleManager.INSTANCE.get(NameProtect.class);
+
     @Override
     protected String getRight() {
         MinecraftClient mc = MinecraftClient.getInstance();
         if (mc.player == null) return "UnknownPlayer!";
 
-        return mc.player.getGameProfile().getName() + "!";
+        return nameProtect.isActive() ? nameProtect.getValue() + "!" : mc.player.getGameProfile().getName() + "!";
     }
 }


### PR DESCRIPTION
- Added 2 boolean settings to Anchor Aura: PauseOnEat & PauseOnMine: AnchorAura will pause if eating when pauseoneat is on or when mining if pauseonmine is on.
- Fixed WelcomeHUD still showing player username even with NameProtect on.