### PR TITLE
Added AutoDock to ElytraFly

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/AbstractBlockMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/AbstractBlockMixin.java
@@ -15,6 +15,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.world.BlockView;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFly.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFly.java
@@ -334,13 +334,16 @@ public class ElytraFly extends Module {
             final boolean underCollidable = under.collidable || !underState.getFluidState().isEmpty();
             final boolean under2Collidable = under2.collidable || !under2State.getFluidState().isEmpty();
 
-            if(!underCollidable && under2Collidable) {
+            if (!underCollidable && under2Collidable) {
                 ((IVec3d)event.movement).set(event.movement.x, -0.1f, event.movement.z);
+
+                mc.player.setPitch(Utils.clamp(mc.player.getPitch(0), -50.f, 20.f)); // clamp between -50 and 20 (>= 30 will pop you off, but lag makes that threshold lower)
             }
 
             if (underCollidable) {
                 ((IVec3d)event.movement).set(event.movement.x, -0.03f, event.movement.z);
-                mc.player.setPitch(Utils.clamp(mc.player.getPitch(0), -90.f, 20.f)); // clamp between -90 and 20 (>= 30 will pop you off, but lag makes that threshold lower)
+
+                mc.player.setPitch(Utils.clamp(mc.player.getPitch(0), -50.f, 20.f));
 
                 if (mc.player.getPos().y <= mc.player.getBlockPos().down().getY() + 1.34f) {
                     ((IVec3d)event.movement).set(event.movement.x, 0, event.movement.z);

--- a/src/main/resources/meteor-client.accesswidener
+++ b/src/main/resources/meteor-client.accesswidener
@@ -68,3 +68,5 @@ accessible   class   net/minecraft/client/gui/screen/ingame/BeaconScreen$BeaconB
 accessible   class   net/minecraft/client/gui/screen/ingame/BeaconScreen$EffectButtonWidget
 
 accessible   class   net/minecraft/client/resource/ResourceReloadLogger$ReloadState
+
+accessible   field   net/minecraft/block/AbstractBlock collidable Z


### PR DESCRIPTION
AutoDock was a very useful feature in Harakiri's ElytraFly module: it will automatically hover you .34 blocks off ground when you hold shift, allowing you to fly through 1x2 tunnels on certain servers (e.g. 9b9t)

https://user-images.githubusercontent.com/43317083/196003683-4df02178-7b1f-4b31-8fbb-2d9f46565e09.mp4

It's slowly docking (and setting pitch to 0) for a reason - to not "pop" you off the elytra and allow you to stay airborne.