### PR TITLE
Implement .nbt paste command

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/commands/arguments/CompoundNbtTagArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/commands/arguments/CompoundNbtTagArgumentType.java
@@ -24,6 +24,7 @@ public class CompoundNbtTagArgumentType implements ArgumentType<NbtCompound> {
         return new CompoundNbtTagArgumentType();
     }
 
+    @Override
     public NbtCompound parse(StringReader reader) throws CommandSyntaxException {
         reader.skipWhitespace();
         if (!reader.canRead()) {
@@ -54,6 +55,7 @@ public class CompoundNbtTagArgumentType implements ArgumentType<NbtCompound> {
         return context.getArgument(name, NbtCompound.class);
     }
 
+    @Override
     public Collection<String> getExamples() {
         return EXAMPLES;
     }

--- a/src/main/java/meteordevelopment/meteorclient/systems/commands/commands/NbtCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/commands/commands/NbtCommand.java
@@ -5,6 +5,7 @@
 
 package meteordevelopment.meteorclient.systems.commands.commands;
 
+import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.systems.commands.Command;
@@ -52,8 +53,7 @@ public class NbtCommand extends Command {
             ItemStack stack = mc.player.getInventory().getMainHandStack();
 
             if (validBasic(stack)) {
-                NbtCompound tag = s.getArgument("nbt_data", NbtCompound.class);
-                stack.setNbt(tag);
+                stack.setNbt(s.getArgument("nbt_data", NbtCompound.class));
                 setStack(stack);
             }
 
@@ -123,6 +123,17 @@ public class NbtCommand extends Command {
                 text.append(new LiteralText(" data copied!"));
 
                 info(text);
+            }
+
+            return SINGLE_SUCCESS;
+        }));
+
+        builder.then(literal("paste").executes(s -> {
+            ItemStack stack = mc.player.getInventory().getMainHandStack();
+
+            if (validBasic(stack)) {
+                stack.setNbt(new CompoundNbtTagArgumentType().parse(new StringReader(mc.keyboard.getClipboard())));
+                setStack(stack);
             }
 
             return SINGLE_SUCCESS;


### PR DESCRIPTION
When editing NBT data through the included command-based interface, it is common to run into the limitation on command length in vanilla.
This PR allow bypassing that limitation by copying the data to a separate editor through the preexisting `.nbt copy` command, modifying the data (and perhaps saving it for later reuse) and reapplying it to the item in question through the added `.nbt paste` command without needing to paste it into the chat input box which was required previously.
To achieve this, the existing NBT parsing in CompoundNbtTagArgumentType is reused via an instantiation of said class, however, moving it to a separate, static method is possible if this implementation is an issue.