### PR TITLE
Make antispam handle multi-line messages

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/ChatHudMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ChatHudMixin.java
@@ -96,7 +96,7 @@ public abstract class ChatHudMixin implements IChatHud {
     @Redirect(method = "addMessage(Lnet/minecraft/text/Text;Lnet/minecraft/network/message/MessageSignatureData;ILnet/minecraft/client/gui/hud/MessageIndicator;Z)V", slice = @Slice(from = @At(value = "FIELD", target = "Lnet/minecraft/client/gui/hud/ChatHud;visibleMessages:Ljava/util/List;")), at = @At(value = "INVOKE", target = "Ljava/util/List;size()I"))
     private int addMessageListSizeProxy(List<ChatHudLine> list) {
         BetterChat betterChat = Modules.get().get(BetterChat.class);
-        if (betterChat.isLongerChat() && betterChat.getChatLength() > 100) return list.size() - betterChat.getChatLength();
+        if (betterChat.isLongerChat() && betterChat.getChatLength() >= 100) return list.size() - betterChat.getChatLength();
         return list.size();
     }
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterChat.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterChat.java
@@ -19,8 +19,10 @@ import meteordevelopment.meteorclient.utils.Utils;
 import meteordevelopment.meteorclient.utils.player.ChatUtils;
 import meteordevelopment.orbit.EventHandler;
 import net.minecraft.client.gui.hud.ChatHudLine;
+import net.minecraft.client.util.ChatMessages;
 import net.minecraft.text.*;
 import net.minecraft.util.Formatting;
+import net.minecraft.util.math.MathHelper;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -249,6 +251,11 @@ public class BetterChat extends Module {
     }
 
     private static final Pattern antiSpamRegex = Pattern.compile(".*(\\([0-9]+\\)$)");
+
+    /**
+     * @author Crosby
+     * Adding author tag because this is spaghetti code
+     */
     private Text appendAntiSpam(Text text) {
         Text returnText = null;
         int messageIndex = -1;
@@ -262,20 +269,15 @@ public class BetterChat extends Module {
             String oldMessage = message.getString();
             String newMessage = text.getString();
 
-            messageIndex = i;
-
-
-
             if (oldMessage.equals(newMessage)) {
                 originalMessage = message.copy();
+                messageIndex = i;
                 returnText = message.append(Text.literal(" (2)").formatted(Formatting.GRAY));
                 break;
             } else {
                 Matcher matcher = antiSpamRegex.matcher(oldMessage);
 
                 if (!matcher.matches()) continue;
-
-                originalMessage = message.copy();
 
                 String group = matcher.group(matcher.groupCount());
                 int number = Integer.parseInt(group.substring(1, group.length() - 1));
@@ -284,6 +286,8 @@ public class BetterChat extends Module {
 
                 if (oldMessage.substring(0, oldMessage.length() - counter.length()).equals(newMessage)) {
                     message.getSiblings().remove(message.getSiblings().size() - 1);
+                    originalMessage = message.copy();
+                    messageIndex = i;
                     returnText = message.append(Text.literal(" (" + (number + 1) + ")").formatted(Formatting.GRAY));
                     break;
                 }
@@ -293,7 +297,12 @@ public class BetterChat extends Module {
         if (returnText != null) {
             ((ChatHudAccessor) mc.inGameHud.getChatHud()).getMessages().remove(messageIndex);
 
-            //todo remove spam message from visibleMessages
+            List<OrderedText> list = ChatMessages.breakRenderedChatMessageLines(originalMessage, MathHelper.floor((double)mc.inGameHud.getChatHud().getWidth() / mc.inGameHud.getChatHud().getChatScale()), mc.textRenderer);
+            int lines = list.size();
+
+            for (int i = 0; i < lines; i++) {
+                ((ChatHudAccessor) mc.inGameHud.getChatHud()).getVisibleMessages().remove(messageIndex);
+            }
         }
 
         return returnText;

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/text/TextUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/text/TextUtils.java
@@ -6,6 +6,8 @@
 package meteordevelopment.meteorclient.utils.misc.text;
 
 import meteordevelopment.meteorclient.utils.render.color.Color;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.OrderedText;
 import net.minecraft.text.Text;
 import net.minecraft.text.TextColor;
 
@@ -21,6 +23,22 @@ public class TextUtils {
         preOrderTraverse(text, stack, coloredTexts);
         coloredTexts.removeIf(e -> e.getText().equals(""));
         return coloredTexts;
+    }
+
+    /**
+     * Parses a given {@link OrderedText} into its {@link Text} equivalent.
+     *
+     * @param orderedText the {@link OrderedText} to parse.
+     * @return The {@link Text} equivalent of the {@link OrderedText} parameter.
+     */
+
+    public static MutableText parseOrderedText(OrderedText orderedText) {
+        MutableText parsedText = Text.empty();
+        orderedText.accept((i, style, codePoint) -> {
+            parsedText.append(Text.literal(new String(Character.toChars(codePoint))).setStyle(style));
+            return true;
+        });
+        return parsedText;
     }
 
     /**

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/text/TextUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/text/TextUtils.java
@@ -31,7 +31,6 @@ public class TextUtils {
      * @param orderedText the {@link OrderedText} to parse.
      * @return The {@link Text} equivalent of the {@link OrderedText} parameter.
      */
-
     public static MutableText parseOrderedText(OrderedText orderedText) {
         MutableText parsedText = Text.empty();
         orderedText.accept((i, style, codePoint) -> {


### PR DESCRIPTION
Refactored the antispam code to support multi-line messages.

It successfully detects them, appends the counter and removes the spam messages from `ChatHud.messages`

All that is left is to remove the spam messages from `ChatHud.visibleMessages`

The old system doesn't work anymore, as multiline messages add only one entry to `messages`, but multiple to `visibleMessages`