### PR TITLE
TOTEM_OF_UNDYING added to items in Offhand.

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Offhand.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Offhand.java
@@ -154,6 +154,7 @@ public class Offhand extends Module {
         EGap(Items.ENCHANTED_GOLDEN_APPLE),
         Gap(Items.GOLDEN_APPLE),
         Crystal(Items.END_CRYSTAL),
+        Totem(Items.TOTEM_OF_UNDYING),
         Shield(Items.SHIELD);
 
         net.minecraft.item.Item item;


### PR DESCRIPTION
Because crystal-on-ca or crystal-on-mine now can be used for strict servers and prevent some totem fails