### PR TITLE
Improved HoleFiller, Surround and AutoTrap.

### DIFF
--- a/src/main/java/minegame159/meteorclient/modules/combat/AutoTrap.java
+++ b/src/main/java/minegame159/meteorclient/modules/combat/AutoTrap.java
@@ -32,12 +32,14 @@ public class AutoTrap extends Module {
     public enum TopMode {
         Full,
         Top,
+        Face,
         None
     }
 
     public enum BottomMode {
         Single,
         Platform,
+        Full,
         None
     }
 
@@ -193,6 +195,12 @@ public class AutoTrap extends Module {
                 add(targetPos.add(0, 1, 1));
                 add(targetPos.add(0, 1, -1));
                 break;
+            case Face:
+                add(targetPos.add(1, 1, 0));
+                add(targetPos.add(-1, 1, 0));
+                add(targetPos.add(0, 1, 1));
+                add(targetPos.add(0, 1, -1));
+                break;
             case Top:
                 add(targetPos.add(0, 2, 0));
         }
@@ -204,6 +212,12 @@ public class AutoTrap extends Module {
                 add(targetPos.add(0, -1, 0));
                 add(targetPos.add(0, -1, 1));
                 add(targetPos.add(0, -1, -1));
+                break;
+            case Full:
+                add(targetPos.add(1, 0, 0));
+                add(targetPos.add(-1, 0, 0));
+                add(targetPos.add(0, 0, -1));
+                add(targetPos.add(0, 0, 1));
                 break;
             case Single:
                 add(targetPos.add(0, -1, 0));

--- a/src/main/java/minegame159/meteorclient/modules/combat/Surround.java
+++ b/src/main/java/minegame159/meteorclient/modules/combat/Surround.java
@@ -73,6 +73,13 @@ public class Surround extends Module {
             .build()
     );
 
+    private final Setting<Boolean> useEnderChests = sgGeneral.add(new BoolSetting.Builder()
+            .name("use-ender-chests")
+            .description("Will surround with ender chests if they are found in your hotbar.")
+            .defaultValue(false)
+            .build()
+    );
+
     // TODO: Make a render for Surround monkeys.
     private final BlockPos.Mutable blockPos = new BlockPos.Mutable();
     private boolean return_;
@@ -158,7 +165,7 @@ public class Surround extends Module {
 
             if (!(item instanceof BlockItem)) continue;
 
-            if (item == Items.OBSIDIAN) {
+            if (item == Items.OBSIDIAN || (item == Items.ENDER_CHEST && useEnderChests.get())) {
                 return i;
             }
         }


### PR DESCRIPTION
-Surround: Uses echests if the setting is on (Someone suggested this in a vc, could also be useful to mine echests to get obsidian

-AutoTrap: Added 2 new modes, 1 for each top and bottom placement. "Face" mode for TopMode can be really useful for AnchorAura or BedAura, as the player wouldn't be able to pearl if a respawn anchor is covering their top part. "Full" in BottomMode pretty much surrounds the player but it _could_ help with either 1.12.2 servers or just fully trapping the opponent.

-HoleFiller: Added a delay to it since on most strict servers it could be a bit too fast for the ac. Also added a "Both" mode which uses both cobwebs and obsidian/crying obsidian if found in hotbar, so if you want to use obsidian then webs mid-fight you only have to move them in your inventory instead of opening clickgui, right clicking holefiller then changing the mode.