### PR TITLE
Flight Packet AntiKick Improvements and Quick Notebot Fixes

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notebot.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notebot.java
@@ -596,7 +596,7 @@ public class Notebot extends Module {
     }
 
     public void stop() {
-        if (autoPlay.get()) {
+        if (autoPlay.get() && stage != Stage.Preview) {
             playRandomSong();
         } else {
             forceStop();
@@ -617,7 +617,6 @@ public class Notebot extends Module {
 
     public void disable() {
         resetVariables();
-        info("Stopping.");
         if (!isActive()) toggle();
     }
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notebot.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notebot.java
@@ -404,8 +404,20 @@ public class Notebot extends Module {
             }
         }
         else if (stage == Stage.SetUp) {
-            setupBlocks();
+            scanForNoteblocks();
+            if (scannedNoteblocks.isEmpty()) {
+                error("Can't find any nearby noteblock!");
+                forceStop();
+                return;
+            }
+
             setupNoteblocksMap();
+            if (noteBlockPositions.isEmpty()) {
+                error("Can't find any valid noteblock to play song.");
+                forceStop();
+                return;
+            }
+
             setupTuneHitsMap();
             stage = Stage.Tune;
         }
@@ -704,10 +716,6 @@ public class Notebot extends Module {
             }
 
         }
-    }
-
-    private void setupBlocks() {
-        scanForNoteblocks();
     }
 
     private void onTickPreview() {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Flight.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Flight.java
@@ -84,6 +84,16 @@ public class Flight extends Module {
         .build()
     );
 
+    private final Setting<Integer> goingDownDelay = sgAntiKick.add(new IntSetting.Builder()
+        .name("going-down-delay")
+        .description("The amount of delay, in milliseconds, to fly down a bit to reset falling ticks.")
+        .defaultValue(1500)
+        .sliderRange(1, 4000)
+        .min(1)
+        .visible(() -> antiKickMode.get() == AntiKickMode.Packet)
+        .build()
+    );
+
     public Flight() {
         super(Categories.Movement, "flight", "FLYYYY! No Fall is recommended with this module.");
     }
@@ -181,7 +191,7 @@ public class Flight extends Module {
         double currentY = packet.getY(Double.MAX_VALUE);
         if (currentY != Double.MAX_VALUE) {
             // maximum time we can be "floating" is 80 ticks, so 4 seconds max
-            if (currentTime - lastModifiedTime > 1000
+            if (currentTime - lastModifiedTime > goingDownDelay.get()
                 && lastY != Double.MAX_VALUE
                 && mc.world.getBlockState(mc.player.getBlockPos().down()).isAir()) {
                 // actual check is for >= -0.03125D but we have to do a bit more than that

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Flight.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Flight.java
@@ -12,6 +12,8 @@ import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.orbit.EventHandler;
+import net.minecraft.block.AbstractBlock;
+import net.minecraft.entity.Entity;
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.util.math.Vec3d;
@@ -193,7 +195,7 @@ public class Flight extends Module {
             // maximum time we can be "floating" is 80 ticks, so 4 seconds max
             if (currentTime - lastModifiedTime > flyDownDelay.get()
                 && lastY != Double.MAX_VALUE
-                && mc.world.getBlockState(mc.player.getBlockPos().down()).isAir()) {
+                && isEntityOnAir(mc.player)) {
                 // actual check is for >= -0.03125D but we have to do a bit more than that
                 // probably due to compression or some shit idk
                 ((PlayerMoveC2SPacketAccessor) packet).setY(lastY - 0.03130D);
@@ -209,5 +211,10 @@ public class Flight extends Module {
         mc.player.getAbilities().setFlySpeed(0.05f);
         if (mc.player.getAbilities().creativeMode) return;
         mc.player.getAbilities().allowFlying = false;
+    }
+
+    // Copied from ServerPlayNetworkHandler#isEntityOnAir
+    private boolean isEntityOnAir(Entity entity) {
+        return entity.world.getStatesInBox(entity.getBoundingBox().expand(0.0625).stretch(0.0, -0.55, 0.0)).allMatch(AbstractBlock.AbstractBlockState::isAir);
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Flight.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Flight.java
@@ -84,8 +84,8 @@ public class Flight extends Module {
         .build()
     );
 
-    private final Setting<Integer> goingDownDelay = sgAntiKick.add(new IntSetting.Builder()
-        .name("going-down-delay")
+    private final Setting<Integer> flyDownDelay = sgAntiKick.add(new IntSetting.Builder()
+        .name("fly-down-delay")
         .description("The amount of delay, in milliseconds, to fly down a bit to reset falling ticks.")
         .defaultValue(1500)
         .sliderRange(1, 4000)
@@ -191,7 +191,7 @@ public class Flight extends Module {
         double currentY = packet.getY(Double.MAX_VALUE);
         if (currentY != Double.MAX_VALUE) {
             // maximum time we can be "floating" is 80 ticks, so 4 seconds max
-            if (currentTime - lastModifiedTime > goingDownDelay.get()
+            if (currentTime - lastModifiedTime > flyDownDelay.get()
                 && lastY != Double.MAX_VALUE
                 && mc.world.getBlockState(mc.player.getBlockPos().down()).isAir()) {
                 // actual check is for >= -0.03125D but we have to do a bit more than that


### PR DESCRIPTION
### Flight Changes
- Added 'Fly Down Delay' option which controls a delay to fly down a bit
- Changed the default 'Fly Down Delay' to 1500ms to avoid kicking while player is not moving
- Added better check if player is in the air to avoid kicking from the server
### Quick Notebot Fixes
- Don't autoplay when song preview has been ended
- Don't play song when there aren't any valid noteblock nearby