### PR TITLE
Auto steal

### DIFF
--- a/src/main/java/minegame159/meteorclient/mixin/GenericContainerScreenMixin.java
+++ b/src/main/java/minegame159/meteorclient/mixin/GenericContainerScreenMixin.java
@@ -5,6 +5,8 @@
 
 package minegame159.meteorclient.mixin;
 
+import minegame159.meteorclient.modules.ModuleManager;
+import minegame159.meteorclient.modules.misc.AutoSteal;
 import minegame159.meteorclient.utils.player.InvUtils;
 import minegame159.meteorclient.utils.render.MeteorButtonWidget;
 import net.minecraft.client.MinecraftClient;
@@ -33,25 +35,16 @@ public abstract class GenericContainerScreenMixin extends HandledScreen<GenericC
         addButton(new MeteorButtonWidget(x + backgroundWidth - 88, y + 3, 40, 12, new LiteralText("Dump"), button -> dump(handler)));
     }
 
-    private void steal(GenericContainerScreenHandler handler) {
-        for (int i = 0; i < handler.getRows() * 9; i++) {
-            InvUtils.clickSlot(i, 0, SlotActionType.QUICK_MOVE);
-        }
-
-        boolean empty = true;
-        for (int i = 0; i < handler.getRows() * 9; i++) {
-            if (!handler.getSlot(i).getStack().isEmpty()) {
-                empty = false;
-                break;
-            }
-        }
-
-        if (empty) MinecraftClient.getInstance().player.closeHandledScreen();
-    }
 
     private void dump(GenericContainerScreenHandler handler) {
         for (int i = handler.getRows() * 9; i < handler.getRows() * 9 + 1 + 3 * 9; i++) {
             InvUtils.clickSlot(i, 0, SlotActionType.QUICK_MOVE);
         }
+    }
+
+    private void steal(GenericContainerScreenHandler handler)
+    {
+        ModuleManager.INSTANCE.get(AutoSteal.class).stealAsync(handler);
+
     }
 }

--- a/src/main/java/minegame159/meteorclient/mixin/GenericContainerScreenMixin.java
+++ b/src/main/java/minegame159/meteorclient/mixin/GenericContainerScreenMixin.java
@@ -7,15 +7,12 @@ package minegame159.meteorclient.mixin;
 
 import minegame159.meteorclient.modules.ModuleManager;
 import minegame159.meteorclient.modules.misc.AutoSteal;
-import minegame159.meteorclient.utils.player.InvUtils;
 import minegame159.meteorclient.utils.render.MeteorButtonWidget;
-import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.ingame.GenericContainerScreen;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.client.gui.screen.ingame.ScreenHandlerProvider;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.screen.GenericContainerScreenHandler;
-import net.minecraft.screen.slot.SlotActionType;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Mixin;
@@ -33,18 +30,19 @@ public abstract class GenericContainerScreenMixin extends HandledScreen<GenericC
         //StorageUtils
         addButton(new MeteorButtonWidget(x + backgroundWidth - 46, y + 3, 40, 12, new LiteralText("Steal"), button -> steal(handler)));
         addButton(new MeteorButtonWidget(x + backgroundWidth - 88, y + 3, 40, 12, new LiteralText("Dump"), button -> dump(handler)));
+
+        AutoSteal autoSteal = ModuleManager.INSTANCE.get(AutoSteal.class);
+        if (autoSteal.isActive())
+            steal(handler);
     }
 
 
     private void dump(GenericContainerScreenHandler handler) {
-        for (int i = handler.getRows() * 9; i < handler.getRows() * 9 + 1 + 3 * 9; i++) {
-            InvUtils.clickSlot(i, 0, SlotActionType.QUICK_MOVE);
-        }
+        ModuleManager.INSTANCE.get(AutoSteal.class).dumpAsync(handler);
     }
 
     private void steal(GenericContainerScreenHandler handler)
     {
         ModuleManager.INSTANCE.get(AutoSteal.class).stealAsync(handler);
-
     }
 }

--- a/src/main/java/minegame159/meteorclient/modules/ModuleManager.java
+++ b/src/main/java/minegame159/meteorclient/modules/ModuleManager.java
@@ -436,6 +436,7 @@ public class ModuleManager extends Savable<ModuleManager> implements Listenable 
         addModule(new LiquidFiller());
         addModule(new VisualRange());
         addModule(new AutoBreed());
+        addModule(new AutoSteal());
     }
 
     public static class ModuleRegistry extends Registry<Module> {

--- a/src/main/java/minegame159/meteorclient/modules/misc/AutoSteal.java
+++ b/src/main/java/minegame159/meteorclient/modules/misc/AutoSteal.java
@@ -1,0 +1,102 @@
+package minegame159.meteorclient.modules.misc;
+
+import minegame159.meteorclient.modules.Category;
+import minegame159.meteorclient.modules.Module;
+import minegame159.meteorclient.settings.BoolSetting;
+import minegame159.meteorclient.settings.IntSetting;
+import minegame159.meteorclient.settings.Setting;
+import minegame159.meteorclient.settings.SettingGroup;
+import minegame159.meteorclient.utils.misc.ThreadUtils;
+import minegame159.meteorclient.utils.player.InvUtils;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.screen.GenericContainerScreenHandler;
+import net.minecraft.screen.slot.SlotActionType;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+public class AutoSteal extends Module {
+	public AutoSteal()
+	{
+		super(Category.Misc, "auto-steal", "Automatically loot chests.");
+	}
+
+	private final SettingGroup sgGeneral = settings.getDefaultGroup();
+	private final SettingGroup sgDelays = settings.createGroup("Delays");
+
+	public final Setting<Boolean> autoSteal = sgGeneral.add(new BoolSetting.Builder()
+			.name("auto-steal")
+			.description("Automatically steals from opened containers.")
+			.defaultValue(false)
+			.build()
+	);
+
+	public final Setting<Boolean> autoCloseEmpty = sgGeneral.add(new BoolSetting.Builder()
+			.name("auto-close-empty")
+			.description("Automatically close the inventory menu if the inventory is empty.")
+			.defaultValue(false)
+			.build()
+	);
+
+	public final Setting<Integer> minimumDelay = sgDelays.add(new IntSetting.Builder()
+			.name("min-delay")
+			.description("Minimum delay between stealing the next stack in milliseconds. Use 0 to steal the entire inventory instantly")
+			.min(0)
+			.sliderMax(1000)
+			.defaultValue(0)
+			.build()
+	);
+
+	public final Setting<Integer> randomDelay = sgDelays.add(new IntSetting.Builder()
+			.name("random-delay")
+			.description("Randomly adds a delay of up to the specified time in milliseconds. Helps avoid anti-cheats.") // Actually ms - 1, due to the RNG excluding upper bound
+			.min(0)
+			.sliderMax(1000)
+			.defaultValue(0)
+			.build()
+	);
+
+
+
+	/**
+	 * Runs {@link #steal(GenericContainerScreenHandler)} in a separate thread
+	 * @param handler
+	 */
+	public void stealAsync(GenericContainerScreenHandler handler)
+	{
+		ThreadUtils.runInThread(() -> steal(handler));
+	}
+
+	/**
+	 * Thread-blocking operation to steal from chests. You REALLY should use {@link #stealAsync(GenericContainerScreenHandler)}
+	 * @param handler Passed in from {@link minegame159.meteorclient.mixin.GenericContainerScreenMixin}
+	 */
+	public void steal(GenericContainerScreenHandler handler)
+	{
+		int stacksCollected = 0; // Used to track the number of stacks collected. If zero, the chest was empty from the beginning, so closing it feels weird to players.
+		for (int i = 0; i < handler.getRows() * 9; i++) {
+			if (!handler.getSlot(i).hasStack())
+				continue;
+
+			int sleep = minimumDelay.get() + (randomDelay.get() > 0 ? ThreadLocalRandom.current().nextInt(0, randomDelay.get()) : 0);
+			if (sleep > 0)
+				ThreadUtils.sleep(sleep);
+
+			// Exit if user closes screen
+			if (mc.currentScreen == null)
+				break;
+
+			InvUtils.clickSlot(i, 0, SlotActionType.QUICK_MOVE);
+			stacksCollected++;
+		}
+
+		// Close screen if chest is empty
+		boolean empty = true;
+		for (int i = 0; i < handler.getRows() * 9; i++) {
+			if (!handler.getSlot(i).getStack().isEmpty()) {
+				empty = false;
+				break;
+			}
+		}
+		if (empty && autoCloseEmpty.get()) MinecraftClient.getInstance().player.closeHandledScreen();
+	}
+}

--- a/src/main/java/minegame159/meteorclient/modules/misc/AutoSteal.java
+++ b/src/main/java/minegame159/meteorclient/modules/misc/AutoSteal.java
@@ -2,13 +2,11 @@ package minegame159.meteorclient.modules.misc;
 
 import minegame159.meteorclient.modules.Category;
 import minegame159.meteorclient.modules.Module;
-import minegame159.meteorclient.settings.BoolSetting;
 import minegame159.meteorclient.settings.IntSetting;
 import minegame159.meteorclient.settings.Setting;
 import minegame159.meteorclient.settings.SettingGroup;
 import minegame159.meteorclient.utils.misc.ThreadUtils;
 import minegame159.meteorclient.utils.player.InvUtils;
-import net.minecraft.client.MinecraftClient;
 import net.minecraft.screen.GenericContainerScreenHandler;
 import net.minecraft.screen.slot.SlotActionType;
 
@@ -23,26 +21,12 @@ public class AutoSteal extends Module {
 	private final SettingGroup sgGeneral = settings.getDefaultGroup();
 	private final SettingGroup sgDelays = settings.createGroup("Delays");
 
-	public final Setting<Boolean> autoSteal = sgGeneral.add(new BoolSetting.Builder()
-			.name("auto-steal")
-			.description("Automatically steals from opened containers.")
-			.defaultValue(false)
-			.build()
-	);
-
-	public final Setting<Boolean> autoCloseEmpty = sgGeneral.add(new BoolSetting.Builder()
-			.name("auto-close-empty")
-			.description("Automatically close the inventory menu if the inventory is empty.")
-			.defaultValue(false)
-			.build()
-	);
-
 	public final Setting<Integer> minimumDelay = sgDelays.add(new IntSetting.Builder()
 			.name("min-delay")
 			.description("Minimum delay between stealing the next stack in milliseconds. Use 0 to steal the entire inventory instantly")
 			.min(0)
 			.sliderMax(1000)
-			.defaultValue(0)
+			.defaultValue(180)
 			.build()
 	);
 
@@ -51,15 +35,14 @@ public class AutoSteal extends Module {
 			.description("Randomly adds a delay of up to the specified time in milliseconds. Helps avoid anti-cheats.") // Actually ms - 1, due to the RNG excluding upper bound
 			.min(0)
 			.sliderMax(1000)
-			.defaultValue(0)
+			.defaultValue(50)
 			.build()
 	);
 
 
-
 	/**
 	 * Runs {@link #steal(GenericContainerScreenHandler)} in a separate thread
-	 * @param handler
+	 * @param handler Passed in from {@link minegame159.meteorclient.mixin.GenericContainerScreenMixin}
 	 */
 	public void stealAsync(GenericContainerScreenHandler handler)
 	{
@@ -67,12 +50,11 @@ public class AutoSteal extends Module {
 	}
 
 	/**
-	 * Thread-blocking operation to steal from chests. You REALLY should use {@link #stealAsync(GenericContainerScreenHandler)}
+	 * Thread-blocking operation to steal from containers. You REALLY should use {@link #stealAsync(GenericContainerScreenHandler)}
 	 * @param handler Passed in from {@link minegame159.meteorclient.mixin.GenericContainerScreenMixin}
 	 */
 	public void steal(GenericContainerScreenHandler handler)
 	{
-		int stacksCollected = 0; // Used to track the number of stacks collected. If zero, the chest was empty from the beginning, so closing it feels weird to players.
 		for (int i = 0; i < handler.getRows() * 9; i++) {
 			if (!handler.getSlot(i).hasStack())
 				continue;
@@ -86,17 +68,34 @@ public class AutoSteal extends Module {
 				break;
 
 			InvUtils.clickSlot(i, 0, SlotActionType.QUICK_MOVE);
-			stacksCollected++;
 		}
-
-		// Close screen if chest is empty
-		boolean empty = true;
-		for (int i = 0; i < handler.getRows() * 9; i++) {
-			if (!handler.getSlot(i).getStack().isEmpty()) {
-				empty = false;
-				break;
-			}
-		}
-		if (empty && autoCloseEmpty.get()) MinecraftClient.getInstance().player.closeHandledScreen();
 	}
+
+	public void dumpAsync(GenericContainerScreenHandler handler)
+	{
+		ThreadUtils.runInThread(() -> dump(handler));
+	}
+
+	/**
+	 * Thread-blocking operation to dump to containers. You REALLY should use {@link #dumpAsync(GenericContainerScreenHandler)}
+	 * @param handler Passed in from {@link minegame159.meteorclient.mixin.GenericContainerScreenMixin}
+	 */
+	public void dump(GenericContainerScreenHandler handler)
+	{
+		for (int i = handler.getRows() * 9; i < handler.getRows() * 9 + 9 + 3 * 9; i++) { // wtf?
+			if (!handler.getSlot(i).hasStack())
+				continue;
+
+			int sleep = minimumDelay.get() + (randomDelay.get() > 0 ? ThreadLocalRandom.current().nextInt(0, randomDelay.get()) : 0);
+			if (sleep > 0)
+				ThreadUtils.sleep(sleep);
+
+			// Exit if user closes screen
+			if (mc.currentScreen == null)
+				break;
+
+			InvUtils.clickSlot(i, 0, SlotActionType.QUICK_MOVE);
+		}
+	}
+
 }

--- a/src/main/java/minegame159/meteorclient/utils/misc/ThreadUtils.java
+++ b/src/main/java/minegame159/meteorclient/utils/misc/ThreadUtils.java
@@ -4,13 +4,13 @@ public class ThreadUtils {
 
 	/**
 	 * Runs a method in a thread. The method cannot return anything. A stack trace is dumped if an exception occurs
-	 * @param method the method to run
+	 * @param runnable the method to run
 	 */
-	public static void runInThread(Runnable method)
+	public static void runInThread(Runnable runnable)
 	{
 		new Thread(() -> {
 			try {
-				method.run();
+				runnable.run();
 			} catch (Exception e) {
 				e.printStackTrace();
 			}

--- a/src/main/java/minegame159/meteorclient/utils/misc/ThreadUtils.java
+++ b/src/main/java/minegame159/meteorclient/utils/misc/ThreadUtils.java
@@ -1,0 +1,32 @@
+package minegame159.meteorclient.utils.misc;
+
+public class ThreadUtils {
+
+	/**
+	 * Runs a method in a thread. The method cannot return anything. A stack trace is dumped if an exception occurs
+	 * @param method the method to run
+	 */
+	public static void runInThread(Runnable method)
+	{
+		new Thread(() -> {
+			try {
+				method.run();
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		}).start();
+	}
+
+	/**
+	 * Makes a thread delay for the specified time.
+	 * @param ms Time to sleep in milliseconds
+	 */
+	public static void sleep(int ms)
+	{
+		try {
+			Thread.sleep(ms);
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+	}
+}


### PR DESCRIPTION
Few things will get a player banned faster than clearing inventories in a single tick. This PR helps fix the buttons on chests, adds a module to auto-steal from opened chests, and also allows user-configurable delay and randomness factor to help defeat anti-cheat systems.

Unfortunately, due to the use of threads to do this, we can't auto-close the container, since closing a container from the non-main thread causes bugs.