### PR TITLE
Improved AutoSwapBack

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AnchorAura.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AnchorAura.java
@@ -366,14 +366,14 @@ public class AnchorAura extends Module {
         if (glowStone.isOffhand()) {
             mc.interactionManager.interactBlock(mc.player, mc.world, Hand.OFF_HAND, new BlockHitResult(new Vec3d(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5), Direction.UP, pos, true));
         } else {
-            InvUtils.autoSwap(glowStone.getSlot());
+            InvUtils.swap(glowStone.getSlot(), true);
             mc.interactionManager.interactBlock(mc.player, mc.world, Hand.MAIN_HAND, new BlockHitResult(new Vec3d(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5), Direction.UP, pos, true));
         }
 
         if (anchor.isOffhand()) {
             mc.interactionManager.interactBlock(mc.player, mc.world, Hand.OFF_HAND, new BlockHitResult(new Vec3d(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5), Direction.UP, pos, true));
         } else {
-            InvUtils.autoSwap(anchor.getSlot());
+            InvUtils.swap(anchor.getSlot(), true);
             mc.interactionManager.interactBlock(mc.player, mc.world, Hand.MAIN_HAND, new BlockHitResult(new Vec3d(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5), Direction.UP, pos, true));
         }
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AnchorAura.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AnchorAura.java
@@ -362,23 +362,22 @@ public class AnchorAura extends Module {
         if (pos == null || mc.world.getBlockState(pos).getBlock() != Blocks.RESPAWN_ANCHOR) return;
 
         mc.player.setSneaking(false);
-        int preSlot = mc.player.getInventory().selectedSlot;
 
         if (glowStone.isOffhand()) {
             mc.interactionManager.interactBlock(mc.player, mc.world, Hand.OFF_HAND, new BlockHitResult(new Vec3d(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5), Direction.UP, pos, true));
         } else {
-            InvUtils.swap(glowStone.getSlot());
+            InvUtils.autoSwap(glowStone.getSlot());
             mc.interactionManager.interactBlock(mc.player, mc.world, Hand.MAIN_HAND, new BlockHitResult(new Vec3d(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5), Direction.UP, pos, true));
         }
 
         if (anchor.isOffhand()) {
             mc.interactionManager.interactBlock(mc.player, mc.world, Hand.OFF_HAND, new BlockHitResult(new Vec3d(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5), Direction.UP, pos, true));
         } else {
-            InvUtils.swap(anchor.getSlot());
+            InvUtils.autoSwap(anchor.getSlot());
             mc.interactionManager.interactBlock(mc.player, mc.world, Hand.MAIN_HAND, new BlockHitResult(new Vec3d(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5), Direction.UP, pos, true));
         }
 
-        InvUtils.swap(preSlot);
+        InvUtils.swapBack();
     }
 
     @Override

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AutoCity.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AutoCity.java
@@ -125,7 +125,7 @@ public class AutoCity extends Module {
 
         if (support.get()) BlockUtils.place(blockPosTarget.down(1), InvUtils.findInHotbar(Items.OBSIDIAN), rotate.get(), 0, true);
 
-        if (autoSwitch.get()) InvUtils.swap(pickaxe.getSlot());
+        if (autoSwitch.get()) InvUtils.swap(pickaxe.getSlot(), false);
 
         if (rotate.get()) Rotations.rotate(Rotations.getYaw(blockPosTarget), Rotations.getPitch(blockPosTarget), () -> mine(blockPosTarget));
         else mine(blockPosTarget);

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AutoWeapon.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AutoWeapon.java
@@ -46,7 +46,7 @@ public class AutoWeapon extends Module {
 
     @EventHandler
     private void onAttack(AttackEntityEvent event) {
-        InvUtils.swap(getBestWeapon());
+        InvUtils.swap(getBestWeapon(), false);
     }
 
     private int getBestWeapon() {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Burrow.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Burrow.java
@@ -199,16 +199,15 @@ public class Burrow extends Module {
         }
 
 
-        int prevSlot = mc.player.getInventory().selectedSlot;
         FindItemResult block = getItem();
 
         if (!(mc.player.getInventory().getStack(block.getSlot()).getItem() instanceof BlockItem)) return;
-        InvUtils.swap(block.getSlot());
+        InvUtils.autoSwap(block.getSlot());
 
         mc.interactionManager.interactBlock(mc.player, mc.world, Hand.MAIN_HAND, new BlockHitResult(Utils.vec3d(blockPos), Direction.UP, blockPos, false));
         mc.player.networkHandler.sendPacket(new HandSwingC2SPacket(Hand.MAIN_HAND));
 
-        InvUtils.swap(prevSlot);
+        InvUtils.swapBack();
 
         if (instant.get()) {
             mc.player.networkHandler.sendPacket(new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(), mc.player.getY() + rubberbandHeight.get(), mc.player.getZ(), false));

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Burrow.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Burrow.java
@@ -202,7 +202,7 @@ public class Burrow extends Module {
         FindItemResult block = getItem();
 
         if (!(mc.player.getInventory().getStack(block.getSlot()).getItem() instanceof BlockItem)) return;
-        InvUtils.autoSwap(block.getSlot());
+        InvUtils.swap(block.getSlot(), true);
 
         mc.interactionManager.interactBlock(mc.player, mc.world, Hand.MAIN_HAND, new BlockHitResult(Utils.vec3d(blockPos), Direction.UP, blockPos, false));
         mc.player.networkHandler.sendPacket(new HandSwingC2SPacket(Hand.MAIN_HAND));

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/CrystalAura.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/CrystalAura.java
@@ -730,7 +730,7 @@ public class CrystalAura extends Module {
                 // Check if the item in your hand is already valid
                 if (!isValidWeaknessItem(mc.player.getMainHandStack())) {
                     // Find valid item to break with
-                    if (!InvUtils.swap(InvUtils.findInHotbar(this::isValidWeaknessItem).getSlot())) return;
+                    if (!InvUtils.swap(InvUtils.findInHotbar(this::isValidWeaknessItem).getSlot(), false)) return;
 
                     switchTimer = 1;
                     return;
@@ -929,7 +929,7 @@ public class CrystalAura extends Module {
 
         int prevSlot = mc.player.getInventory().selectedSlot;
 
-        if (autoSwitch.get() != AutoSwitchMode.None && !item.isOffhand()) InvUtils.swap(item.getSlot());
+        if (autoSwitch.get() != AutoSwitchMode.None && !item.isOffhand()) InvUtils.swap(item.getSlot(), false);
 
         Hand hand = item.getHand();
         if (hand == null) return;
@@ -959,7 +959,7 @@ public class CrystalAura extends Module {
         }
 
         // Switch back
-        if (autoSwitch.get() == AutoSwitchMode.Silent) InvUtils.swap(prevSlot);
+        if (autoSwitch.get() == AutoSwitchMode.Silent) InvUtils.swap(prevSlot, false);
     }
 
     // Yaw steps

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/KillAura.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/KillAura.java
@@ -271,7 +271,7 @@ public class KillAura extends Module {
                 };
             });
 
-            InvUtils.swap(weaponResult.getSlot());
+            InvUtils.swap(weaponResult.getSlot(), false);
         }
 
         if (!itemInHand()) return;

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Quiver.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Quiver.java
@@ -64,7 +64,7 @@ public class Quiver extends Module {
         mc.options.keyUse.setPressed(false);
         mc.interactionManager.stopUsingItem(mc.player);
 
-        InvUtils.autoSwap(bow.getSlot());
+        InvUtils.swap(bow.getSlot(), true);
 
         arrowSlots.clear();
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Quiver.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Quiver.java
@@ -46,7 +46,6 @@ public class Quiver extends Module {
     );
 
     private final List<Integer> arrowSlots = new ArrayList<>();
-    private int prevSlot;
 
     public Quiver() {
         super(Categories.Combat, "quiver", "Shoots arrows at yourself.");
@@ -54,7 +53,6 @@ public class Quiver extends Module {
 
     @Override
     public void onActivate() {
-        prevSlot = mc.player.getInventory().selectedSlot;
 
         FindItemResult bow = InvUtils.findInHotbar(Items.BOW);
 
@@ -66,7 +64,7 @@ public class Quiver extends Module {
         mc.options.keyUse.setPressed(false);
         mc.interactionManager.stopUsingItem(mc.player);
 
-        InvUtils.swap(bow.getSlot());
+        InvUtils.autoSwap(bow.getSlot());
 
         arrowSlots.clear();
 
@@ -104,7 +102,7 @@ public class Quiver extends Module {
 
     @Override
     public void onDeactivate() {
-        InvUtils.swap(prevSlot);
+        InvUtils.swapBack();
     }
 
     @EventHandler

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/SmartSurround.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/SmartSurround.java
@@ -91,7 +91,7 @@ public class SmartSurround extends Module {
             placeObi(crystal, rPosX + 1, rPosZ, obsidian);
         }
 
-        InvUtils.swap(prevSlot);
+        InvUtils.swap(prevSlot, false);
     }
 
     private void placeObi(Entity crystal, int x, int z, FindItemResult findItemResult) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/NoFall.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/NoFall.java
@@ -164,7 +164,7 @@ public class NoFall extends Module {
                 mc.interactionManager.interactItem(mc.player, mc.world, Hand.OFF_HAND);
             } else {
                 int preSlot = mc.player.getInventory().selectedSlot;
-                InvUtils.autoSwap(bucket.getSlot());
+                InvUtils.swap(bucket.getSlot(), true);
                 mc.interactionManager.interactItem(mc.player, mc.world, Hand.MAIN_HAND);
                 InvUtils.swapBack();
             }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/NoFall.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/NoFall.java
@@ -164,9 +164,9 @@ public class NoFall extends Module {
                 mc.interactionManager.interactItem(mc.player, mc.world, Hand.OFF_HAND);
             } else {
                 int preSlot = mc.player.getInventory().selectedSlot;
-                InvUtils.swap(bucket.getSlot());
+                InvUtils.autoSwap(bucket.getSlot());
                 mc.interactionManager.interactItem(mc.player, mc.world, Hand.MAIN_HAND);
-                InvUtils.swap(preSlot);
+                InvUtils.swapBack();
             }
 
             this.placedWater = placedWater;

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFlightMode.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFlightMode.java
@@ -104,7 +104,7 @@ public class ElytraFlightMode {
                     mc.interactionManager.interactItem(mc.player, mc.world, Hand.OFF_HAND);
                     mc.player.swingHand(Hand.OFF_HAND);
                 } else {
-                    InvUtils.autoSwap(itemResult.getSlot());
+                    InvUtils.swap(itemResult.getSlot(), true);
 
                     mc.interactionManager.interactItem(mc.player, mc.world, Hand.MAIN_HAND);
                     mc.player.swingHand(Hand.MAIN_HAND);

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFlightMode.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFlightMode.java
@@ -104,13 +104,12 @@ public class ElytraFlightMode {
                     mc.interactionManager.interactItem(mc.player, mc.world, Hand.OFF_HAND);
                     mc.player.swingHand(Hand.OFF_HAND);
                 } else {
-                    int prevSlot = mc.player.getInventory().selectedSlot;
-                    InvUtils.swap(itemResult.getSlot());
+                    InvUtils.autoSwap(itemResult.getSlot());
 
                     mc.interactionManager.interactItem(mc.player, mc.world, Hand.MAIN_HAND);
                     mc.player.swingHand(Hand.MAIN_HAND);
 
-                    InvUtils.swap(prevSlot);
+                    InvUtils.swapBack();
                 }
             }
             ticksLeft--;

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoEat.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoEat.java
@@ -194,7 +194,7 @@ public class AutoEat extends Module {
     }
 
     private void changeSlot(int slot) {
-        InvUtils.swap(slot);
+        InvUtils.swap(slot, false);
         this.slot = slot;
     }
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoGap.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoGap.java
@@ -235,7 +235,7 @@ public class AutoGap extends Module {
     }
 
     private void changeSlot(int slot) {
-        InvUtils.swap(slot);
+        InvUtils.swap(slot, false);
         this.slot = slot;
     }
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoTool.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoTool.java
@@ -70,7 +70,6 @@ public class AutoTool extends Module {
         .build()
     ));
 
-    private int prevSlot;
     private boolean wasPressed;
     private boolean shouldSwitch;
     private int ticks;
@@ -82,9 +81,8 @@ public class AutoTool extends Module {
 
     @EventHandler
     private void onTick(TickEvent.Post event) {
-        if (switchBack.get() && !mc.options.keyAttack.isPressed() && wasPressed && prevSlot != -1) {
-            InvUtils.swap(prevSlot);
-            prevSlot = -1;
+        if (switchBack.get() && !mc.options.keyAttack.isPressed() && wasPressed && InvUtils.previousSlot != -1) {
+            InvUtils.swapBack();
             wasPressed = false;
             return;
         }
@@ -124,9 +122,7 @@ public class AutoTool extends Module {
         if ((bestSlot != -1 && (bestScore > getScore(currentStack, blockState)) || shouldStopUsing(currentStack) || !(currentStack.getItem() instanceof ToolItem))) {
             ticks = switchDelay.get();
 
-            prevSlot = mc.player.getInventory().selectedSlot;
-
-            if (ticks == 0) InvUtils.swap(bestSlot);
+            if (ticks == 0) InvUtils.autoSwap(bestSlot);
             else shouldSwitch = true;
         }
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoTool.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoTool.java
@@ -88,7 +88,7 @@ public class AutoTool extends Module {
         }
 
         if (ticks <= 0 && shouldSwitch && bestSlot != -1) {
-            InvUtils.swap(bestSlot);
+            InvUtils.swap(bestSlot, false);
             shouldSwitch = false;
         } else {
             ticks--;
@@ -122,7 +122,7 @@ public class AutoTool extends Module {
         if ((bestSlot != -1 && (bestScore > getScore(currentStack, blockState)) || shouldStopUsing(currentStack) || !(currentStack.getItem() instanceof ToolItem))) {
             ticks = switchDelay.get();
 
-            if (ticks == 0) InvUtils.autoSwap(bestSlot);
+            if (ticks == 0) InvUtils.swap(bestSlot, true);
             else shouldSwitch = true;
         }
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoTool.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoTool.java
@@ -88,7 +88,7 @@ public class AutoTool extends Module {
         }
 
         if (ticks <= 0 && shouldSwitch && bestSlot != -1) {
-            InvUtils.swap(bestSlot, false);
+            InvUtils.swap(bestSlot, switchBack.get());
             shouldSwitch = false;
         } else {
             ticks--;

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/EXPThrower.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/EXPThrower.java
@@ -80,10 +80,9 @@ public class EXPThrower extends Module {
         if (exp.isOffhand()) {
             mc.interactionManager.interactItem(mc.player, mc.world, Hand.OFF_HAND);
         } else {
-            int prevSlot = mc.player.getInventory().selectedSlot;
-            InvUtils.swap(exp.getSlot());
+            InvUtils.autoSwap(exp.getSlot());
             mc.interactionManager.interactItem(mc.player, mc.world, Hand.MAIN_HAND);
-            InvUtils.swap(prevSlot);
+            InvUtils.swapBack();
         }
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/EXPThrower.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/EXPThrower.java
@@ -80,7 +80,7 @@ public class EXPThrower extends Module {
         if (exp.isOffhand()) {
             mc.interactionManager.interactItem(mc.player, mc.world, Hand.OFF_HAND);
         } else {
-            InvUtils.autoSwap(exp.getSlot());
+            InvUtils.swap(exp.getSlot(), true);
             mc.interactionManager.interactItem(mc.player, mc.world, Hand.MAIN_HAND);
             InvUtils.swapBack();
         }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/MiddleClickExtra.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/MiddleClickExtra.java
@@ -93,7 +93,7 @@ public class MiddleClickExtra extends Module {
             return;
         }
 
-        InvUtils.autoSwap(result.getSlot());
+        InvUtils.swap(result.getSlot(), true);
 
         switch (mode.get().type) {
             case Immediate -> {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/MiddleClickExtra.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/MiddleClickExtra.java
@@ -72,7 +72,6 @@ public class MiddleClickExtra extends Module {
     );
 
     private boolean isUsing;
-    private int preSlot;
 
     public MiddleClickExtra() {
         super(Categories.Player, "middle-click-extra", "Lets you use items when you middle click.");
@@ -94,13 +93,12 @@ public class MiddleClickExtra extends Module {
             return;
         }
 
-        preSlot = mc.player.getInventory().selectedSlot;
-        InvUtils.swap(result.getSlot());
+        InvUtils.autoSwap(result.getSlot());
 
         switch (mode.get().type) {
             case Immediate -> {
                 mc.interactionManager.interactItem(mc.player, mc.world, Hand.MAIN_HAND);
-                InvUtils.swap(preSlot);
+                InvUtils.swapBack();
             }
             case LongerSingleClick -> mc.interactionManager.interactItem(mc.player, mc.world, Hand.MAIN_HAND);
             case Longer -> {
@@ -136,7 +134,7 @@ public class MiddleClickExtra extends Module {
     private void stopIfUsing() {
         if (isUsing) {
             mc.options.keyUse.setPressed(false);
-            InvUtils.swap(preSlot);
+            InvUtils.swapBack();
             isUsing = false;
         }
     }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoNametag.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoNametag.java
@@ -97,7 +97,7 @@ public class AutoNametag extends Module {
 
 
         // Swapping slots
-        InvUtils.autoSwap(findNametag.getSlot());
+        InvUtils.swap(findNametag.getSlot(), true);
 
         offHand = findNametag.isOffhand();
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoNametag.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoNametag.java
@@ -66,7 +66,6 @@ public class AutoNametag extends Module {
 
     private Entity target;
     private boolean offHand;
-    private int preSlot;
 
     public AutoNametag() {
         super(Categories.World, "auto-nametag", "Automatically uses nametags on entities without a nametag. WILL nametag ALL entities in the specified distance.");
@@ -98,8 +97,7 @@ public class AutoNametag extends Module {
 
 
         // Swapping slots
-        preSlot = mc.player.getInventory().selectedSlot;
-        InvUtils.swap(findNametag.getSlot());
+        InvUtils.autoSwap(findNametag.getSlot());
 
         offHand = findNametag.isOffhand();
 
@@ -111,6 +109,6 @@ public class AutoNametag extends Module {
 
     private void interact() {
         mc.interactionManager.interactEntity(mc.player, target, offHand ? Hand.OFF_HAND : Hand.MAIN_HAND);
-        InvUtils.swap(preSlot);
+        InvUtils.swapBack();
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoShearer.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoShearer.java
@@ -82,7 +82,7 @@ public class AutoShearer extends Module {
             if (findNewShears) {
                 FindItemResult shears = InvUtils.findInHotbar(itemStack -> (!antiBreak.get() || (antiBreak.get() && itemStack.getDamage() < itemStack.getMaxDamage() - 1)) && itemStack.getItem() == Items.SHEARS);
 
-                if (InvUtils.autoSwap(shears.getSlot())) foundShears = true;
+                if (InvUtils.swap(shears.getSlot(), true)) foundShears = true;
             }
 
             if (foundShears) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoShearer.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoShearer.java
@@ -48,7 +48,6 @@ public class AutoShearer extends Module {
     );
 
     private Entity entity;
-    private int preSlot;
     private boolean offHand;
 
     public AutoShearer() {
@@ -83,7 +82,7 @@ public class AutoShearer extends Module {
             if (findNewShears) {
                 FindItemResult shears = InvUtils.findInHotbar(itemStack -> (!antiBreak.get() || (antiBreak.get() && itemStack.getDamage() < itemStack.getMaxDamage() - 1)) && itemStack.getItem() == Items.SHEARS);
 
-                if (InvUtils.swap(shears.getSlot())) foundShears = true;
+                if (InvUtils.autoSwap(shears.getSlot())) foundShears = true;
             }
 
             if (foundShears) {
@@ -99,6 +98,6 @@ public class AutoShearer extends Module {
 
     private void interact() {
         mc.interactionManager.interactEntity(mc.player, entity, offHand ? Hand.OFF_HAND : Hand.MAIN_HAND);
-        InvUtils.swap(preSlot);
+        InvUtils.swapBack();
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/EChestFarmer.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/EChestFarmer.java
@@ -116,7 +116,7 @@ public class EChestFarmer extends Module {
 
     @Override
     public void onDeactivate() {
-        InvUtils.swap(prevSlot);
+        InvUtils.swapBack();
     }
 
     @EventHandler
@@ -143,7 +143,7 @@ public class EChestFarmer extends Module {
 
         // Toggle if obby amount reached
         if (selfToggle.get() && InvUtils.find(Items.OBSIDIAN).getCount() - (ignoreExisting.get() ? startCount : 0) >= amount.get()) {
-            InvUtils.swap(prevSlot);
+            InvUtils.swapBack();
             toggle();
             return;
         }
@@ -167,7 +167,7 @@ public class EChestFarmer extends Module {
 
             if (bestSlot == -1) return;
 
-            InvUtils.swap(bestSlot);
+            InvUtils.autoSwap(bestSlot);
             BlockUtils.breakBlock(target, swingHand.get());
         }
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/EChestFarmer.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/EChestFarmer.java
@@ -167,7 +167,7 @@ public class EChestFarmer extends Module {
 
             if (bestSlot == -1) return;
 
-            InvUtils.autoSwap(bestSlot);
+            InvUtils.swap(bestSlot, true);
             BlockUtils.breakBlock(target, swingHand.get());
         }
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/Flamethrower.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/Flamethrower.java
@@ -80,7 +80,6 @@ public class Flamethrower extends Module {
     );
 
     private Entity entity;
-    private int preSlot;
     private int ticks = 0;
 
     public Flamethrower() {
@@ -136,12 +135,10 @@ public class Flamethrower extends Module {
             }
         }
 
-        InvUtils.swap(preSlot);
+        InvUtils.swapBack();
     }
 
     private boolean selectSlot() {
-        preSlot = mc.player.getInventory().selectedSlot;
-
         boolean findNewFlintAndSteel = false;
         if (mc.player.getInventory().getMainHandStack().getItem() == Items.FLINT_AND_STEEL) {
             if (antiBreak.get() && mc.player.getInventory().getMainHandStack().getDamage() >= mc.player.getInventory().getMainHandStack().getMaxDamage() - 1)
@@ -155,7 +152,7 @@ public class Flamethrower extends Module {
 
         boolean foundFlintAndSteel = !findNewFlintAndSteel;
         if (findNewFlintAndSteel) {
-            foundFlintAndSteel = InvUtils.swap(InvUtils.findInHotbar(itemStack -> (!antiBreak.get() || (antiBreak.get() && itemStack.getDamage() < itemStack.getMaxDamage() - 1)) && itemStack.getItem() == Items.FLINT_AND_STEEL).getSlot());
+            foundFlintAndSteel = InvUtils.autoSwap(InvUtils.findInHotbar(itemStack -> (!antiBreak.get() || (antiBreak.get() && itemStack.getDamage() < itemStack.getMaxDamage() - 1)) && itemStack.getItem() == Items.FLINT_AND_STEEL).getSlot());
         }
         return foundFlintAndSteel;
     }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/Flamethrower.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/Flamethrower.java
@@ -152,7 +152,7 @@ public class Flamethrower extends Module {
 
         boolean foundFlintAndSteel = !findNewFlintAndSteel;
         if (findNewFlintAndSteel) {
-            foundFlintAndSteel = InvUtils.autoSwap(InvUtils.findInHotbar(itemStack -> (!antiBreak.get() || (antiBreak.get() && itemStack.getDamage() < itemStack.getMaxDamage() - 1)) && itemStack.getItem() == Items.FLINT_AND_STEEL).getSlot());
+            foundFlintAndSteel = InvUtils.swap(InvUtils.findInHotbar(itemStack -> (!antiBreak.get() || (antiBreak.get() && itemStack.getDamage() < itemStack.getMaxDamage() - 1)) && itemStack.getItem() == Items.FLINT_AND_STEEL).getSlot(), true);
         }
         return foundFlintAndSteel;
     }

--- a/src/main/java/meteordevelopment/meteorclient/utils/player/InvUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/InvUtils.java
@@ -17,6 +17,7 @@ import static meteordevelopment.meteorclient.utils.Utils.mc;
 
 public class InvUtils {
     private static final Action ACTION = new Action();
+    public static int previousSlot = -1;
 
     // Finding items
 
@@ -89,6 +90,20 @@ public class InvUtils {
     }
 
     // Interactions
+
+    public static boolean autoSwap(int slot) {
+        if (previousSlot == -1) previousSlot = mc.player.getInventory().selectedSlot;
+
+        return swap(slot);
+    }
+
+    public static boolean swapBack() {
+        if (previousSlot == -1) return false;
+
+        boolean return_ = swap(previousSlot);
+        previousSlot = -1;
+        return return_;
+    }
 
     public static boolean swap(int slot) {
         if (slot < 0 || slot > 8) return false;

--- a/src/main/java/meteordevelopment/meteorclient/utils/player/InvUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/InvUtils.java
@@ -91,26 +91,21 @@ public class InvUtils {
 
     // Interactions
 
-    public static boolean autoSwap(int slot) {
-        if (previousSlot == -1) previousSlot = mc.player.getInventory().selectedSlot;
+    public static boolean swap(int slot, boolean swapBack) {
+        if (slot < 0 || slot > 8) return false;
+        if (swapBack && previousSlot == -1) previousSlot = mc.player.getInventory().selectedSlot;
 
-        return swap(slot);
+        mc.player.getInventory().selectedSlot = slot;
+        ((IClientPlayerInteractionManager) mc.interactionManager).syncSelected();
+        return true;
     }
 
     public static boolean swapBack() {
         if (previousSlot == -1) return false;
 
-        boolean return_ = swap(previousSlot);
+        boolean return_ = swap(previousSlot, false);
         previousSlot = -1;
         return return_;
-    }
-
-    public static boolean swap(int slot) {
-        if (slot < 0 || slot > 8) return false;
-
-        mc.player.getInventory().selectedSlot = slot;
-        ((IClientPlayerInteractionManager) mc.interactionManager).syncSelected();
-        return true;
     }
 
     public static Action move() {

--- a/src/main/java/meteordevelopment/meteorclient/utils/world/BlockUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/world/BlockUtils.java
@@ -92,14 +92,14 @@ public class BlockUtils {
 
         if (rotate) {
             Rotations.rotate(Rotations.getYaw(hitPos), Rotations.getPitch(hitPos), rotationPriority, () -> {
-                InvUtils.autoSwap(slot);
+                InvUtils.swap(slot, swapBack);
 
                 place(new BlockHitResult(hitPos, s, neighbour, false), hand, swingHand);
 
                 if (swapBack) InvUtils.swapBack();
             });
         } else {
-            InvUtils.autoSwap(slot);
+            InvUtils.swap(slot, swapBack);
 
             place(new BlockHitResult(hitPos, s, neighbour, false), hand, swingHand);
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/world/BlockUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/world/BlockUtils.java
@@ -92,20 +92,18 @@ public class BlockUtils {
 
         if (rotate) {
             Rotations.rotate(Rotations.getYaw(hitPos), Rotations.getPitch(hitPos), rotationPriority, () -> {
-                int prevSlot = Utils.mc.player.getInventory().selectedSlot;
-                InvUtils.swap(slot);
+                InvUtils.autoSwap(slot);
 
                 place(new BlockHitResult(hitPos, s, neighbour, false), hand, swingHand);
 
-                if (swapBack) InvUtils.swap(prevSlot);
+                if (swapBack) InvUtils.swapBack();
             });
         } else {
-            int prevSlot = Utils.mc.player.getInventory().selectedSlot;
-            InvUtils.swap(slot);
+            InvUtils.autoSwap(slot);
 
             place(new BlockHitResult(hitPos, s, neighbour, false), hand, swingHand);
 
-            if (swapBack) InvUtils.swap(prevSlot);
+            if (swapBack) InvUtils.swapBack();
         }
 
 


### PR DESCRIPTION
- Uses single static `previousSlot` variable which avoids the possibility of 2 or more modules conflicting due to having seperate `previousSlot` values.
- Allows multiple swaps before swapping back (previously `previousSlot` kept being forgotten everytime a new swap happens).