### PR TITLE
Add a waypoint command

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/commands/Commands.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/commands/Commands.java
@@ -70,6 +70,7 @@ public class Commands extends System<Commands> {
         add(new BindCommand());
         add(new FOVCommand());
         add(new RotationCommand());
+        add(new WaypointCommand());
 
         commands.sort(Comparator.comparing(Command::getName));
     }

--- a/src/main/java/meteordevelopment/meteorclient/systems/commands/arguments/ProfileArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/commands/arguments/ProfileArgumentType.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client/).
+ * Copyright (c) 2021 Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.systems.commands.arguments;
+
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import meteordevelopment.meteorclient.systems.profiles.Profile;
+import meteordevelopment.meteorclient.systems.profiles.Profiles;
+import net.minecraft.command.CommandSource;
+import net.minecraft.text.LiteralText;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public class ProfileArgumentType implements ArgumentType<String> {
+    private static final DynamicCommandExceptionType NO_SUCH_PROFILE = new DynamicCommandExceptionType(name -> new LiteralText("Profile with name " + name + " doesn't exist."));
+
+    public static ProfileArgumentType profile() {
+        return new ProfileArgumentType();
+    }
+
+    public static Profile getProfile(final CommandContext<?> context, final String name) {
+        return Profiles.get().get(context.getArgument(name, String.class));
+    }
+
+    @Override
+    public String parse(StringReader reader) throws CommandSyntaxException {
+        String argument = reader.readString();
+
+        if (Profiles.get().get(argument) == null) throw NO_SUCH_PROFILE.create(argument);
+        return argument;
+    }
+
+    @Override
+    public <S> CompletableFuture<Suggestions> listSuggestions(CommandContext<S> context, SuggestionsBuilder builder) {
+        return CommandSource.suggestMatching(getExamples(), builder);
+    }
+
+    @Override
+    public Collection<String> getExamples() {
+        List<String> names = new ArrayList<>();
+        for (Profile profile : Profiles.get()) names.add(profile.name);
+        return names;
+    }
+}

--- a/src/main/java/meteordevelopment/meteorclient/systems/commands/arguments/WaypointArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/commands/arguments/WaypointArgumentType.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client/).
+ * Copyright (c) 2021 Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.systems.commands.arguments;
+
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import meteordevelopment.meteorclient.systems.waypoints.Waypoint;
+import meteordevelopment.meteorclient.systems.waypoints.Waypoints;
+import net.minecraft.command.CommandSource;
+import net.minecraft.text.LiteralText;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public class WaypointArgumentType implements ArgumentType<String> {
+    private static final DynamicCommandExceptionType NO_SUCH_WAYPOINT = new DynamicCommandExceptionType(name -> new LiteralText("Waypoint with name '" + name + "' doesn't exist."));
+
+    public static WaypointArgumentType waypoint() {return new WaypointArgumentType();}
+
+    public static Waypoint getWaypoint(final CommandContext<?> context, final String name) {
+        return Waypoints.get().get(context.getArgument(name, String.class));
+    }
+
+    @Override
+    public String parse(StringReader reader) throws CommandSyntaxException {
+        final String argument = reader.getRemaining();
+        reader.setCursor(reader.getTotalLength());          //ty sb :pray:
+
+        if (Waypoints.get().get(argument) == null) throw NO_SUCH_WAYPOINT.create(argument);
+        return argument;
+    }
+
+    @Override
+    public <S> CompletableFuture<Suggestions> listSuggestions(CommandContext<S> context, SuggestionsBuilder builder) {
+        return CommandSource.suggestMatching(getExamples(), builder);
+    }
+
+    @Override
+    public Collection<String> getExamples() {
+        List<String> names = new ArrayList<>();
+        for (Waypoint waypoint : Waypoints.get()) names.add(waypoint.name);
+        return names;
+    }
+}
+

--- a/src/main/java/meteordevelopment/meteorclient/systems/commands/commands/ProfilesCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/commands/commands/ProfilesCommand.java
@@ -5,24 +5,12 @@
 
 package meteordevelopment.meteorclient.systems.commands.commands;
 
-import com.mojang.brigadier.StringReader;
-import com.mojang.brigadier.arguments.ArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
-import com.mojang.brigadier.context.CommandContext;
-import com.mojang.brigadier.exceptions.CommandSyntaxException;
-import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
-import com.mojang.brigadier.suggestion.Suggestions;
-import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import meteordevelopment.meteorclient.systems.commands.Command;
+import meteordevelopment.meteorclient.systems.commands.arguments.ProfileArgumentType;
 import meteordevelopment.meteorclient.systems.profiles.Profile;
 import meteordevelopment.meteorclient.systems.profiles.Profiles;
 import net.minecraft.command.CommandSource;
-import net.minecraft.text.LiteralText;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
 
@@ -66,37 +54,4 @@ public class ProfilesCommand extends Command {
                     return SINGLE_SUCCESS;
                 })));
     }
-
-    public static class ProfileArgumentType implements ArgumentType<String> {
-        private static final DynamicCommandExceptionType NO_SUCH_PROFILE = new DynamicCommandExceptionType(name -> new LiteralText("Profile with name " + name + " doesn't exist."));
-
-        public static ProfileArgumentType profile() {
-            return new ProfileArgumentType();
-        }
-
-        public static Profile getProfile(final CommandContext<?> context, final String name) {
-            return Profiles.get().get(context.getArgument(name, String.class));
-        }
-
-        @Override
-        public String parse(StringReader reader) throws CommandSyntaxException {
-            String argument = reader.readString();
-
-            if (Profiles.get().get(argument) == null) throw NO_SUCH_PROFILE.create(argument);
-            return argument;
-        }
-
-        @Override
-        public <S> CompletableFuture<Suggestions> listSuggestions(CommandContext<S> context, SuggestionsBuilder builder) {
-            return CommandSource.suggestMatching(getExamples(), builder);
-        }
-
-        @Override
-        public Collection<String> getExamples() {
-            List<String> names = new ArrayList<>();
-            for (Profile profile : Profiles.get()) names.add(profile.name);
-            return names;
-        }
-    }
-
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/commands/commands/WaypointCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/commands/commands/WaypointCommand.java
@@ -1,0 +1,139 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client/).
+ * Copyright (c) 2021 Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.systems.commands.commands;
+
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import meteordevelopment.meteorclient.systems.commands.Command;
+import meteordevelopment.meteorclient.systems.waypoints.Waypoint;
+import meteordevelopment.meteorclient.systems.waypoints.Waypoints;
+import meteordevelopment.meteorclient.utils.player.PlayerUtils;
+import net.minecraft.command.CommandSource;
+import net.minecraft.text.LiteralText;
+import net.minecraft.util.Formatting;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
+
+public class WaypointCommand extends Command {
+    public WaypointCommand() {
+        super("waypoint", "Manages waypoints.", "wp");
+    }
+
+    @Override
+    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+        builder.then(literal("get").executes(ctx -> {
+            if (Waypoints.get().waypoints.isEmpty()) error("No created waypoints.");
+            else {
+                info(Formatting.WHITE + "Created Waypoints:");
+                for (Waypoint waypoint : Waypoints.get()) {
+                    info("Name: (highlight)'%s'(default), Dimension: (highlight)%s(default), Pos: (highlight)%s(default)", waypoint.name, waypoint.actualDimension, waypointPos(waypoint));
+                }
+            }
+            return SINGLE_SUCCESS;
+        }).then(argument("waypoint", WaypointArgumentType.waypoint()).executes(context -> {
+            Waypoint waypoint = WaypointArgumentType.getWaypoint(context, "waypoint");
+            info("Name: " + Formatting.WHITE + waypoint.name);
+            info("Actual Dimension: " + Formatting.WHITE + waypoint.actualDimension);
+            info("Position: " + Formatting.WHITE + waypointFullPos(waypoint));
+            info("Visible: " + (waypoint.visible ? Formatting.GREEN + "True" : Formatting.RED + "False"));
+            return SINGLE_SUCCESS;
+        })));
+
+        builder.then(literal("add").then(argument("waypoint", StringArgumentType.greedyString()).executes(context -> {
+            if (mc.player == null) return -1;
+            Waypoint waypoint = new Waypoint() {{
+                name = StringArgumentType.getString(context, "waypoint");
+                actualDimension = PlayerUtils.getDimension();
+
+                x = (int) mc.player.getX();
+                y = (int) mc.player.getY() + 1;
+                z = (int) mc.player.getZ();
+
+                switch (actualDimension) {
+                    case Overworld -> overworld = true;
+                    case Nether -> nether = true;
+                    case End -> end = true;
+                }
+            }};
+
+            Waypoints.get().add(waypoint);
+            Waypoints.get().save();
+
+            info("Created waypoint with name: (highlight)%s(default)", waypoint.name);
+            return SINGLE_SUCCESS;
+        })));
+
+        builder.then(literal("delete").then(argument("waypoint", WaypointArgumentType.waypoint()).executes(context -> {
+            Waypoint waypoint = WaypointArgumentType.getWaypoint(context, "waypoint");
+
+            info("The waypoint (highlight)'%s'(default) has been deleted.", waypoint.name);
+
+            Waypoints.get().remove(waypoint);
+            Waypoints.get().save();
+
+            return SINGLE_SUCCESS;
+        })));
+
+        builder.then(literal("toggle").then(argument("waypoint", WaypointArgumentType.waypoint()).executes(context -> {
+            Waypoint waypoint = WaypointArgumentType.getWaypoint(context, "waypoint");
+            waypoint.visible = !waypoint.visible;
+
+            Waypoints.get().save();
+            return SINGLE_SUCCESS;
+        })));
+    }
+
+    public static class WaypointArgumentType implements ArgumentType<String> {
+        private static final DynamicCommandExceptionType NO_SUCH_WAYPOINT = new DynamicCommandExceptionType(name -> new LiteralText("Waypoint with name '" + name + "' doesn't exist."));
+
+        public static WaypointArgumentType waypoint() {return new WaypointArgumentType();}
+
+        public static Waypoint getWaypoint(final CommandContext<?> context, final String name) {
+            return Waypoints.get().get(context.getArgument(name, String.class));
+        }
+
+        @Override
+        public String parse(StringReader reader) throws CommandSyntaxException {
+            final String argument = reader.getRemaining();
+            reader.setCursor(reader.getTotalLength());          //ty sb :pray:
+
+            if (Waypoints.get().get(argument) == null) throw NO_SUCH_WAYPOINT.create(argument);
+            return argument;
+        }
+
+        @Override
+        public <S> CompletableFuture<Suggestions> listSuggestions(CommandContext<S> context, SuggestionsBuilder builder) {
+            return CommandSource.suggestMatching(getExamples(), builder);
+        }
+
+        @Override
+        public Collection<String> getExamples() {
+            List<String> names = new ArrayList<>();
+            for (Waypoint waypoint : Waypoints.get()) names.add(waypoint.name);
+            return names;
+        }
+    }
+
+    private String waypointPos(Waypoint waypoint) {
+        return "X: " + waypoint.x + " Z: " + waypoint.z;
+    }
+
+    private String waypointFullPos(Waypoint waypoint) {
+        return "X: " + waypoint.x +  ", Y: " + waypoint.y + ", Z: " + waypoint.z;
+    }
+}

--- a/src/main/java/meteordevelopment/meteorclient/systems/commands/commands/WaypointCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/commands/commands/WaypointCommand.java
@@ -5,27 +5,15 @@
 
 package meteordevelopment.meteorclient.systems.commands.commands;
 
-import com.mojang.brigadier.StringReader;
-import com.mojang.brigadier.arguments.ArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
-import com.mojang.brigadier.context.CommandContext;
-import com.mojang.brigadier.exceptions.CommandSyntaxException;
-import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
-import com.mojang.brigadier.suggestion.Suggestions;
-import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import meteordevelopment.meteorclient.systems.commands.Command;
+import meteordevelopment.meteorclient.systems.commands.arguments.WaypointArgumentType;
 import meteordevelopment.meteorclient.systems.waypoints.Waypoint;
 import meteordevelopment.meteorclient.systems.waypoints.Waypoints;
 import meteordevelopment.meteorclient.utils.player.PlayerUtils;
 import net.minecraft.command.CommandSource;
-import net.minecraft.text.LiteralText;
 import net.minecraft.util.Formatting;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
 
@@ -36,7 +24,7 @@ public class WaypointCommand extends Command {
 
     @Override
     public void build(LiteralArgumentBuilder<CommandSource> builder) {
-        builder.then(literal("get").executes(ctx -> {
+        builder.then(literal("list").executes(context -> {
             if (Waypoints.get().waypoints.isEmpty()) error("No created waypoints.");
             else {
                 info(Formatting.WHITE + "Created Waypoints:");
@@ -45,7 +33,9 @@ public class WaypointCommand extends Command {
                 }
             }
             return SINGLE_SUCCESS;
-        }).then(argument("waypoint", WaypointArgumentType.waypoint()).executes(context -> {
+        }));
+
+        builder.then(literal("get").then(argument("waypoint", WaypointArgumentType.waypoint()).executes(context -> {
             Waypoint waypoint = WaypointArgumentType.getWaypoint(context, "waypoint");
             info("Name: " + Formatting.WHITE + waypoint.name);
             info("Actual Dimension: " + Formatting.WHITE + waypoint.actualDimension);
@@ -96,37 +86,6 @@ public class WaypointCommand extends Command {
             Waypoints.get().save();
             return SINGLE_SUCCESS;
         })));
-    }
-
-    public static class WaypointArgumentType implements ArgumentType<String> {
-        private static final DynamicCommandExceptionType NO_SUCH_WAYPOINT = new DynamicCommandExceptionType(name -> new LiteralText("Waypoint with name '" + name + "' doesn't exist."));
-
-        public static WaypointArgumentType waypoint() {return new WaypointArgumentType();}
-
-        public static Waypoint getWaypoint(final CommandContext<?> context, final String name) {
-            return Waypoints.get().get(context.getArgument(name, String.class));
-        }
-
-        @Override
-        public String parse(StringReader reader) throws CommandSyntaxException {
-            final String argument = reader.getRemaining();
-            reader.setCursor(reader.getTotalLength());          //ty sb :pray:
-
-            if (Waypoints.get().get(argument) == null) throw NO_SUCH_WAYPOINT.create(argument);
-            return argument;
-        }
-
-        @Override
-        public <S> CompletableFuture<Suggestions> listSuggestions(CommandContext<S> context, SuggestionsBuilder builder) {
-            return CommandSource.suggestMatching(getExamples(), builder);
-        }
-
-        @Override
-        public Collection<String> getExamples() {
-            List<String> names = new ArrayList<>();
-            for (Waypoint waypoint : Waypoints.get()) names.add(waypoint.name);
-            return names;
-        }
     }
 
     private String waypointPos(Waypoint waypoint) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/waypoints/Waypoints.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/waypoints/Waypoints.java
@@ -47,7 +47,7 @@ public class Waypoints extends System<Waypoints> implements Iterable<Waypoint> {
 
     public final Map<String, AbstractTexture> icons = new HashMap<>();
 
-    private List<Waypoint> waypoints = new ArrayList<>();
+    public List<Waypoint> waypoints = new ArrayList<>();
     private final Vec3 pos = new Vec3();
 
     public Waypoints() {
@@ -91,6 +91,16 @@ public class Waypoints extends System<Waypoints> implements Iterable<Waypoint> {
         if (waypoints.remove(waypoint)) {
             save();
         }
+    }
+
+    public Waypoint get(String name) {
+        for (Waypoint waypoint : this) {
+            if (waypoint.name.equalsIgnoreCase(name)) {
+                return waypoint;
+            }
+        }
+
+        return null;
     }
 
     @EventHandler


### PR DESCRIPTION
Added a command to help manage waypoints. Usage:

`.wp get [name]` gets information on all waypoints, or more detailed info on a specific one
`.wp add [name]` adds a waypoint to your current position with the specified name
`.wp delete [name]` deletes the specified waypoint
`.wp toggle [name]` toggles the specified waypoints visibility