### PR TITLE
Improve KillAura

### DIFF
--- a/src/main/java/minegame159/meteorclient/systems/modules/combat/KillAura.java
+++ b/src/main/java/minegame159/meteorclient/systems/modules/combat/KillAura.java
@@ -184,14 +184,6 @@ public class KillAura extends Module {
             .build()
     );
 
-    private final Setting<Boolean> rotateCamera = sgRotations.add(new BoolSetting.Builder()
-            .name("rotate-camera")
-            .description("Rotate the client-side camera when targeting")
-            .defaultValue(false)
-            .visible(() -> !onlyWhenLook.get())
-            .build()
-    );
-
     // Delay
 
     private final Setting<Boolean> smartDelay = sgDelay.add(new BoolSetting.Builder()
@@ -355,13 +347,7 @@ public class KillAura extends Module {
     }
 
     private void rotate(Entity target, Runnable callback) {
-        double yaw = Rotations.getYaw(target);
-        double pitch = Rotations.getPitch(target, rotationDirection.get());
-        Rotations.rotate(yaw, pitch, callback);
-        if (rotateCamera.get() && !onlyWhenLook.get()) {
-            mc.player.yaw = (float)yaw;
-            mc.player.pitch = (float)pitch;
-        }
+        Rotations.rotate(Rotations.getYaw(target), Rotations.getPitch(target, rotationDirection.get()), callback);
     }
 
     private void hitEntity(Entity target) {

--- a/src/main/java/minegame159/meteorclient/systems/modules/combat/KillAura.java
+++ b/src/main/java/minegame159/meteorclient/systems/modules/combat/KillAura.java
@@ -29,6 +29,7 @@ import net.minecraft.item.AxeItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.SwordItem;
 import net.minecraft.util.Hand;
+import net.minecraft.world.GameMode;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -158,6 +159,14 @@ public class KillAura extends Module {
             .build()
     );
 
+    private final Setting<Boolean> randomTeleport = sgGeneral.add(new BoolSetting.Builder()
+            .name("random-teleport")
+            .description("Randomly teleport around the target")
+            .defaultValue(false)
+            .visible(() -> !onlyWhenLook.get())
+            .build()
+    );
+
     // Rotations
 
     private final Setting<RotationMode> rotationMode = sgRotations.add(new EnumSetting.Builder<RotationMode>()
@@ -172,6 +181,14 @@ public class KillAura extends Module {
             .description("The direction to use for rotating towards the enemy.")
             .defaultValue(Target.Head)
             .visible(() -> rotationMode.get() != RotationMode.None)
+            .build()
+    );
+
+    private final Setting<Boolean> rotateCamera = sgRotations.add(new BoolSetting.Builder()
+            .name("rotate-camera")
+            .description("Rotate the client-side camera when targeting")
+            .defaultValue(false)
+            .visible(() -> !onlyWhenLook.get())
             .build()
     );
 
@@ -234,7 +251,7 @@ public class KillAura extends Module {
     private void onTick(TickEvent.Pre event) {
         entityList.clear();
 
-        if (mc.player.isDead() || !mc.player.isAlive() || !itemInHand()) return;
+        if (mc.player.isDead() || !mc.player.isAlive() || !itemInHand() || EntityUtils.getGameMode(mc.player) == GameMode.SPECTATOR) return;
 
         EntityUtils.getList(entity -> {
             if (entity == mc.player || entity == mc.cameraEntity) return false;
@@ -266,38 +283,35 @@ public class KillAura extends Module {
             wasPathing = true;
         }
 
-        if (rotationMode.get() == RotationMode.Always && target != null) {
-            Rotations.rotate(Rotations.getYaw(target), Rotations.getPitch(target, rotationDirection.get()));
-        }
-
-        if (onlyWhenLook.get()){
-            if (!(mc.targetedEntity instanceof LivingEntity)) return;
-
-            if (onlyOnClick.get() && (!mc.options.keyAttack.isPressed() || mc.options.keyAttack.wasPressed())) return;
-
-            if (!delayCheck()) return;
-
-            if (attack(mc.targetedEntity) && canAttack)
-                hitEntity(mc.targetedEntity);
-        }
-        else if (onlyOnClick.get()) {
-            if (mc.options.keyAttack.isPressed() && !mc.options.keyAttack.wasPressed()) {
-                for (Entity target : entityList) {
-                    if (attack(target) && (canAttack)) {
-                        hitEntity(target);
+        if (!onlyOnClick.get() || (!mc.options.keyAttack.wasPressed() && mc.options.keyAttack.isPressed())) {
+            if (onlyWhenLook.get()) {
+                if (mc.targetedEntity instanceof LivingEntity && delayCheck()) {
+                    if (attack(mc.targetedEntity) && canAttack) {
+                        hitEntity(mc.targetedEntity);
                     }
                 }
-            }
-        }
-        else {
-            if (!delayCheck()) return;
-
-            for (Entity target : entityList) {
-                if (attack(target) && (canAttack)) {
-                    hitEntity(target);
+            } else {
+                if (delayCheck()) {
+                    for (Entity target : entityList) {
+                        if (attack(target) && canAttack) {
+                            hitEntity(target);
+                        }
+                    }
+                }
+                if (randomTeleport.get() && !entityList.isEmpty()) {
+                    Entity target = entityList.get(0);
+                    mc.player.updatePosition(target.getX() + randomOffset(), target.getY(), target.getZ() + randomOffset());
                 }
             }
         }
+
+        if (rotationMode.get() == RotationMode.Always && target != null) {
+            rotate(target, null);
+        }
+    }
+
+    private double randomOffset() {
+        return Math.random() * 4 - 2;
     }
 
     private boolean delayCheck() {
@@ -330,15 +344,24 @@ public class KillAura extends Module {
 
         if (Math.random() > hitChance.get() / 100) return false;
 
-        if (rotationMode.get() == RotationMode.None || rotationMode.get() == RotationMode.Always) {
+        if (rotationMode.get() == RotationMode.OnHit) {
+            rotate(target, () -> hitEntity(target));
+        } else {
             hitEntity(target);
-        }
-        else {
-            Rotations.rotate(Rotations.getYaw(target), Rotations.getPitch(target, rotationDirection.get()), () -> hitEntity(target));
         }
 
         canAttack = true;
         return true;
+    }
+
+    private void rotate(Entity target, Runnable callback) {
+        double yaw = Rotations.getYaw(target);
+        double pitch = Rotations.getPitch(target, rotationDirection.get());
+        Rotations.rotate(yaw, pitch, callback);
+        if (rotateCamera.get() && !onlyWhenLook.get()) {
+            mc.player.yaw = (float)yaw;
+            mc.player.pitch = (float)pitch;
+        }
     }
 
     private void hitEntity(Entity target) {


### PR DESCRIPTION
This contains the following improvements to KillAura from my fork:
- Fully disabled in spectator mode
- "Random Teleport" Option, similar to Wursts TP Aura
- ~Option to automatically rotate the clients viewport towards targets (useful in combination with onlyOnClick)~

I created a single PR for all of these because isolating changes would be bothersome. If you don't want some of these changes I can remove them.