### PR TITLE
Disabled 1.19 Multiplayer Block

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/ChatPreviewerMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ChatPreviewerMixin.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client/).
+ * Copyright (c) 2021 Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.mixin;
+
+import net.minecraft.client.network.ChatPreviewer;
+import net.minecraft.text.Text;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ChatPreviewer.class)
+public class ChatPreviewerMixin {
+    @Inject(at=@At("HEAD"),method = "tryRequest",cancellable = true)
+    public void noRequest(String message, CallbackInfo ci) {
+        ci.cancel();
+    }
+    @Inject(at=@At("HEAD"),method = "onResponse",cancellable = true)
+    public void noModify(int id, Text text, CallbackInfo ci) {
+        ci.cancel();
+    }
+}

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ChatScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ChatScreenMixin.java
@@ -5,6 +5,8 @@
 
 package meteordevelopment.meteorclient.mixin;
 
+import net.minecraft.client.MinecraftClient;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.misc.BetterChat;
 import net.minecraft.client.gui.screen.ChatScreen;
@@ -22,5 +24,17 @@ public class ChatScreenMixin {
     @Inject(method = "init", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/widget/TextFieldWidget;setMaxLength(I)V", shift = At.Shift.AFTER))
     private void onInit(CallbackInfo info) {
         if (Modules.get().get(BetterChat.class).isInfiniteChatBox()) chatField.setMaxLength(Integer.MAX_VALUE);
+    }
+
+    @Inject(at=@At("HEAD"),method = "shouldPreviewChat",cancellable = true)
+    public void noChatPreviewChecks(CallbackInfoReturnable<Boolean> cir) {
+        if (MinecraftClient.getInstance().player == null) {
+            cir.setReturnValue(false);
+
+        }
+        if (MinecraftClient.getInstance().isInSingleplayer()) {
+            cir.setReturnValue(true);
+        }
+
     }
 }

--- a/src/main/resources/meteor-client.mixins.json
+++ b/src/main/resources/meteor-client.mixins.json
@@ -37,6 +37,7 @@
     "ChatHudAccessor",
     "ChatHudMixin",
     "ChatScreenMixin",
+    "ChatPreviewerMixin",
     "ChunkAccessor",
     "ChunkOcclusionDataBuilderMixin",
     "ChunkSkyLightProviderMixin",


### PR DESCRIPTION
You can no longer be blocked out of multiplayer by getting reported
basically fixing [this](https://help.minecraft.net/hc/en-us/articles/7149823936781-Player-Reporting-in-Minecraft-Java-Edition)
Should work in theory, couldn't test it yet, and don't really feel like it