### PR TITLE
Add LavaBucket to Offhand

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Offhand.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Offhand.java
@@ -155,7 +155,8 @@ public class Offhand extends Module {
         Gap(Items.GOLDEN_APPLE),
         Crystal(Items.END_CRYSTAL),
         Totem(Items.TOTEM_OF_UNDYING),
-        Shield(Items.SHIELD);
+        Shield(Items.SHIELD),
+        LavaBucket(Items.LAVA_BUCKET);
 
         net.minecraft.item.Item item;
 


### PR DESCRIPTION
When having a full inventory of lava buckets its annoying mouse time to get those into the hotbar.
Probably similar for water but since water has infinite sources I think its more common to walk around with a inventory full of lava.
Possible use case:


https://user-images.githubusercontent.com/20344300/189163595-61aff57e-0355-4247-9fac-692b7646f42a.mp4

