### PR TITLE
Fix player jumping too high 

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/speed/SpeedMode.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/speed/SpeedMode.java
@@ -55,7 +55,7 @@ public class SpeedMode {
 
     protected double getHop(double height) {
         StatusEffectInstance jumpBoost = mc.player.hasStatusEffect(StatusEffects.JUMP_BOOST) ? mc.player.getStatusEffect(StatusEffects.JUMP_BOOST) : null;
-        if (jumpBoost != null) height += jumpBoost.getAmplifier() + 1 * 0.1f;
+        if (jumpBoost != null) height += (jumpBoost.getAmplifier() + 1) * 0.1f;
         return height;
     }
 


### PR DESCRIPTION
Fix player jumping too high when speed module is on and the player has jump boost 2