### PR TITLE
Flight AntiKick Improvements

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayerEntityAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayerEntityAccessor.java
@@ -19,6 +19,9 @@ public interface ClientPlayerEntityAccessor {
     @Accessor("mountJumpStrength")
     void setMountJumpStrength(float strength);
 
+    @Accessor("ticksSinceLastPositionPacketSent")
+    void setTicksSinceLastPositionPacketSent(int ticks);
+
     @Invoker("signChatMessage")
     MessageSignatureData _signChatMessage(MessageMetadata metadata, DecoratedContents content, LastSeenMessageList lastSeenMessages);
 }


### PR DESCRIPTION
### Changes
- Make sure that move packet is always sent (not only change Y when client sent packet itself)
- Added better check if player is in the air to avoid kicking from the server
- Don't change Y if player is flying down