### PR TITLE
KillAura: target multiple

### DIFF
--- a/src/main/java/minegame159/meteorclient/modules/combat/KillAura.java
+++ b/src/main/java/minegame159/meteorclient/modules/combat/KillAura.java
@@ -128,6 +128,13 @@ public class KillAura extends Module {
             .build()
     );
 
+    private final Setting<Boolean> targetMultiple = sgGeneral.add(new BoolSetting.Builder()
+            .name("target-multiple")
+            .description("Target multiple entities at once")
+            .defaultValue(false)
+            .build()
+    );
+
     // Rotations
 
     private final Setting<RotationMode> rotationMode = sgRotations.add(new EnumSetting.Builder<RotationMode>()
@@ -180,7 +187,6 @@ public class KillAura extends Module {
 
     private int hitDelayTimer;
     private int randomDelayTimer;
-    private Entity target;
     private boolean wasPathing;
     private boolean canAttack;
 
@@ -194,18 +200,17 @@ public class KillAura extends Module {
     public void onDeactivate() {
         hitDelayTimer = 0;
         randomDelayTimer = 0;
-        target = null;
+        entityList.clear();
     }
 
     @EventHandler
     private void onTick(TickEvent.Pre event) {
 
         if (mc.player.isDead() || !mc.player.isAlive() || !itemInHand()) {
-            target = null;
+            entityList.clear();
             return;
         }
-
-        target = EntityUtils.get(entity -> {
+        EntityUtils.getAll(entity -> {
             if (entity == mc.player || entity == mc.cameraEntity) return false;
             if ((entity instanceof LivingEntity && ((LivingEntity) entity).isDead()) || !entity.isAlive()) return false;
             if (entity.distanceTo(mc.player) > range.get()) return false;
@@ -220,8 +225,14 @@ public class KillAura extends Module {
 
             return true;
         }, priority.get());
+        entityList.clear();
 
-        if (target == null) {
+        if (targetMultiple.get())
+            entityList.addAll(EntityUtils.entities);
+        else if (!EntityUtils.entities.isEmpty())
+            entityList.add(EntityUtils.entities.get(0));
+
+        if (entityList.isEmpty()) {
             if (wasPathing){
                 BaritoneAPI.getProvider().getPrimaryBaritone().getCommandManager().execute("resume");
                 wasPathing = false;
@@ -234,52 +245,58 @@ public class KillAura extends Module {
             wasPathing = true;
         }
 
-        if (attack() && rotationMode.get() == RotationMode.Always) {
-            Rotations.rotate(Rotations.getYaw(target), Rotations.getPitch(target, rotationDirection.get()), () -> {
-                if (canAttack) hitEntity();
-            });
+        if (!targetMultiple.get() || !smartDelay.get() || mc.player.getAttackCooldownProgress(0.5f) >= 1) {
+            if (randomDelayEnabled.get()) {
+                if (randomDelayTimer > 0) {
+                    randomDelayTimer--;
+                    return;
+                } else {
+                    randomDelayTimer = (int) Math.round(Math.random() * randomDelayMax.get());
+                }
+            }
+
+            for (Entity target : entityList) {
+                if (attack(target) && rotationMode.get() == RotationMode.Always) {
+                    Rotations.rotate(Rotations.getYaw(target), Rotations.getPitch(target, rotationDirection.get()), () -> {
+                        if (canAttack) hitEntity(target);
+                    });
+                }
+            }
         }
     }
 
-    private boolean attack() {
+    private boolean attack(Entity target) {
         canAttack = false;
 
         // Entities without health can be hit instantly
-        if (target instanceof LivingEntity) {
-            if (smartDelay.get()) {
-                if (mc.player.getAttackCooldownProgress(0.5f) < 1) return false;
-            }
-            else {
-                if (hitDelayTimer >= 0) {
-                    hitDelayTimer--;
-                    return false;
-                } else hitDelayTimer = hitDelay.get();
-            }
-        }
-
-        if (randomDelayEnabled.get()) {
-            if (randomDelayTimer > 0) {
-                randomDelayTimer--;
-                return false;
-            } else {
-                randomDelayTimer = (int) Math.round(Math.random() * randomDelayMax.get());
+        if (!targetMultiple.get()) {
+            if (target instanceof LivingEntity) {
+                if (smartDelay.get()) {
+                    if (mc.player.getAttackCooldownProgress(0.5f) < 1) return false;
+                }
+                else {
+                    if (hitDelayTimer >= 0) {
+                        hitDelayTimer--;
+                        return false;
+                    } else hitDelayTimer = hitDelay.get();
+                }
             }
         }
 
         if (Math.random() > hitChance.get() / 100) return false;
 
         if (rotationMode.get() == RotationMode.None) {
-            hitEntity();
+            hitEntity(target);
         }
         else {
-            Rotations.rotate(Rotations.getYaw(target), Rotations.getPitch(target, rotationDirection.get()), this::hitEntity);
+            Rotations.rotate(Rotations.getYaw(target), Rotations.getPitch(target, rotationDirection.get()), () -> hitEntity(target));
         }
 
         canAttack = true;
         return true;
     }
 
-    private void hitEntity() {
+    private void hitEntity(Entity target) {
         mc.interactionManager.attackEntity(mc.player, target);
         mc.player.swingHand(Hand.MAIN_HAND);
     }
@@ -295,8 +312,12 @@ public class KillAura extends Module {
 
     @Override
     public String getInfoString() {
-        if (target != null && target instanceof PlayerEntity) return target.getEntityName();
-        if (target != null) return target.getType().getName().getString();
+        if (!entityList.isEmpty()) {
+            Entity targetFirst = entityList.get(0);
+            if (targetFirst instanceof PlayerEntity)
+                return targetFirst.getEntityName();
+            return targetFirst.getType().getName().getString();
+        }
         return null;
     }
 }

--- a/src/main/java/minegame159/meteorclient/utils/entity/EntityUtils.java
+++ b/src/main/java/minegame159/meteorclient/utils/entity/EntityUtils.java
@@ -47,7 +47,8 @@ public class EntityUtils {
         return Utils.WHITE;
     }
 
-    public static Entity get(Predicate<Entity> isGood, SortPriority sortPriority) {
+    public static void getAll(Predicate<Entity> isGood, SortPriority sortPriority) {
+        entities.clear();
         for (Entity entity : mc.world.getEntities()) {
             if (isGood.test(entity)) entities.add(entity);
         }
@@ -57,12 +58,12 @@ public class EntityUtils {
         }
 
         entities.sort((e1, e2) -> sort(e1, e2, sortPriority));
+    }
 
+    public static Entity get(Predicate<Entity> isGood, SortPriority sortPriority) {
+        getAll(isGood, sortPriority);
         if (!entities.isEmpty()) {
-            Entity res = entities.get(0);
-
-            entities.clear();
-            return res;
+            return entities.get(0);
         }
 
         return null;


### PR DESCRIPTION
Allows the killaura module to target multiple entities each tick. This is useful when farming (for example) slimes or magma cubes and might increase dps in environments where lower damage because of high attack speed is not a thing.