### PR TITLE
Consistent FakePlayer

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/commands/commands/FakePlayerCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/commands/commands/FakePlayerCommand.java
@@ -22,10 +22,12 @@ public class FakePlayerCommand extends Command {
         super("fake-player", "Manages fake players that you can use for testing.");
     }
 
+    FakePlayer fakePlayer = Modules.get().get(FakePlayer.class);
+
     @Override
     public void build(LiteralArgumentBuilder<CommandSource> builder) {
         builder.then(literal("spawn").executes(context -> {
-            if (active()) FakePlayerManager.add("Meteor on Crack", 36, true);
+            if (active()) FakePlayerManager.add(fakePlayer.name.get(), 36, true);
             return SINGLE_SUCCESS;
         })
                  .then(argument("name", StringArgumentType.word())


### PR DESCRIPTION
Command now summons FakePlayers with the name set in the module instead of always using "Meteor On Crack"