### PR TITLE
I dont know how to name this

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/MeteorClient.java
+++ b/src/main/java/meteordevelopment/meteorclient/MeteorClient.java
@@ -91,9 +91,7 @@ public class MeteorClient implements ClientModInitializer {
             try {
                 EVENT_BUS.registerLambdaFactory(addon.getPackage(), (lookupInMethod, klass) -> (MethodHandles.Lookup) lookupInMethod.invoke(null, klass, MethodHandles.lookup()));
             } catch (AbstractMethodError e) {
-                AbstractMethodError exception = new AbstractMethodError("Addon \"%s\" is too old and cannot be ran.".formatted(addon.name));
-                exception.addSuppressed(e);
-                throw exception;
+                throw new RuntimeException("Addon \"%s\" is too old and cannot be ran.".formatted(addon.name), e);
             }
         });
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/ReflectInit.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/ReflectInit.java
@@ -29,9 +29,7 @@ public class ReflectInit {
                     packages.add(pkg);
                 }
             } catch (AbstractMethodError e) {
-                AbstractMethodError exception = new AbstractMethodError("Addon \"%s\" is too old and cannot be ran.".formatted(addon.name));
-                exception.addSuppressed(e);
-                throw exception;
+                throw new RuntimeException("Addon \"%s\" is too old and cannot be ran.".formatted(addon.name), e);
             }
         }
     }
@@ -66,9 +64,7 @@ public class ReflectInit {
         } catch (IllegalAccessException | InvocationTargetException e) {
             e.printStackTrace();
         } catch (NullPointerException e) {
-            RuntimeException exception = new IllegalStateException("Method \"%s\" using Init annotations from non-static context".formatted(task.getName()));
-            exception.addSuppressed(e);
-            throw exception;
+            throw new RuntimeException("Method \"%s\" using Init annotations from non-static context".formatted(task.getName()), e);
         }
     }
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/network/Capes.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/network/Capes.java
@@ -34,7 +34,7 @@ public class Capes {
     private static final List<Cape> TO_RETRY = new ArrayList<>();
     private static final List<Cape> TO_REMOVE = new ArrayList<>();
 
-    @PreInit
+    @PreInit(dependencies = MeteorExecutor.class)
     public static void init() {
         OWNERS.clear();
         URLS.clear();


### PR DESCRIPTION
- Setting the cause of the `RuntimeException` as the original exception is more useful than having an arbitrary exception loosely connected to the cause of the exception.
- `Capes.preInit` requires `MeteorExecutor.preInit` to have ran. It's not currently a problem because they're ran in alphabetical order anyways and I'm just future proofing here.