### PR TITLE
CrystalAura rotation changes bruh

### DIFF
--- a/src/main/java/minegame159/meteorclient/modules/combat/CrystalAura.java
+++ b/src/main/java/minegame159/meteorclient/modules/combat/CrystalAura.java
@@ -316,7 +316,7 @@ public class CrystalAura extends Module {
 
     private final Setting<Double> rotationLock = sgRotations.add(new DoubleSetting.Builder()
             .name("place-rotation-lock")
-            .description("Where to look at when placing crystals.")
+            .description("How high to look at the support block you're placing your crystals on.")
             .min(0)
             .defaultValue(100)
             .sliderMax(100)
@@ -458,7 +458,7 @@ public class CrystalAura extends Module {
     @Override
     public void onDeactivate() {
         assert mc.player != null;
-        if (switchBack.get()) if (preSlot != -1) mc.player.inventory.selectedSlot = preSlot;
+        if (switchBack.get() && preSlot != -1) mc.player.inventory.selectedSlot = preSlot;
         for (RenderBlock renderBlock : renderBlocks) {
             renderBlockPool.free(renderBlock);
         }

--- a/src/main/java/minegame159/meteorclient/modules/combat/CrystalAura.java
+++ b/src/main/java/minegame159/meteorclient/modules/combat/CrystalAura.java
@@ -464,11 +464,8 @@ public class CrystalAura extends Module {
         }
         renderBlocks.clear();
         if (target != null && resetRotations.get()) {
-            float preYaw = mc.player.yaw;
-            float prePitch = mc.player.pitch;
-
             if (rotationMode.get() == RotationMode.Both || rotationMode.get() == RotationMode.Place || rotationMode.get() == RotationMode.Break) {
-                RotationUtils.packetRotate(preYaw, prePitch);
+                RotationUtils.packetRotate(mc.player.yaw, mc.player.pitch);
             }
         }
     }


### PR DESCRIPTION
Default rotation settings send 2 times less packets now

Added an option to disable the remove entity thing as that's what was desyncing the fuck out of players on ncp servers (still on by default)

Also made the rotation resets only be sent when disabling because sending them after breaking/placing is packet spamming

Rotation Lock setting can be useful for servers with way more stricter rotation checks that may require you to look at a specific part of the support block