### PR TITLE
Added more clarity for issue prerequisites

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -18,11 +18,6 @@ body:
     attributes:
       label: Steps to reproduce
       description: How do you trigger this bug?
-      value: |
-        1.
-        2.
-        3.
-        ...
       render: bash
     validations:
       required: true
@@ -53,7 +48,11 @@ body:
     attributes:
       label: Before submitting a bug report
       options:
-        - label: This bug wasn't already reported.
-          required: true
-        - label: This is a valid bug and I have checked all settings.
-          required: true
+        - label: |
+            This bug wasn't already reported.
+            (I have checked every bug report on github)
+          required: false
+        - label: |
+            This is a valid bug.
+            (I am able to reproduce this on the latest dev build)
+          required: false

--- a/.github/ISSUE_TEMPLATE/suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/suggestion.yml
@@ -15,9 +15,15 @@ body:
     attributes:
       label: Before submitting a suggestion
       options:
-        - label: This feature doesn't already exist in the client.
-          required: true
-        - label: This wasn't already suggested.
-          required: true
-        - label: This feature is a valid suggestion, according to the FAQ and Guides.
-          required: true
+        - label: |
+            This feature doesn't already exist in the client.
+            (I have checked every module and their settings on the **latest dev build**)
+          required: false
+        - label: |
+            This wasn't already suggested.
+            (I have checked every suggestion on github)
+          required: false
+        - label: |
+            This feature is a valid suggestion.
+            (I have read the FAQs and Guides)
+          required: false


### PR DESCRIPTION
Incase it wasn't clear enough for the tards.

Removed the `value` from `Steps to reproduce` in bug because with it people can leave it empty, and the `true` requirement will be useless.