### PR TITLE
Fix BoundingBox

### DIFF
--- a/src/main/java/minegame159/meteorclient/modules/render/hud/modules/PlayersHud.java
+++ b/src/main/java/minegame159/meteorclient/modules/render/hud/modules/PlayersHud.java
@@ -27,11 +27,9 @@ public class PlayersHud extends HudElement {
 
     @Override
     public void update(HudRenderer renderer) {
-        double width = 0;
-        double height = 0;
+        double width = renderer.textWidth("Players:");
+        double height = renderer.textHeight();
 
-        box.setSize(renderer.textWidth("Players:"), renderer.textHeight());
-        height += renderer.textHeight();
         int i = 0;
         if(mc.world == null) return;
         for (Entity entity : mc.world.getEntities()) {


### PR DESCRIPTION
Fixed a bug where the PlayersHUD bounding box is 0 when there aren't other players around (no players in the PlayersHUD list). Meaning it cannot be selected/moved in the HUD editor.