### PR TITLE
Make Waypoints threadsafe

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/System.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/System.java
@@ -49,7 +49,7 @@ public abstract class System<T> implements ISerializable<T> {
         }
     }
 
-    public void save() {
+    public synchronized void save() {
         save(null);
     }
 


### PR DESCRIPTION
I have a meteor add-on that updates Waypoints state on a different thread than render. 

Occasionally, rendering occurs when we are updating the waypoints. This results in a `java.util.ConcurrentModificationException`.

```
java.util.ConcurrentModificationException
	at java.base/java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1013)
	at java.base/java.util.ArrayList$Itr.next(ArrayList.java:967)
	at meteordevelopment.meteorclient.systems.waypoints.Waypoints.onRender2D(Waypoints.java:128)
	at meteordevelopment.orbit.listeners.LambdaListener.call(LambdaListener.java:83)
	at meteordevelopment.orbit.EventBus.post(EventBus.java:47)
	at net.minecraft.class_329.handler$zlf000$onRender(class_329.java:2041)
	at net.minecraft.class_329.method_1753(class_329.java:416)
	at net.minecraft.class_757.method_3192(class_757.java:858)
	at net.minecraft.class_310.method_1523(class_310.java:1122)
	at net.minecraft.class_310.method_1514(class_310.java:737)
	at net.minecraft.client.main.Main.main(Main.java:236)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:416)
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:77)
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)
```

The fix here is to use `java.util.concurrent` data structures.