### PR TITLE
tiny fix to the dropdown?

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -40,8 +40,8 @@ body:
     attributes:
       label: Operating System
       options:
-        - label: macOS
-        - label: Windows
-        - label: Linux
+        - macOS
+        - Windows
+        - Linux
     validations:
       required: true


### PR DESCRIPTION
this replaces the for example `{"label"=>"copeOS"}` with `copeOS`