### PR TITLE
Allow ESC on HUD screen to go to previous tab

### DIFF
--- a/src/main/java/minegame159/meteorclient/gui/WidgetScreen.java
+++ b/src/main/java/minegame159/meteorclient/gui/WidgetScreen.java
@@ -9,6 +9,7 @@ import minegame159.meteorclient.MeteorClient;
 import minegame159.meteorclient.gui.renderer.GuiDebugRenderer;
 import minegame159.meteorclient.gui.renderer.GuiRenderer;
 import minegame159.meteorclient.gui.tabs.TabScreen;
+import minegame159.meteorclient.gui.tabs.builtin.HudTab;
 import minegame159.meteorclient.gui.utils.Cell;
 import minegame159.meteorclient.gui.widgets.WRoot;
 import minegame159.meteorclient.gui.widgets.WWidget;
@@ -64,7 +65,7 @@ public abstract class WidgetScreen extends Screen {
         if (parent != null) {
             animProgress = 1;
 
-            if (this instanceof TabScreen && parent instanceof TabScreen) {
+            if (this instanceof TabScreen && parent instanceof TabScreen && !(this instanceof HudTab.HudScreen)) {
                 parent = ((TabScreen) parent).parent;
             }
         }

--- a/src/main/java/minegame159/meteorclient/gui/tabs/builtin/HudTab.java
+++ b/src/main/java/minegame159/meteorclient/gui/tabs/builtin/HudTab.java
@@ -53,7 +53,7 @@ public class HudTab extends Tab {
         return screen instanceof HudScreen;
     }
 
-    private static class HudScreen extends WindowTabScreen {
+    public static class HudScreen extends WindowTabScreen {
         private final Color HOVER_BG_COLOR = new Color(200, 200, 200, 50);
         private final Color HOVER_OL_COLOR = new Color(200, 200, 200, 200);
 


### PR DESCRIPTION
This simple change allows pressing ESC in the HUD tab to open the previous tab instead of closing the click GUI as you cant navigate from there using the tabs