### PR TITLE
Fix Shears and AutoTool

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoTool.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoTool.java
@@ -20,6 +20,7 @@ import net.minecraft.block.Blocks;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.enchantment.Enchantments;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.ShearsItem;
 import net.minecraft.item.ToolItem;
 
 public class AutoTool extends Module {
@@ -119,7 +120,7 @@ public class AutoTool extends Module {
             }
         }
 
-        if ((bestSlot != -1 && (bestScore > getScore(currentStack, blockState)) || shouldStopUsing(currentStack) || !(currentStack.getItem() instanceof ToolItem))) {
+        if ((bestSlot != -1 && (bestScore > getScore(currentStack, blockState)) || shouldStopUsing(currentStack) || !isTool(currentStack))) {
             ticks = switchDelay.get();
 
             if (ticks == 0) InvUtils.swap(bestSlot, true);
@@ -129,14 +130,14 @@ public class AutoTool extends Module {
         // Anti break
         currentStack = mc.player.getMainHandStack();
 
-        if (shouldStopUsing(currentStack) && currentStack.getItem() instanceof ToolItem) {
+        if (shouldStopUsing(currentStack) && isTool(currentStack)) {
             mc.options.keyAttack.setPressed(false);
             event.setCancelled(true);
         }
     }
 
     private double getScore(ItemStack itemStack, BlockState state) {
-        if (shouldStopUsing(itemStack) || !(itemStack.getItem() instanceof ToolItem)) return -1;
+        if (shouldStopUsing(itemStack) || !isTool(itemStack)) return -1;
 
         if (silkTouchForEnderChest.get()
             && state.getBlock() == Blocks.ENDER_CHEST
@@ -159,6 +160,11 @@ public class AutoTool extends Module {
 
     private boolean shouldStopUsing(ItemStack itemStack) {
         return antiBreak.get() && itemStack.getMaxDamage() - itemStack.getDamage() < breakDurability.get();
+    }
+
+    private boolean isTool(ItemStack itemStack)
+    {
+        return itemStack.getItem() instanceof ToolItem || itemStack.getItem() instanceof ShearsItem;
     }
 
     public enum EnchantPreference {


### PR DESCRIPTION
Fixes shears not being counted as a valid tool in the autotool module. This manifests in shears always being skipped over because ShearsItem is a valid tool despite not extending ToolItem.
