### PR TITLE
Fix StorageESP block offset to middle

### DIFF
--- a/src/main/java/minegame159/meteorclient/modules/render/StorageESP.java
+++ b/src/main/java/minegame159/meteorclient/modules/render/StorageESP.java
@@ -160,7 +160,7 @@ public class StorageESP extends Module {
                     if (Dir.is(excludeDir, Dir.SOUTH)) z2 -= a;
                 }
 
-                double dist = mc.player.squaredDistanceTo(blockEntity.getPos().getX() + 1, blockEntity.getPos().getY() + 1, blockEntity.getPos().getZ() + 1);
+                double dist = mc.player.squaredDistanceTo(blockEntity.getPos().getX() + 0.5, blockEntity.getPos().getY() + 0.5, blockEntity.getPos().getZ() + 0.5);
                 double a = 1;
                 if (dist <= fadeDistance.get() * fadeDistance.get()) a = dist / (fadeDistance.get() * fadeDistance.get());
 


### PR DESCRIPTION
- Currently distance is calculated to a corner of a block instead of the middle, this fixes that.

So as you come closer to a chest, the fade fades away faster from certain directions than others