### PR TITLE
Update to match the new 1.18 height limit

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Anchor.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Anchor.java
@@ -25,7 +25,7 @@ public class Anchor extends Module {
         .name("max-height")
         .description("The maximum height Anchor will work at.")
         .defaultValue(10)
-        .range(0, 255)
+        .range(0, 383)
         .sliderMax(20)
         .build()
     );


### PR DESCRIPTION
changed the max slider range in Anchor to match the new 128 blocks higher height limit in 1.18+