### PR TITLE
Make packet mine block class public

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/PacketMine.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/PacketMine.java
@@ -251,7 +251,7 @@ public class PacketMine extends Module {
         return speed;
     }
 
-    private class MyBlock {
+    public class MyBlock {
         public BlockPos blockPos;
         public BlockState blockState;
         public Block block;


### PR DESCRIPTION
Make `MyBlock` accessible so other modules and addons can use it too.

I am currently working on villager trade rolling addon and I don't really want to copypaste packet mine basically.