### PR TITLE
Make freecam fov less jumpy (closed #2716)

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Freecam.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Freecam.java
@@ -109,6 +109,8 @@ public class Freecam extends Module {
     public float yaw, pitch;
     public float prevYaw, prevPitch;
 
+    private double fovScale;
+
     private boolean forward, backward, right, left, up, down;
 
     public Freecam() {
@@ -117,6 +119,8 @@ public class Freecam extends Module {
 
     @Override
     public void onActivate() {
+        fovScale = mc.options.getFovEffectScale().getValue();
+        mc.options.getFovEffectScale().setValue((double)0);
         yaw = mc.player.getYaw();
         pitch = mc.player.getPitch();
 
@@ -144,6 +148,7 @@ public class Freecam extends Module {
     public void onDeactivate() {
         if (reloadChunks.get()) mc.worldRenderer.reload();
         mc.options.setPerspective(perspective);
+        mc.options.getFovEffectScale().setValue((double)fovScale);
     }
 
     @EventHandler


### PR DESCRIPTION
It basically slides this down to OFF when freecam gets activated and restores the value later on activation.

![image](https://user-images.githubusercontent.com/20344300/189968450-28307dc2-3c51-42fb-b362-5f135e0f68fa.png)

This makes it more pleasant to watch baritone in freecam.