### PR TITLE
Fix PotionTimers render in world

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PotionTimersHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PotionTimersHud.java
@@ -100,7 +100,7 @@ public class PotionTimersHud extends HudElement {
 
     @Override
     public void tick(HudRenderer renderer) {
-        if (mc.player == null) {
+        if (mc.player == null || isInEditor()) {
             setSize(renderer.textWidth("Potion Timers 0:00", shadow.get(), getScale()), renderer.textHeight(shadow.get(), getScale()));
             return;
         }

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PotionTimersHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PotionTimersHud.java
@@ -125,7 +125,7 @@ public class PotionTimersHud extends HudElement {
             renderer.quad(this.x, this.y, getWidth(), getHeight(), backgroundColor.get());
         }
 
-        if (mc.player == null) {
+        if (mc.player == null || isInEditor()) {
             renderer.text("Potion Timers 0:00", x, y, color, shadow.get(), getScale());
             return;
         }


### PR DESCRIPTION
Fixing a bug with potion timers when you open the hud editor in the world