### PR TITLE
clamp default slider range

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/settings/DoubleSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/DoubleSetting.java
@@ -89,18 +89,18 @@ public class DoubleSetting extends Setting<Double> {
         }
 
         public Builder sliderMin(double min) {
-            sliderMin = Math.max(min, this.min);
+            sliderMin = min;
             return this;
         }
 
         public Builder sliderMax(double max) {
-            sliderMax = Math.min(max, this.max);
+            sliderMax = max;
             return this;
         }
 
         public Builder sliderRange(double min, double max) {
-            sliderMin = Math.max(min, this.min);
-            sliderMax = Math.min(max, this.max);
+            sliderMin = min;
+            sliderMax = max;
             return this;
         }
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/DoubleSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/DoubleSetting.java
@@ -120,7 +120,7 @@ public class DoubleSetting extends Setting<Double> {
         }
 
         public DoubleSetting build() {
-            return new DoubleSetting(name, description, defaultValue, onChanged, onModuleActivated, visible, min, max, sliderMin, sliderMax, onSliderRelease, decimalPlaces, noSlider);
+            return new DoubleSetting(name, description, defaultValue, onChanged, onModuleActivated, visible, min, max, Math.max(sliderMin, min), Math.min(sliderMax, max), onSliderRelease, decimalPlaces, noSlider);
         }
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/settings/IntSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/IntSetting.java
@@ -78,18 +78,18 @@ public class IntSetting extends Setting<Integer> {
         }
 
         public Builder sliderMin(int min) {
-            this.sliderMin = Math.max(min, this.min);
+            this.sliderMin = min;
             return this;
         }
 
         public Builder sliderMax(int max) {
-            this.sliderMax = Math.min(max, this.max);
+            this.sliderMax = max;
             return this;
         }
 
         public Builder sliderRange(int min, int max) {
-            this.sliderMin = Math.max(min, this.min);
-            this.sliderMax = Math.min(max, this.max);
+            this.sliderMin = min;
+            this.sliderMax = max;
             return this;
         }
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/IntSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/IntSetting.java
@@ -100,7 +100,7 @@ public class IntSetting extends Setting<Integer> {
 
         @Override
         public IntSetting build() {
-            return new IntSetting(name, description, defaultValue, onChanged, onModuleActivated, visible, min, max, sliderMin, sliderMax, noSlider);
+            return new IntSetting(name, description, defaultValue, onChanged, onModuleActivated, visible, min, max, Math.max(sliderMin, min), Math.min(sliderMax, max), noSlider);
         }
     }
 }


### PR DESCRIPTION
Currently, the slider range is only clamped if it is modified

For example:
```java
public final Setting<Integer> setting = sgGeneral.add(new IntSetting.Builder()
    .name("setting")
    .max(8)
    .build()
);
```
The following code block currently creates a setting with a max of 8, yet a sliderMax of 10.