### PR TITLE
Filter anti-cheat bots by gamemode

### DIFF
--- a/src/main/java/minegame159/meteorclient/modules/render/Nametags.java
+++ b/src/main/java/minegame159/meteorclient/modules/render/Nametags.java
@@ -161,6 +161,13 @@ public class Nametags extends Module {
             .build()
     );
 
+    private final Setting<Boolean> tryFilterAntiCheatBots = sgPlayers.add(new BoolSetting.Builder()
+            .name("filter-AC-bots")
+            .description("Attempts to filter out anti-cheat bots to help de-clutter the screen.")
+            .defaultValue(true)
+            .build()
+    );
+
     private final Setting<SettingColor> normalName = sgPlayers.add(new ColorSetting.Builder()
             .name("normal-color")
             .description("The color of people not in your Friends List.")
@@ -315,11 +322,15 @@ public class Nametags extends Module {
     }
 
     private void renderNametagPlayer(PlayerEntity entity) {
+        // Gamemode
+        GameMode gm = EntityUtils.getGameMode(entity);
+
+        if (gm == null && tryFilterAntiCheatBots.get())
+            return;
+
         TextRenderer text = TextRenderer.get();
         NametagUtils.begin(pos);
 
-        // Gamemode
-        GameMode gm = EntityUtils.getGameMode(entity);
         String gmText = "ERR";
         if (gm != null) {
             switch (gm) {


### PR DESCRIPTION
Gets rid of dumb shit like this by eliminating players with invalid gamemodes (note the bots with randomly generated names).

![2021 02 14 15 04 03](https://user-images.githubusercontent.com/30786211/107892055-6b2bf900-6ed7-11eb-8b4a-38fc5b7d92ad.png)

If someone finds a server that bypasses this maybe add a way to check if the user is in the players list or something.