### PR TITLE
Fixed CrystalAura rotations (squid monkey)

### DIFF
--- a/src/main/java/minegame159/meteorclient/modules/combat/CrystalAura.java
+++ b/src/main/java/minegame159/meteorclient/modules/combat/CrystalAura.java
@@ -733,7 +733,7 @@ public class CrystalAura extends Module {
         }
         float yaw = mc.player.yaw;
         float pitch = mc.player.pitch;
-        if (rotationMode.get() == RotationMode.FaceCrystal || rotationMode.get() == RotationMode.Return) RotationUtils.packetRotate(block.add(0.5, 1.5, 0.5));
+        if (rotationMode.get() == RotationMode.FaceCrystal || rotationMode.get() == RotationMode.Return) RotationUtils.packetRotate(block.add(0.5, 1, 0.5));
         mc.interactionManager.interactBlock(mc.player, mc.world, hand, new BlockHitResult(mc.player.getPos(), Direction.UP, new BlockPos(block), false));
         if (!noSwing.get()) mc.player.swingHand(hand);
         if (rotationMode.get() == RotationMode.Return)RotationUtils.packetRotate(yaw, pitch);


### PR DESCRIPTION
basically 1.5 would make it so if the block was at your height (player's blockPos), it would be looking at air/where the crystal is placed. However in vanilla you right click the top of the support block, which is supposed to be 1, not 1.5