### PR TITLE
breaking block hud element hide while not breaking

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/modules/BreakingBlockHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/modules/BreakingBlockHud.java
@@ -15,8 +15,14 @@ public class BreakingBlockHud extends DoubleTextHudElement {
 
     @Override
     protected String getRight() {
-        if (isInEditor()) return "0%";
+        if (isInEditor()) {
+            visible = false;
+            return "0%";
+        }
 
-        return String.format("%.0f%%", ((ClientPlayerInteractionManagerAccessor) mc.interactionManager).getBreakingProgress() * 100);
+        float breakingProgress = ((ClientPlayerInteractionManagerAccessor) mc.interactionManager).getBreakingProgress();
+
+        visible = breakingProgress > 0;
+        return String.format("%.0f%%", breakingProgress * 100);
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/modules/BreakingBlockHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/modules/BreakingBlockHud.java
@@ -6,9 +6,21 @@
 package meteordevelopment.meteorclient.systems.hud.modules;
 
 import meteordevelopment.meteorclient.mixin.ClientPlayerInteractionManagerAccessor;
+import meteordevelopment.meteorclient.settings.BoolSetting;
+import meteordevelopment.meteorclient.settings.Setting;
+import meteordevelopment.meteorclient.settings.SettingGroup;
 import meteordevelopment.meteorclient.systems.hud.HUD;
 
 public class BreakingBlockHud extends DoubleTextHudElement {
+    private final SettingGroup sgGeneral = settings.getDefaultGroup();
+
+    private final Setting<Boolean> hide = sgGeneral.add(new BoolSetting.Builder()
+        .name("hide")
+        .description("Hide while not breaking any block.")
+        .defaultValue(true)
+        .build()
+    );
+
     public BreakingBlockHud(HUD hud) {
         super(hud, "breaking-block", "Displays percentage of the block you are breaking.", "Breaking Block: ");
     }
@@ -21,7 +33,7 @@ public class BreakingBlockHud extends DoubleTextHudElement {
         }
 
         float breakingProgress = ((ClientPlayerInteractionManagerAccessor) mc.interactionManager).getBreakingProgress();
-        visible = breakingProgress > 0;
+        if (hide.get()) visible = breakingProgress > 0;
         return String.format("%.0f%%", breakingProgress * 100);
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/modules/BreakingBlockHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/modules/BreakingBlockHud.java
@@ -29,7 +29,7 @@ public class BreakingBlockHud extends DoubleTextHudElement {
     protected String getRight() {
         if (isInEditor()) {
             visible = true;
-            return "42%";
+            return "0%";
         }
 
         float breakingProgress = ((ClientPlayerInteractionManagerAccessor) mc.interactionManager).getBreakingProgress();

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/modules/BreakingBlockHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/modules/BreakingBlockHud.java
@@ -16,12 +16,11 @@ public class BreakingBlockHud extends DoubleTextHudElement {
     @Override
     protected String getRight() {
         if (isInEditor()) {
-            visible = false;
-            return "0%";
+            visible = true;
+            return "42%";
         }
 
         float breakingProgress = ((ClientPlayerInteractionManagerAccessor) mc.interactionManager).getBreakingProgress();
-
         visible = breakingProgress > 0;
         return String.format("%.0f%%", breakingProgress * 100);
     }


### PR DESCRIPTION
Adds a setting to the `breaking-block` hud element to hide it while there is no block breaking activity.