### PR TITLE
Added Anti-Xray Bypass

### DIFF
--- a/src/main/java/minegame159/meteorclient/mixin/indigo/TerrainRenderContextMixin.java
+++ b/src/main/java/minegame159/meteorclient/mixin/indigo/TerrainRenderContextMixin.java
@@ -23,7 +23,7 @@ public class TerrainRenderContextMixin {
     private void onTesselateBlock(BlockState blockState, BlockPos blockPos, BakedModel model, MatrixStack matrixStack, CallbackInfoReturnable<Boolean> info) {
         Xray xray = Modules.get().get(Xray.class);
 
-        if (xray.isActive() && xray.isBlocked(blockState.getBlock())) {
+        if (xray.isActive() && xray.isBlocked(blockState.getBlock(), blockPos)) {
             info.cancel();
         }
     }

--- a/src/main/java/minegame159/meteorclient/mixin/sodium/SodiumBlockRendererMixin.java
+++ b/src/main/java/minegame159/meteorclient/mixin/sodium/SodiumBlockRendererMixin.java
@@ -62,7 +62,7 @@ public class SodiumBlockRendererMixin {
     private void onRenderModel(BlockRenderView world, BlockState state, BlockPos pos, BakedModel model, ModelQuadSinkDelegate builder, boolean cull, long seed, CallbackInfoReturnable<Boolean> cir) {
         Xray xray = Modules.get().get(Xray.class);
 
-        if (xray.isActive() && xray.isBlocked(state.getBlock())) {
+        if (xray.isActive() && xray.isBlocked(state.getBlock(), pos)) {
             cir.setReturnValue(false);
         }
     }

--- a/src/main/java/minegame159/meteorclient/systems/modules/render/Xray.java
+++ b/src/main/java/minegame159/meteorclient/systems/modules/render/Xray.java
@@ -41,7 +41,7 @@ public class Xray extends Module {
             .build()
     );
 
-    private final Setting<Boolean> antixraybypass = sgGeneral.add(new BoolSetting.Builder()
+    private final Setting<Boolean> antiXrayBypass = sgGeneral.add(new BoolSetting.Builder()
             .name("Anti-Xray Bypass")
             .description("Only shows blocks that have at least one face exposed to air, This will only show the ores that are in caves!")
             .defaultValue(false)
@@ -113,7 +113,7 @@ public class Xray extends Module {
     }
 
     public boolean isBlocked(Block block, BlockPos pos) {
-        if (antixraybypass.get()) {
+        if (antiXrayBypass.get()) {
             if (isExposedToAir(pos)) {
                 return !blocks.get().contains(block);
             } else {


### PR DESCRIPTION
Only shows blocks that have at least one face exposed to air thus bypassing anti xray plugins found on some servers.

### Tested on
Paper built-in anti xray engine mode 2

### Notes
Since the only ores exposed to air are in caves you will see less ores compared to not using this mode, although its better to have this setting than seeing this:
![image](https://user-images.githubusercontent.com/68184538/115418980-a06c0480-a202-11eb-9eea-8eaff4313654.png)
Also can you guys tell me if you guys give special role to contributors in Discord