### PR TITLE
Improved ElytraPlus AutoPilot setting + Crystal/Anchor Aura PauseOnHealth setting.

### DIFF
--- a/src/main/java/minegame159/meteorclient/modules/combat/AnchorAura.java
+++ b/src/main/java/minegame159/meteorclient/modules/combat/AnchorAura.java
@@ -57,6 +57,7 @@ public class AnchorAura extends Module {
 
     private final SettingGroup sgPlace = settings.createGroup("Place");
     private final SettingGroup sgBreak = settings.createGroup("Break");
+    private final SettingGroup sgPause = settings.createGroup("Pause");
     private final SettingGroup sgMisc = settings.createGroup("Misc");
     private final SettingGroup sgRender = settings.createGroup("Render");
 
@@ -160,24 +161,36 @@ public class AnchorAura extends Module {
             .build()
     );
 
-    private final Setting<Boolean> pauseOnEat = sgMisc.add(new BoolSetting.Builder()
+    // Pause
+
+    private final Setting<Boolean> pauseOnEat = sgPause.add(new BoolSetting.Builder()
             .name("pause-on-eat")
             .description("Pauses Anchor Aura while eating.")
             .defaultValue(false)
             .build()
     );
 
-    private final Setting<Boolean> pauseOnDrink = sgMisc.add(new BoolSetting.Builder()
+    private final Setting<Boolean> pauseOnDrink = sgPause.add(new BoolSetting.Builder()
             .name("pause-on-drink")
             .description("Pauses Anchor Aura while drinking a potion.")
             .defaultValue(false)
             .build()
     );
 
-    private final Setting<Boolean> pauseOnMine = sgMisc.add(new BoolSetting.Builder()
+    private final Setting<Boolean> pauseOnMine = sgPlace.add(new BoolSetting.Builder()
             .name("pause-on-mine")
             .description("Pauses Anchor Aura while mining blocks.")
             .defaultValue(false)
+            .build()
+    );
+
+    private final Setting<Double> pauseOnHealth = sgPause.add(new DoubleSetting.Builder()
+            .name("pause-on-health")
+            .description("Pauses Anchor Aura if your health is lower than this amount.")
+            .min(0)
+            .defaultValue(0)
+            .sliderMax(36)
+            .max(36)
             .build()
     );
 
@@ -259,7 +272,8 @@ public class AnchorAura extends Module {
 
         if ((mc.player.isUsingItem() && (mc.player.getMainHandStack().getItem().isFood() || mc.player.getOffHandStack().getItem().isFood()) && pauseOnEat.get())
                 || (mc.interactionManager.isBreakingBlock() && pauseOnMine.get())
-                || (mc.player.isUsingItem() && (mc.player.getMainHandStack().getItem() instanceof PotionItem || mc.player.getOffHandStack().getItem() instanceof PotionItem) && pauseOnDrink.get())) {
+                || (mc.player.isUsingItem() && (mc.player.getMainHandStack().getItem() instanceof PotionItem || mc.player.getOffHandStack().getItem() instanceof PotionItem) && pauseOnDrink.get())
+                || (mc.player.getHealth() <= pauseOnHealth.get())) {
             return;
         }
 

--- a/src/main/java/minegame159/meteorclient/modules/combat/AnchorAura.java
+++ b/src/main/java/minegame159/meteorclient/modules/combat/AnchorAura.java
@@ -154,13 +154,6 @@ public class AnchorAura extends Module {
             .build()
     );
 
-    private final Setting<Double> minHealth = sgMisc.add(new DoubleSetting.Builder()
-            .name("min-health")
-            .description("The minimum health you have to be for Anchor Aura to work.")
-            .defaultValue(15)
-            .build()
-    );
-
     // Pause
 
     private final Setting<Boolean> pauseOnEat = sgPause.add(new BoolSetting.Builder()
@@ -245,7 +238,9 @@ public class AnchorAura extends Module {
             .build()
     );
 
-    public AnchorAura() {super(Category.Combat, "anchor-aura", "Automatically places and breaks Respawn Anchors to harm entities.");}
+    public AnchorAura() {
+        super(Category.Combat, "anchor-aura", "Automatically places and breaks Respawn Anchors to harm entities.");
+    }
 
     private int placeDelayLeft;
     private int breakDelayLeft;
@@ -277,7 +272,7 @@ public class AnchorAura extends Module {
             return;
         }
 
-        if (getTotalHealth(mc.player) <= minHealth.get() && placeMode.get() != Mode.Suicide && breakMode.get() != Mode.Suicide) return;
+        if (getTotalHealth(mc.player) <= pauseOnHealth.get() && placeMode.get() != Mode.Suicide && breakMode.get() != Mode.Suicide) return;
 
         if (target == null || mc.player.distanceTo(target) > targetRange.get() || !target.isAlive()) target = findTarget();
         if (target == null) return;

--- a/src/main/java/minegame159/meteorclient/modules/combat/CrystalAura.java
+++ b/src/main/java/minegame159/meteorclient/modules/combat/CrystalAura.java
@@ -296,6 +296,16 @@ public class CrystalAura extends Module {
             .build()
     );
 
+    private final Setting<Double> pauseOnHealth = sgPause.add(new DoubleSetting.Builder()
+            .name("pause-on-health")
+            .description("Pauses Crystal Aura if your health is lower than this amount.")
+            .min(0)
+            .defaultValue(0)
+            .sliderMax(36)
+            .max(36)
+            .build()
+    );
+
     // Misc
 
     private final Setting<Double> maxDamage = sgMisc.add(new DoubleSetting.Builder()
@@ -462,7 +472,8 @@ public class CrystalAura extends Module {
 
         if ((mc.player.isUsingItem() && (mc.player.getMainHandStack().getItem().isFood() || mc.player.getOffHandStack().getItem().isFood()) && pauseOnEat.get())
                 || (mc.interactionManager.isBreakingBlock() && pauseOnMine.get())
-                || (mc.player.isUsingItem() && (mc.player.getMainHandStack().getItem() instanceof PotionItem || mc.player.getOffHandStack().getItem() instanceof PotionItem) && pauseOnDrink.get())) {
+                || (mc.player.isUsingItem() && (mc.player.getMainHandStack().getItem() instanceof PotionItem || mc.player.getOffHandStack().getItem() instanceof PotionItem) && pauseOnDrink.get())
+                || (mc.player.getHealth() <= pauseOnHealth.get())) {
             return;
         }
 

--- a/src/main/java/minegame159/meteorclient/modules/combat/CrystalAura.java
+++ b/src/main/java/minegame159/meteorclient/modules/combat/CrystalAura.java
@@ -113,13 +113,6 @@ public class CrystalAura extends Module {
             .build()
     );
 
-    private final Setting<Double> minHealth = sgPlace.add(new DoubleSetting.Builder()
-            .name("min-health")
-            .description("The minimum health you have to be for it to place.")
-            .defaultValue(15)
-            .build()
-    );
-
     private final Setting<Boolean> surroundBreak = sgPlace.add(new BoolSetting.Builder()
             .name("surround-break")
             .description("Places a crystal next to a surrounded player and keeps it there so they cannot use Surround again.")
@@ -502,7 +495,7 @@ public class CrystalAura extends Module {
             }
         }
         boolean shouldFacePlace = false;
-        if (getTotalHealth(mc.player) <= minHealth.get() && placeMode.get() != Mode.Suicide) return;
+        if (getTotalHealth(mc.player) <= pauseOnHealth.get() && placeMode.get() != Mode.Suicide) return;
         if (target != null && heldCrystal != null && placeDelayLeft <= 0 && mc.world.raycast(new RaycastContext(target.getPos(), heldCrystal.getPos(), RaycastContext.ShapeType.COLLIDER, RaycastContext.FluidHandling.NONE, target)).getType()
                 == HitResult.Type.MISS) locked = false;
         if (heldCrystal == null) locked = false;
@@ -591,7 +584,7 @@ public class CrystalAura extends Module {
         }
     });
 
-    private void singleBreak(){
+    private void singleBreak() {
         assert mc.player != null;
         assert mc.world != null;
         Streams.stream(mc.world.getEntities())
@@ -605,7 +598,7 @@ public class CrystalAura extends Module {
                 .ifPresent(entity -> hitCrystal((EndCrystalEntity) entity));
     }
 
-    private void multiBreak(){
+    private void multiBreak() {
         assert mc.world != null;
         assert mc.player != null;
         crystalMap.clear();
@@ -637,7 +630,7 @@ public class CrystalAura extends Module {
         }
     }
 
-    private EndCrystalEntity findBestCrystal(Map<EndCrystalEntity, List<Double>> map){
+    private EndCrystalEntity findBestCrystal(Map<EndCrystalEntity, List<Double>> map) {
         bestDamage = 0;
         double currentDamage = 0;
         if (targetMode.get() == TargetMode.HighestXDamages){
@@ -666,7 +659,7 @@ public class CrystalAura extends Module {
         return bestBreak;
     }
 
-    private void hitCrystal(EndCrystalEntity entity){
+    private void hitCrystal(EndCrystalEntity entity) {
         assert mc.player != null;
         assert mc.world != null;
         assert mc.interactionManager != null;
@@ -692,7 +685,7 @@ public class CrystalAura extends Module {
         breakDelayLeft = breakDelay.get();
     }
 
-    private void findTarget(){
+    private void findTarget() {
         assert  mc.world != null;
         Optional<LivingEntity> livingEntity = Streams.stream(mc.world.getEntities())
                 .filter(Entity::isAlive)
@@ -710,7 +703,7 @@ public class CrystalAura extends Module {
         target = livingEntity.get();
     }
 
-    private void doSwitch(){
+    private void doSwitch() {
         assert mc.player != null;
         if (mc.player.getMainHandStack().getItem() != Items.END_CRYSTAL && mc.player.getOffHandStack().getItem() != Items.END_CRYSTAL) {
             int slot = InvUtils.findItemWithCount(Items.END_CRYSTAL).slot;
@@ -721,7 +714,7 @@ public class CrystalAura extends Module {
         }
     }
 
-    private void doHeldCrystal(){
+    private void doHeldCrystal() {
         assert mc.player != null;
         if (switchMode.get() != SwitchMode.None) doSwitch();
         if (mc.player.getMainHandStack().getItem() != Items.END_CRYSTAL && mc.player.getOffHandStack().getItem() != Items.END_CRYSTAL) return;
@@ -737,7 +730,7 @@ public class CrystalAura extends Module {
         placeBlock(bestBlock, getHand());
     }
 
-    private void placeBlock(Vec3d block, Hand hand){
+    private void placeBlock(Vec3d block, Hand hand) {
         assert mc.player != null;
         assert mc.interactionManager != null;
         assert mc.world != null;
@@ -759,7 +752,7 @@ public class CrystalAura extends Module {
         }
     }
 
-    private void findValidBlocks(LivingEntity target){
+    private void findValidBlocks(LivingEntity target) {
         assert mc.player != null;
         assert mc.world != null;
         bestBlock = new Vec3d(0, 0, 0);
@@ -827,7 +820,7 @@ public class CrystalAura extends Module {
         }
     }
 
-    private void findFacePlace(LivingEntity target){
+    private void findFacePlace(LivingEntity target) {
         assert mc.world != null;
         assert mc.player != null;
         BlockPos targetBlockPos = target.getBlockPos();
@@ -846,12 +839,12 @@ public class CrystalAura extends Module {
         }
     }
 
-    private boolean getDamagePlace(BlockPos pos){
+    private boolean getDamagePlace(BlockPos pos) {
         assert mc.player != null;
         return placeMode.get() == Mode.Suicide || DamageCalcUtils.crystalDamage(mc.player, new Vec3d(pos.getX() + 0.5, pos.getY(), pos.getZ() + 0.5)) <= maxDamage.get();
     }
 
-    private Vec3d findOpen(LivingEntity target){
+    private Vec3d findOpen(LivingEntity target) {
         assert mc.player != null;
         int x = 0;
         int z = 0;
@@ -874,7 +867,7 @@ public class CrystalAura extends Module {
         return null;
     }
 
-    private Vec3d findOpenSurround(LivingEntity target){
+    private Vec3d findOpenSurround(LivingEntity target) {
         assert mc.player != null;
         assert mc.world != null;
 
@@ -913,9 +906,9 @@ public class CrystalAura extends Module {
                 != HitResult.Type.MISS;
     }
 
-    private boolean isSafe(Vec3d crystalPos){
+    private boolean isSafe(Vec3d crystalPos) {
         assert mc.player != null;
-        return (!(breakMode.get() == Mode.Safe) || (getTotalHealth(mc.player) - DamageCalcUtils.crystalDamage(mc.player, crystalPos) > minHealth.get()
+        return (!(breakMode.get() == Mode.Safe) || (getTotalHealth(mc.player) - DamageCalcUtils.crystalDamage(mc.player, crystalPos) > pauseOnHealth.get()
                 && DamageCalcUtils.crystalDamage(mc.player, crystalPos) < maxDamage.get()));
     }
 

--- a/src/main/java/minegame159/meteorclient/modules/movement/ElytraPlus.java
+++ b/src/main/java/minegame159/meteorclient/modules/movement/ElytraPlus.java
@@ -315,7 +315,6 @@ public class ElytraPlus extends Module {
             }
             lastForwardPressed = true;
         } else if (autoPilotMode.get() == AutoPilotMode.Firework) {
-            ticksLeft--;
             if (!mc.player.isFallFlying()) return;
             if (slot == -1 && mc.player.getOffHandStack().getItem() != Items.FIREWORK_ROCKET) {
                 ChatUtils.moduleWarning(this, "No fireworks found in hotbar... Changing AutoPilot mode to NONE.");
@@ -329,6 +328,7 @@ public class ElytraPlus extends Module {
                 mc.player.swingHand(getFireworkHand());
                 if (autoPilotFireworkGhosthand.get()) mc.player.inventory.selectedSlot = prevSlot;
             }
+            ticksLeft--;
         }
     }
 


### PR DESCRIPTION
Improved elytra+ autopilot settings.

New "Firework" setting bypasses the speed patch part of the elytra fly patch epearl made on ec.me lol

CrystalAura and AnchorAura now have a PauseOnHealth setting. If your health is lower than your selected value, the module will get paused. By default both AnchorAura and CrystalAura have it at 0 which is pretty much no pause for it.