### PR TITLE
fixed bug in shader system

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/MinecraftClientMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MinecraftClientMixin.java
@@ -88,6 +88,9 @@ public abstract class MinecraftClientMixin implements IMinecraftClient {
         getProfiler().push("meteor-client_post_update");
         MeteorClient.EVENT_BUS.post(TickEvent.Post.get());
         getProfiler().pop();
+
+        if (!Utils.canUpdate())
+            Utils.unscaledProjection();
     }
 
     @Inject(method = "doItemUse", at = @At("HEAD"))


### PR DESCRIPTION
When the ShaderSystem is used in screens, errors occur because the Rendering3D in the Shader System is not deactivated and therefore sometimes the rendering shifts up or down.