### PR TITLE
Fix faulty commas in output of modules command

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/commands/commands/ModulesCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/commands/commands/ModulesCommand.java
@@ -47,7 +47,7 @@ public class ModulesCommand extends Command {
         tooltip.append(new LiteralText(module.description).formatted(Formatting.WHITE));
 
         BaseText finalModule = new LiteralText(module.title);
-        if (module != Modules.get().getList().get(Modules.get().getList().size() - 1)) finalModule.append(new LiteralText(", ").formatted(Formatting.GRAY));
+        if (!module.equals(Modules.get().getGroup(module.category).get(Modules.get().getGroup(module.category).size() - 1))) finalModule.append(new LiteralText(", ").formatted(Formatting.GRAY));
         finalModule.setStyle(finalModule.getStyle().withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, tooltip)));
 
         return finalModule;


### PR DESCRIPTION
The list that got used to check if the module is the last one is for everything and not just the category which would be the right one