### PR TITLE
unfocusedcpu custom fps limit

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/MinecraftClientMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MinecraftClientMixin.java
@@ -25,6 +25,7 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.Mouse;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.network.ClientPlayerInteractionManager;
+import net.minecraft.client.option.GameOptions;
 import net.minecraft.client.util.Window;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.util.hit.HitResult;
@@ -54,6 +55,7 @@ public abstract class MinecraftClientMixin implements IMinecraftClient {
     @Shadow @Final public Mouse mouse;
     @Shadow @Final private Window window;
     @Shadow public Screen currentScreen;
+    @Shadow @Final public GameOptions options;
 
     @Shadow protected abstract void doItemUse();
     @Shadow public abstract Profiler getProfiler();
@@ -143,7 +145,7 @@ public abstract class MinecraftClientMixin implements IMinecraftClient {
 
     @Inject(method = "getFramerateLimit", at = @At("HEAD"), cancellable = true)
     private void onGetFramerateLimit(CallbackInfoReturnable<Integer> info) {
-        if (Modules.get().isActive(UnfocusedCPU.class) && !isWindowFocused()) info.setReturnValue(Modules.get().get(UnfocusedCPU.class).fps.get());
+        if (Modules.get().isActive(UnfocusedCPU.class) && !isWindowFocused()) info.setReturnValue(Math.min(Modules.get().get(UnfocusedCPU.class).fps.get(), this.options.getMaxFps().getValue()));
     }
 
     // Time delta

--- a/src/main/java/meteordevelopment/meteorclient/mixin/MinecraftClientMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MinecraftClientMixin.java
@@ -143,7 +143,7 @@ public abstract class MinecraftClientMixin implements IMinecraftClient {
 
     @Inject(method = "getFramerateLimit", at = @At("HEAD"), cancellable = true)
     private void onGetFramerateLimit(CallbackInfoReturnable<Integer> info) {
-        if (Modules.get().isActive(UnfocusedCPU.class) && !isWindowFocused()) info.setReturnValue(1);
+        if (Modules.get().isActive(UnfocusedCPU.class) && !isWindowFocused()) info.setReturnValue(Modules.get().get(UnfocusedCPU.class).fps.get());
     }
 
     // Time delta

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/UnfocusedCPU.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/UnfocusedCPU.java
@@ -5,10 +5,24 @@
 
 package meteordevelopment.meteorclient.systems.modules.render;
 
+import meteordevelopment.meteorclient.settings.IntSetting;
+import meteordevelopment.meteorclient.settings.Setting;
+import meteordevelopment.meteorclient.settings.SettingGroup;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
 
 public class UnfocusedCPU extends Module {
+    private final SettingGroup sgGeneral = this.settings.getDefaultGroup();
+
+    public final Setting<Integer> fps = sgGeneral.add(new IntSetting.Builder()
+        .name("target-fps")
+        .description("Target FPS to set as the limit when the window is not focused.")
+        .min(1)
+        .defaultValue(1)
+        .sliderRange(1, 20)
+        .build()
+    );
+
     public UnfocusedCPU() {
         super(Categories.Render, "unfocused-cpu", "Will not render anything when your Minecraft window is not focused.");
     }


### PR DESCRIPTION
Since the game sends packets every frame, having UnfocusedCpu activated while using baritone results in really really janky movements and teleportation from an outside perspective