### PR TITLE
Added a NoGlitchBlocks Module

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/events/entity/player/BreakBlockEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/entity/player/BreakBlockEvent.java
@@ -5,11 +5,12 @@
 
 package meteordevelopment.meteorclient.events.entity.player;
 
+import meteordevelopment.meteorclient.events.Cancellable;
 import net.minecraft.block.BlockState;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
-public class BreakBlockEvent {
+public class BreakBlockEvent extends Cancellable {
     private static final BreakBlockEvent INSTANCE = new BreakBlockEvent();
 
     public BlockPos blockPos;
@@ -20,6 +21,7 @@ public class BreakBlockEvent {
 
     public static BreakBlockEvent get(BlockPos blockPos) {
         INSTANCE.blockPos = blockPos;
+        INSTANCE.setCancelled(false);
         return INSTANCE;
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayerInteractionManagerMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayerInteractionManagerMixin.java
@@ -124,9 +124,15 @@ public abstract class ClientPlayerInteractionManagerMixin implements IClientPlay
         blockBreakingCooldown = value;
     }
 
-    @Inject(method = "breakBlock", at = @At("HEAD"))
+    @Inject(method = "breakBlock", at = @At("HEAD"), cancellable = true)
     private void onBreakBlock(BlockPos blockPos, CallbackInfoReturnable<Boolean> info) {
-        MeteorClient.EVENT_BUS.post(BreakBlockEvent.get(blockPos));
+        final BreakBlockEvent event = BreakBlockEvent.get(blockPos);
+        MeteorClient.EVENT_BUS.post(event);
+
+        if (event.isCancelled()) {
+            info.setReturnValue(false);
+            info.cancel();
+        }
     }
 
     @Inject(method = "interactItem", at = @At("HEAD"), cancellable = true)

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
@@ -534,7 +534,7 @@ public class Modules extends System<Modules> {
         add(new InfinityMiner());
         add(new LiquidFiller());
         add(new MountBypass());
-        add(new NoGlitchBlocks());
+        add(new NoGhostBlocks());
         add(new Nuker());
         add(new StashFinder());
         add(new SpawnProofer());

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
@@ -534,6 +534,7 @@ public class Modules extends System<Modules> {
         add(new InfinityMiner());
         add(new LiquidFiller());
         add(new MountBypass());
+        add(new NoGlitchBlocks());
         add(new Nuker());
         add(new StashFinder());
         add(new SpawnProofer());

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/NoGhostBlocks.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/NoGhostBlocks.java
@@ -11,10 +11,10 @@ import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.orbit.EventHandler;
 import net.minecraft.block.BlockState;
 
-public class NoGlitchBlocks extends Module {
+public class NoGhostBlocks extends Module {
 
-    public NoGlitchBlocks() {
-        super(Categories.World, "no-glitch-blocks", "Attempts to prevent ghost blocks arising from breaking blocks quickly. Especially useful with multiconnect.");
+    public NoGhostBlocks() {
+        super(Categories.World, "no-ghost-blocks", "Attempts to prevent ghost blocks arising from breaking blocks quickly. Especially useful with multiconnect.");
     }
 
     private BlockState lastState;

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/NoGlitchBlocks.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/NoGlitchBlocks.java
@@ -1,0 +1,33 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.systems.modules.world;
+
+import meteordevelopment.meteorclient.events.entity.player.BreakBlockEvent;
+import meteordevelopment.meteorclient.systems.modules.Categories;
+import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.orbit.EventHandler;
+import net.minecraft.block.BlockState;
+
+public class NoGlitchBlocks extends Module {
+
+    public NoGlitchBlocks() {
+        super(Categories.World, "no-glitch-blocks", "Attempts to prevent ghost blocks arising from breaking blocks quickly. Especially useful with multiconnect.");
+    }
+
+    private BlockState lastState;
+
+    @EventHandler
+    public void onBreakBlock(BreakBlockEvent event) {
+        if (mc.isInSingleplayer())
+            return;
+
+        event.setCancelled(true);
+
+        // play the related sounds and particles for the user.
+        BlockState blockState = mc.world.getBlockState(event.blockPos);
+        blockState.getBlock().onBreak(mc.world, event.blockPos, blockState, mc.player); // this doesn't alter the state of the block in the world
+    }
+}


### PR DESCRIPTION
Fixes #818, IMHO.

This adds a module that will prevent ghost blocks from breaking stuff too fast. 

I've tested the recommended "Anti Ghost" mod on 9b9t (multiconnect 1.12.2) and it doesn't do anything. This, however, works perfectly.

It will prevent the client from removing the block until the server acknowledges the break. It will still play the breaking animations and sounds, because being silent it is annoying and confusing.

https://user-images.githubusercontent.com/43317083/196008001-fe04d9a0-3ed5-4997-a73b-c05343598daf.mp4

I am unsure about the name but that's how it's been called in my client and I took the name from future, so it should be pretty fitting.