### PR TITLE
Fix the light overlay on 1.18

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/LightOverlay.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/LightOverlay.java
@@ -60,6 +60,13 @@ public class LightOverlay extends Module {
             .build()
     );
 
+    private final Setting<Boolean> newMobSpawnLightLevel = sgGeneral.add(new BoolSetting.Builder()
+            .name("now-mob-spawn-light-level")
+            .description("Use the new (1.18+) mob spawn behavior")
+            .defaultValue(true)
+            .build()
+    );
+
     // Colors
 
     private final Setting<SettingColor> color = sgColors.add(new ColorSetting.Builder()
@@ -93,7 +100,7 @@ public class LightOverlay extends Module {
         crosses.clear();
 
         BlockIterator.register(horizontalRange.get(), verticalRange.get(), (blockPos, blockState) -> {
-            switch (BlockUtils.isValidMobSpawn(blockPos)) {
+            switch (BlockUtils.isValidMobSpawn(blockPos, newMobSpawnLightLevel.get())) {
                 case Never:
                     break;
                 case Potential:

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/LightOverlay.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/LightOverlay.java
@@ -61,7 +61,7 @@ public class LightOverlay extends Module {
     );
 
     private final Setting<Boolean> newMobSpawnLightLevel = sgGeneral.add(new BoolSetting.Builder()
-            .name("now-mob-spawn-light-level")
+            .name("new-mob-spawn-light-level")
             .description("Use the new (1.18+) mob spawn behavior")
             .defaultValue(true)
             .build()

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/SpawnProofer.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/SpawnProofer.java
@@ -62,6 +62,13 @@ public class SpawnProofer extends Module {
         .build()
     );
 
+    private final Setting<Boolean> newMobSpawnLightLevel = sgGeneral.add(new BoolSetting.Builder()
+            .name("now-mob-spawn-light-level")
+            .description("Use the new (1.18+) mob spawn behavior")
+            .defaultValue(true)
+            .build()
+    );
+
 
     private final Pool<BlockPos.Mutable> spawnPool = new Pool<>(BlockPos.Mutable::new);
     private final List<BlockPos.Mutable> spawns = new ArrayList<>();
@@ -90,7 +97,7 @@ public class SpawnProofer extends Module {
         for (BlockPos.Mutable blockPos : spawns) spawnPool.free(blockPos);
         spawns.clear();
         BlockIterator.register(range.get(), range.get(), (blockPos, blockState) -> {
-            BlockUtils.MobSpawn spawn = BlockUtils.isValidMobSpawn(blockPos);
+            BlockUtils.MobSpawn spawn = BlockUtils.isValidMobSpawn(blockPos, newMobSpawnLightLevel.get());
 
             if ((spawn == BlockUtils.MobSpawn.Always && (mode.get() == Mode.Always || mode.get() == Mode.Both)) ||
                     spawn == BlockUtils.MobSpawn.Potential && (mode.get() == Mode.Potential || mode.get() == Mode.Both)) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/SpawnProofer.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/SpawnProofer.java
@@ -63,7 +63,7 @@ public class SpawnProofer extends Module {
     );
 
     private final Setting<Boolean> newMobSpawnLightLevel = sgGeneral.add(new BoolSetting.Builder()
-            .name("now-mob-spawn-light-level")
+            .name("new-mob-spawn-light-level")
             .description("Use the new (1.18+) mob spawn behavior")
             .defaultValue(true)
             .build()

--- a/src/main/java/meteordevelopment/meteorclient/utils/world/BlockUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/world/BlockUtils.java
@@ -226,7 +226,8 @@ public class BlockUtils {
             || block instanceof TrapdoorBlock;
     }
 
-    public static MobSpawn isValidMobSpawn(BlockPos blockPos) {
+    public static MobSpawn isValidMobSpawn(BlockPos blockPos, boolean newMobSpawnLightLevel) {
+        int spawnLightLimit = newMobSpawnLightLevel ? 0 : 7;
         if (!(mc.world.getBlockState(blockPos).getBlock() instanceof AirBlock) ||
             mc.world.getBlockState(blockPos.down()).getBlock() == Blocks.BEDROCK) return MobSpawn.Never;
 
@@ -235,8 +236,8 @@ public class BlockUtils {
             if (mc.world.getBlockState(blockPos.down()).isTranslucent(mc.world, blockPos.down())) return MobSpawn.Never;
         }
 
-        if (mc.world.getLightLevel(blockPos, 0) <= 7) return MobSpawn.Potential;
-        else if (mc.world.getLightLevel(LightType.BLOCK, blockPos) <= 7) return MobSpawn.Always;
+        if (mc.world.getLightLevel(blockPos, 0) <= spawnLightLimit) return MobSpawn.Potential;
+        else if (mc.world.getLightLevel(LightType.BLOCK, blockPos) <= spawnLightLimit) return MobSpawn.Always;
 
         return MobSpawn.Never;
     }


### PR DESCRIPTION
This fixes the light overlay on 1.18. Mobs now only spawn at light level 0 rather than 7 as on 1.17.x. I'm unsure if there should be a version check to handle earlier versions. Happy for feedback on that or any other point.

This should fix #1762 