### PR TITLE
Fix Freelook to work for camera in first person

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/FreeLook.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/FreeLook.java
@@ -89,7 +89,7 @@ public class FreeLook extends Module {
     }
 
     public boolean cameraMode() {
-        return isActive() && mc.options.getPerspective() == Perspective.THIRD_PERSON_BACK && mode.get() == Mode.Camera;
+        return isActive() && mode.get() == Mode.Camera;
     }
 
     @EventHandler


### PR DESCRIPTION
This patch fixes an issue in the free look module wherein camera rotation in first person mode rotates the player instead. With this, the user can rotate their camera in first person mode, making it possible with some configuration possible to emulate ArmA 3's look-around option without having to enter third person mode.