### PR TITLE
Added swarm exec command

### DIFF
--- a/src/main/java/minegame159/meteorclient/systems/commands/commands/SwarmCommand.java
+++ b/src/main/java/minegame159/meteorclient/systems/commands/commands/SwarmCommand.java
@@ -8,6 +8,7 @@ package minegame159.meteorclient.systems.commands.commands;
 import baritone.api.BaritoneAPI;
 import baritone.api.pathing.goals.GoalXZ;
 import com.mojang.brigadier.arguments.BoolArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import minegame159.meteorclient.systems.commands.Command;
@@ -22,6 +23,7 @@ import net.minecraft.command.CommandSource;
 import net.minecraft.command.argument.BlockStateArgument;
 import net.minecraft.command.argument.BlockStateArgumentType;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.client.MinecraftClient;
 
 import java.util.Random;
 
@@ -271,6 +273,17 @@ public class SwarmCommand extends Command {
             }
             return SINGLE_SUCCESS;
         }));
+
+        builder.then(literal("exec").then(argument("command", StringArgumentType.greedyString()).executes(context -> {
+            Swarm swarm = Modules.get().get(Swarm.class);
+            if (swarm.currentMode == Swarm.Mode.Queen && swarm.server != null) {
+                swarm.server.sendMessage(context.getInput());
+            } else {
+                String command = context.getArgument("command", String.class);
+                MinecraftClient.getInstance().player.sendChatMessage(command);
+            }
+            return SINGLE_SUCCESS;
+        })));
     }
 
     private void runInfinityMiner() {


### PR DESCRIPTION
This pull request adds a `.swarm exec {command}` command which allows for executing commands on slave players.
Examples:
```
.swarm exec test - Will make slaves say "test"
.swarm exec .vclip 10 - Will make slaves clip 10 blocks up
.swarm exec /tpa NomNomMaster - Will make slaves send a teleport request to NomNomMaster (on servers with the tpa command)
```