### PR TITLE
Added Under Height and Render to Surround

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Surround.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Surround.java
@@ -35,7 +35,7 @@ public class Surround extends Module {
 
     private final Setting<Boolean> underHeight = sgGeneral.add(new BoolSetting.Builder()
         .name("under-height")
-        .description("Places obsidian next to the block you are standing on. (Bypasses some anti cheats)")
+        .description("Places obsidian next to the block you are standing on. (Bypasses some anticheats blocking surround in air)")
         .defaultValue(true)
         .build()
     );

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Surround.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Surround.java
@@ -21,12 +21,24 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.util.math.BlockPos;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+// Implemented Scaffold render and added Under Height (Place under the sides)
+// - Matejko06
 
 public class Surround extends Module {
 
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
+    private final SettingGroup sgRender = settings.createGroup("Render");
+
+    private final Setting<Boolean> underHeight = sgGeneral.add(new BoolSetting.Builder()
+        .name("under-height")
+        .description("Places obsidian next to the block you are standing on. (Bypasses some anti cheats)")
+        .defaultValue(true)
+        .build()
+    );
 
     private final Setting<Boolean> doubleHeight = sgGeneral.add(new BoolSetting.Builder()
             .name("double-height")
@@ -92,9 +104,47 @@ public class Surround extends Module {
             .build()
     );
 
-    // TODO: Make a render for Surround monkeys.
+    // Render
+
+    private final Setting<Boolean> render = sgRender.add(new BoolSetting.Builder()
+        .name("render")
+        .description("Renders the block where it is placing a bed.")
+        .defaultValue(true)
+        .build()
+    );
+
+    private final Setting<ShapeMode> shapeMode = sgRender.add(new EnumSetting.Builder<ShapeMode>()
+        .name("shape-mode")
+        .description("How the shapes are rendered.")
+        .defaultValue(ShapeMode.Both)
+        .build()
+    );
+
+    private final Setting<SettingColor> sideColor = sgRender.add(new ColorSetting.Builder()
+        .name("side-color")
+        .description("The side color for positions to be placed.")
+        .defaultValue(new SettingColor(15, 255, 211,75))
+        .build()
+    );
+
+    private final Setting<SettingColor> lineColor = sgRender.add(new ColorSetting.Builder()
+        .name("line-color")
+        .description("The line color for positions to be placed.")
+        .defaultValue(new SettingColor(15, 255, 211))
+        .build()
+    );
+
     private final BlockPos.Mutable blockPos = new BlockPos.Mutable();
     private boolean return_;
+    private final Pool<RenderSurroundBlock> renderSurroundBlockPool = new Pool<>(RenderSurroundBlock::new);
+    private final List<RenderSurroundBlock> renderSurroundBlocks = new ArrayList<>();
+    private boolean underHeightPlaced = false;
+    private boolean doubleHeightPlaced = false;
+    private boolean p1;
+    private boolean p6;
+    private boolean p7;
+    private boolean p8;
+    private boolean p9;
 
     public Surround() {
         super(Categories.Combat, "surround", "Surrounds you in blocks to prevent you from taking lots of damage.");
@@ -103,10 +153,23 @@ public class Surround extends Module {
     @Override
     public void onActivate() {
         if (center.get()) PlayerUtils.centerPlayer();
+
+        for (RenderSurroundBlock renderSurroundBlock : renderSurroundBlocks) renderSurroundBlockPool.free(renderSurroundBlock);
+        renderSurroundBlocks.clear();
+    }
+
+    @Override
+    public void onDeactivate() {
+        for (RenderSurroundBlock renderSurroundBlock : renderSurroundBlocks) renderSurroundBlockPool.free(renderSurroundBlock);
+        renderSurroundBlocks.clear();
     }
 
     @EventHandler
     private void onTick(TickEvent.Pre event) {
+        // Ticking fade animation
+        renderSurroundBlocks.forEach(RenderSurroundBlock::tick);
+        renderSurroundBlocks.removeIf(renderSurroundBlock -> renderSurroundBlock.ticks <= 0);
+
         if ((disableOnJump.get() && (mc.options.keyJump.isPressed() || mc.player.input.jumping)) || (disableOnYChange.get() && mc.player.prevY < mc.player.getY())) {
             toggle();
             return;
@@ -119,36 +182,52 @@ public class Surround extends Module {
         return_ = false;
 
         // Bottom
-        boolean p1 = place(0, -1, 0);
+        p1 = place(0, -1, 0);
         if (return_) return;
 
+        // Under height
+        underHeightPlaced = false;
+        if (underHeight.get()) {
+            boolean p2 = place(1, -1, 0);
+            if (return_) return;
+            boolean p3 = place(-1, -1, 0);
+            if (return_) return;
+            boolean p4 = place(0, -1, 1);
+            if (return_) return;
+            boolean p5 = place(0, -1, -1);
+            if (return_) return;
+
+            if (p2 && p3 && p4 && p5) underHeightPlaced = true;
+        }
+
         // Sides
-        boolean p2 = place(1, 0, 0);
+        p6 = place(1, 0, 0);
         if (return_) return;
-        boolean p3 = place(-1, 0, 0);
+        p7 = place(-1, 0, 0);
         if (return_) return;
-        boolean p4 = place(0, 0, 1);
+        p8 = place(0, 0, 1);
         if (return_) return;
-        boolean p5 = place(0, 0, -1);
+        p9 = place(0, 0, -1);
         if (return_) return;
 
         // Sides up
-        boolean doubleHeightPlaced = false;
+        doubleHeightPlaced = false;
         if (doubleHeight.get()) {
-            boolean p6 = place(1, 1, 0);
+            boolean p10 = place(1, 1, 0);
             if (return_) return;
-            boolean p7 = place(-1, 1, 0);
+            boolean p11 = place(-1, 1, 0);
             if (return_) return;
-            boolean p8 = place(0, 1, 1);
+            boolean p12 = place(0, 1, 1);
             if (return_) return;
-            boolean p9 = place(0, 1, -1);
+            boolean p13 = place(0, 1, -1);
             if (return_) return;
 
-            if (p6 && p7 && p8 && p9) doubleHeightPlaced = true;
+            if (p10 && p11 && p12 && p13) doubleHeightPlaced = true;
         }
 
         // Auto turn off
-        if (turnOff.get() && p1 && p2 && p3 && p4 && p5) {
+        if (turnOff.get() && p1 && p6 && p7 && p8 &&p9) {
+            if (underHeightPlaced || !underHeight.get()) toggle();
             if (doubleHeightPlaced || !doubleHeight.get()) toggle();
         }
     }
@@ -171,10 +250,55 @@ public class Surround extends Module {
             return_ = true;
         }
 
+        // Render block if was placed
+        renderSurroundBlocks.add(renderSurroundBlockPool.get().set(blockPos));
+
         return false;
     }
 
     private void setBlockPos(int x, int y, int z) {
         blockPos.set(mc.player.getX() + x, mc.player.getY() + y, mc.player.getZ() + z);
+    }
+
+    public static class RenderSurroundBlock {
+        public BlockPos.Mutable pos = new BlockPos.Mutable();
+        public int ticks;
+
+        public RenderSurroundBlock set(BlockPos blockPos) {
+            pos.set(blockPos);
+            ticks = 8;
+
+            return this;
+        }
+
+        public void tick() {
+            ticks--;
+        }
+
+        public void render(Render3DEvent event, Color sides, Color lines, ShapeMode shapeMode) {
+            int preSideA = sides.a;
+            int preLineA = lines.a;
+
+            sides.a *= (double) ticks / 8;
+            lines.a *= (double) ticks / 8;
+
+            event.renderer.box(pos, sides, lines, shapeMode, 0);
+
+            sides.a = preSideA;
+            lines.a = preLineA;
+        }
+    }
+
+    @EventHandler
+    private void onRender(Render3DEvent event) {
+        if (!render.get()) return;
+        if (blockPos == null) return;
+        if (p1 && p6 && p7 && p8 &&p9) {
+            if (underHeightPlaced || !underHeight.get()) return;
+            if (doubleHeightPlaced || !doubleHeight.get()) return;
+        }
+        renderSurroundBlocks.sort(Comparator.comparingInt(o -> -o.ticks));
+        renderSurroundBlocks.forEach(renderSurroundBlock -> renderSurroundBlock.render(event, sideColor.get(), lineColor.get(), shapeMode.get()));
+        event.renderer.box(blockPos, sideColor.get(), lineColor.get(), shapeMode.get(), 0);
     }
 }


### PR DESCRIPTION
I made Surround render using Scaffold render because normal render was staying visible and blinked too fast. Under Height places blocks under the surround blocks first and then the normal ones to bypass a few anticheats. (Mainly happening on 1.12 servers)