### PR TITLE
Make highway builder a bit more stable

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/HighwayBuilder.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/HighwayBuilder.java
@@ -386,7 +386,7 @@ public class HighwayBuilder extends Module {
     }
 
     public MutableText getStatsText() {
-        MutableText text = new LiteralText(String.format("%sDistance: %s%.0f\n", Formatting.GRAY, Formatting.WHITE, mc.player.getPos().distanceTo(start)));
+        MutableText text = new LiteralText(String.format("%sDistance: %s%.0f\n", Formatting.GRAY, Formatting.WHITE, mc.player == null ? 0.0f : mc.player.getPos().distanceTo(start)));
         text.append(String.format("%sBlocks broken: %s%d\n", Formatting.GRAY, Formatting.WHITE, blocksBroken));
         text.append(String.format("%sBlocks placed: %s%d", Formatting.GRAY, Formatting.WHITE, blocksPlaced));
 


### PR DESCRIPTION
Fixes crash that is produced by chat message info if:
1. Highway builder is enabled from main menu or not disabled upon leave of server/sp
2. You join server that has auto-load profile with highway builder disabled
3. Sometimes it tries to produce chat message of module disable with player not yet initialized (crash)