### PR TITLE
HUD elements visibility changes

### DIFF
--- a/src/main/java/minegame159/meteorclient/systems/modules/render/hud/modules/ActiveModulesHud.java
+++ b/src/main/java/minegame159/meteorclient/systems/modules/render/hud/modules/ActiveModulesHud.java
@@ -44,10 +44,10 @@ public class ActiveModulesHud extends HudElement {
             .build()
     );
 
-    private final Setting<ActiveModulesHud.ColorMode> colorMode = sgGeneral.add(new EnumSetting.Builder<ActiveModulesHud.ColorMode>()
+    private final Setting<ColorMode> colorMode = sgGeneral.add(new EnumSetting.Builder<ColorMode>()
             .name("color-mode")
             .description("What color to use for active modules.")
-            .defaultValue(ActiveModulesHud.ColorMode.Rainbow)
+            .defaultValue(ColorMode.Rainbow)
             .build()
     );
 
@@ -55,6 +55,7 @@ public class ActiveModulesHud extends HudElement {
             .name("flat-color")
             .description("Color for flat color mode.")
             .defaultValue(new SettingColor(225, 25, 25))
+            .visible(() -> colorMode.get() == ColorMode.Flat)
             .build()
     );
 
@@ -64,6 +65,7 @@ public class ActiveModulesHud extends HudElement {
             .defaultValue(0.025)
             .sliderMax(0.1)
             .decimalPlaces(4)
+            .visible(() -> colorMode.get() == ColorMode.Rainbow)
             .build()
     );
 
@@ -73,6 +75,7 @@ public class ActiveModulesHud extends HudElement {
             .defaultValue(0.025)
             .sliderMax(0.05)
             .decimalPlaces(4)
+            .visible(() -> colorMode.get() == ColorMode.Rainbow)
             .build()
     );
 

--- a/src/main/java/minegame159/meteorclient/systems/modules/render/hud/modules/ActiveModulesHud.java
+++ b/src/main/java/minegame159/meteorclient/systems/modules/render/hud/modules/ActiveModulesHud.java
@@ -62,7 +62,7 @@ public class ActiveModulesHud extends HudElement {
     private final Setting<Double> rainbowSpeed = sgGeneral.add(new DoubleSetting.Builder()
             .name("rainbow-speed")
             .description("Rainbow speed of rainbow color mode.")
-            .defaultValue(0.025)
+            .defaultValue(0.0035)
             .sliderMax(0.1)
             .decimalPlaces(4)
             .visible(() -> colorMode.get() == ColorMode.Rainbow)

--- a/src/main/java/minegame159/meteorclient/systems/modules/render/hud/modules/CombatHud.java
+++ b/src/main/java/minegame159/meteorclient/systems/modules/render/hud/modules/CombatHud.java
@@ -105,6 +105,7 @@ public class CombatHud extends HudElement {
             .name("ping-stage-1")
             .description("Color of ping text when under 75.")
             .defaultValue(new SettingColor(15, 255, 15))
+            .visible(displayPing::get)
             .build()
     );
 
@@ -112,6 +113,7 @@ public class CombatHud extends HudElement {
             .name("ping-stage-2")
             .description("Color of ping text when between 75 and 200.")
             .defaultValue(new SettingColor(255, 150, 15))
+            .visible(displayPing::get)
             .build()
     );
 
@@ -119,6 +121,7 @@ public class CombatHud extends HudElement {
             .name("ping-stage-3")
             .description("Color of ping text when over 200.")
             .defaultValue(new SettingColor(255, 15, 15))
+            .visible(displayPing::get)
             .build()
     );
 
@@ -126,6 +129,7 @@ public class CombatHud extends HudElement {
             .name("distance-stage-1")
             .description("The color when a player is within 10 blocks of you.")
             .defaultValue(new SettingColor(255, 15, 15))
+            .visible(displayDistance::get)
             .build()
     );
 
@@ -133,6 +137,7 @@ public class CombatHud extends HudElement {
             .name("distance-stage-2")
             .description("The color when a player is within 50 blocks of you.")
             .defaultValue(new SettingColor(255, 150, 15))
+            .visible(displayDistance::get)
             .build()
     );
 
@@ -140,6 +145,7 @@ public class CombatHud extends HudElement {
             .name("distance-stage-3")
             .description("The color when a player is greater then 50 blocks away from you.")
             .defaultValue(new SettingColor(15, 255, 15))
+            .visible(displayDistance::get)
             .build()
     );
 

--- a/src/main/java/minegame159/meteorclient/systems/modules/render/hud/modules/InventoryViewerHud.java
+++ b/src/main/java/minegame159/meteorclient/systems/modules/render/hud/modules/InventoryViewerHud.java
@@ -37,7 +37,7 @@ public class InventoryViewerHud extends HudElement {
             .build()
     );
 
-    private final Setting<Background> background = sgGeneral.add(new EnumSetting.Builder<InventoryViewerHud.Background>()
+    private final Setting<Background> background = sgGeneral.add(new EnumSetting.Builder<Background>()
             .name("background")
             .description("Background of inventory viewer.")
             .defaultValue(Background.Texture)
@@ -48,6 +48,7 @@ public class InventoryViewerHud extends HudElement {
             .name("background-color")
             .description("Color of the background.")
             .defaultValue(new SettingColor(255, 255, 255))
+            .visible(() -> background.get() != Background.None)
             .build()
     );
 

--- a/src/main/java/minegame159/meteorclient/systems/modules/render/hud/modules/PlayerModelHud.java
+++ b/src/main/java/minegame159/meteorclient/systems/modules/render/hud/modules/PlayerModelHud.java
@@ -52,6 +52,7 @@ public class PlayerModelHud extends HudElement {
             .max(180)
             .sliderMin(-180)
             .sliderMax(180)
+            .visible(() -> !copyYaw.get())
             .build()
     );
 
@@ -63,6 +64,7 @@ public class PlayerModelHud extends HudElement {
             .max(180)
             .sliderMin(-180)
             .sliderMax(180)
+            .visible(() -> !copyPitch.get())
             .build()
     );
 
@@ -77,6 +79,7 @@ public class PlayerModelHud extends HudElement {
             .name("background-color")
             .description("Color of background.")
             .defaultValue(new SettingColor(0, 0, 0, 64))
+            .visible(background::get)
             .build()
     );
 

--- a/src/main/java/minegame159/meteorclient/systems/modules/render/hud/modules/PositionHud.java
+++ b/src/main/java/minegame159/meteorclient/systems/modules/render/hud/modules/PositionHud.java
@@ -5,6 +5,8 @@
 
 package minegame159.meteorclient.systems.modules.render.hud.modules;
 
+import minegame159.meteorclient.systems.modules.Modules;
+import minegame159.meteorclient.systems.modules.render.Freecam;
 import minegame159.meteorclient.systems.modules.render.hud.HUD;
 import minegame159.meteorclient.systems.modules.render.hud.HudRenderer;
 import minegame159.meteorclient.utils.player.PlayerUtils;
@@ -33,9 +35,11 @@ public class PositionHud extends HudElement {
             return;
         }
 
-        double x1 = mc.gameRenderer.getCamera().getPos().x;
-        double y1 = mc.gameRenderer.getCamera().getPos().y - mc.player.getEyeHeight(mc.player.getPose());
-        double z1 = mc.gameRenderer.getCamera().getPos().z;
+        Freecam freecam = Modules.get().get(Freecam.class);
+
+        double x1 = freecam.isActive() ? mc.gameRenderer.getCamera().getPos().x : mc.player.getX();
+        double y1 = freecam.isActive() ? mc.gameRenderer.getCamera().getPos().y - mc.player.getEyeHeight(mc.player.getPose()) : mc.player.getY();
+        double z1 = freecam.isActive() ? mc.gameRenderer.getCamera().getPos().z : mc.player.getZ();
 
         right1 = String.format("%.1f %.1f %.1f", x1, y1, z1);
 


### PR DESCRIPTION
also for coords hud I made it to only do camera x y z if freecam is enabled since going into 3rd person would show the incorrect player's coords