### PR TITLE
Many Improvements to Notebot Tuning System

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notebot.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notebot.java
@@ -233,7 +233,7 @@ public class Notebot extends Module {
     private int lastTick = -1;
 
     private boolean anyNoteblockTuned = false;
-    private final Map<BlockPos, Integer> tuneHits = new HashMap<>(); // noteblock -> target hits
+    private final Map<BlockPos, Integer> tuneHits = new HashMap<>(); // noteblock -> target hits number
 
     private int waitTicks = -1;
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notebot.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notebot.java
@@ -126,7 +126,7 @@ public class Notebot extends Module {
     private final Setting<Integer> checkNoteblocksAgainDelay = sgGeneral.add(new IntSetting.Builder()
         .name("check-noteblocks-again-delay")
         .description("How much delay should be between end of tuning and checking again")
-        .defaultValue(20)
+        .defaultValue(10)
         .min(1)
         .sliderRange(1, 20)
         .build()

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notebot.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notebot.java
@@ -132,8 +132,15 @@ public class Notebot extends Module {
         .build()
     );
 
-    private final Setting<Boolean> render = sgRender.add(new BoolSetting.Builder()
-        .name("render")
+    private final Setting<Boolean> renderText = sgRender.add(new BoolSetting.Builder()
+        .name("render-text")
+        .description("Whether or not to render the text above noteblocks.")
+        .defaultValue(true)
+        .build()
+    );
+
+    private final Setting<Boolean> renderBoxes = sgRender.add(new BoolSetting.Builder()
+        .name("render-boxes")
         .description("Whether or not to render the outline around the noteblocks.")
         .defaultValue(true)
         .build()
@@ -281,7 +288,7 @@ public class Notebot extends Module {
 
     @EventHandler
     private void onRender3D(Render3DEvent event) {
-        if (!render.get()) return;
+        if (!renderBoxes.get()) return;
 
         if (stage != Stage.SetUp && stage != Stage.Tune && stage != Stage.WaitingToCheckNoteblocks && !isPlaying) return;
 
@@ -339,7 +346,7 @@ public class Notebot extends Module {
 
     @EventHandler
     private void onRender2D(Render2DEvent event) {
-        if (!render.get()) return;
+        if (!renderText.get()) return;
 
         if (stage != Stage.SetUp && stage != Stage.Tune && stage != Stage.WaitingToCheckNoteblocks && !isPlaying) return;
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notebot.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notebot.java
@@ -834,9 +834,11 @@ public class Notebot extends Module {
         scannedNoteblocks.clear();
         int min = (int) (-mc.interactionManager.getReachDistance()) - 2;
         int max = (int) mc.interactionManager.getReachDistance() + 2;
-        // 5^3 kek
-        for (int x = min; x < max; x++) {
-            for (int y = min; y < max; y++) {
+
+        // Scan for noteblocks horizontally
+        // 6^3 kek
+        for (int y = min; y < max; y++) {
+            for (int x = min; x < max; x++) {
                 for (int z = min; z < max; z++) {
                     BlockPos pos = mc.player.getBlockPos().add(x, y + 1, z);
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notebot.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notebot.java
@@ -667,21 +667,19 @@ public class Notebot extends Module {
 
     public void loadSong(File file) {
         if (!isActive()) toggle();
-        if (!loadFileToMap(file)) {
+        if (!loadFileToMap(file, () -> stage = Stage.SetUp)) {
             if (autoPlay.get()) {
                 playRandomSong();
             }
-            return;
         }
     }
 
     public void previewSong(File file) {
         if (!isActive()) toggle();
-        if (loadFileToMap(file)) {
-            info("Song \"%s\" loaded.", getFileLabel(file.toPath()));
+        loadFileToMap(file, () -> {
             stage = Stage.Preview;
             play();
-        }
+        });
     }
 
     private void addNote(int tick, Note value) {
@@ -696,7 +694,7 @@ public class Notebot extends Module {
         }
     }
 
-    private boolean loadFileToMap(File file) {
+    private boolean loadFileToMap(File file, Runnable callback) {
         if (!file.exists() || !file.isFile()) {
             error("File not found");
             return false;
@@ -718,10 +716,10 @@ public class Notebot extends Module {
                 long diff = time2 - time1;
 
                 lastTick = Collections.max(song.keySet());
-                stage = Stage.SetUp;
-                info("Song has been loaded to the memory! Took "+diff+"ms");
+                info("Song '"+getFileLabel(file.toPath())+"' has been loaded to the memory! Took "+diff+"ms");
+                callback.run();
             } else {
-                error("Could not load song '"+file.getName()+"'");
+                error("Could not load song '"+getFileLabel(file.toPath())+"'");
                 if (autoPlay.get()) {
                     playRandomSong();
                 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notebot.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notebot.java
@@ -516,6 +516,15 @@ public class Notebot extends Module {
     public WWidget getWidget(GuiTheme theme) {
         WTable table = theme.table();
 
+        // Align Center
+        WButton alignCenter = table.add(theme.button("Align Center")).expandCellX().center().widget();
+        alignCenter.action = () -> {
+            if (mc.player == null) return;
+            mc.player.setPosition(Vec3d.ofBottomCenter(mc.player.getBlockPos()));
+        };
+
+        table.row();
+
         // Label
         status = table.add(theme.label(getStatus())).expandCellX().widget();
 
@@ -829,6 +838,7 @@ public class Notebot extends Module {
                     BlockState blockState = mc.world.getBlockState(pos);
                     if (blockState.getBlock() != Blocks.NOTE_BLOCK) continue;
 
+                    // Copied from ServerPlayNetworkHandler#onPlayerInteractBlock
                     Vec3d vec3d2 = Vec3d.ofCenter(pos);
                     double sqrt = mc.player.getEyePos().squaredDistanceTo(vec3d2);
                     if (sqrt > ServerPlayNetworkHandler.MAX_BREAK_SQUARED_DISTANCE) continue;

--- a/src/main/java/meteordevelopment/meteorclient/utils/notebot/NotebotUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/notebot/NotebotUtils.java
@@ -5,7 +5,6 @@
 
 package meteordevelopment.meteorclient.utils.notebot;
 
-import meteordevelopment.meteorclient.systems.modules.misc.Notebot;
 import meteordevelopment.meteorclient.utils.notebot.nbs.Note;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.NoteBlock;

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/NametagUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/NametagUtils.java
@@ -39,7 +39,14 @@ public class NametagUtils {
     }
 
     public static boolean to2D(Vec3 pos, double scale) {
-        NametagUtils.scale = getScale(pos) * scale;
+        return to2D(pos, scale, true);
+    }
+
+    public static boolean to2D(Vec3 pos, double scale, boolean distanceScaling) {
+        NametagUtils.scale = scale;
+        if (distanceScaling) {
+            NametagUtils.scale *= getScale(pos);
+        }
 
         vec4.set(cameraNegated.x + pos.x, cameraNegated.y + pos.y, cameraNegated.z + pos.z, 1);
 


### PR DESCRIPTION
### Features
- Instead of comparing notes of noteblocks, it calculates a number of hits to hit a noteblock. (this can avoid tuning one noteblock several times)
- Concurrent Tuning 😮‍
- After a tuning, notebot checks if noteblocks have correct notes.
- Added texts on each noteblocks representing a note of that noteblock
- Added `Swing Arm` Toggle
- Noteblocks that are tuned have different color than untuned noteblocks
- Async Song Loading
- You can control how much delay should be between end of tuning and checking again. (for latency reasons)
- Improved scanning noteblocks to work with [this crazy thing](https://cdn.discordapp.com/attachments/733704766953357324/782510483424018432/PerSong114.schem) (from [inertia docs](https://cdn.discordapp.com/attachments/737778716465168455/783739854197358642/Note_Bot_Documentation.pdf))
- Added `Show scanned Noteblocks` Toggle
- Firstly, find the noteblocks that already have target notes set to not tune everything from the start
- Added `Align Center` Button
- Added `Render Text` and `Render Boxes` toggles instead of `Render` toggle