### PR TITLE
Quick Notebot Fixes

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/commands/commands/NotebotCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/commands/commands/NotebotCommand.java
@@ -154,6 +154,8 @@ public class NotebotCommand extends Command {
             return;
         }
         try {
+            MeteorClient.EVENT_BUS.unsubscribe(this);
+
             FileWriter file = new FileWriter(path.toFile());
             for (var entry : song.entrySet()) {
                 int tick = entry.getKey();
@@ -169,7 +171,6 @@ public class NotebotCommand extends Command {
 
             file.close();
             info("Song saved.");
-            MeteorClient.EVENT_BUS.unsubscribe(this);
         } catch (IOException e) {
             info("Couldn't create the file.");
             MeteorClient.EVENT_BUS.unsubscribe(this);

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notebot.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notebot.java
@@ -404,8 +404,19 @@ public class Notebot extends Module {
             }
         }
         else if (stage == Stage.SetUp) {
-            setupBlocks();
+            scanForNoteblocks();
+            if (scannedNoteblocks.isEmpty()) {
+                error("Can't find any nearby noteblock!");
+                forceStop();
+                return;
+            }
+
             setupNoteblocksMap();
+            if (noteBlockPositions.isEmpty()) {
+                error("Can't find any valid noteblock to play song.");
+                forceStop();
+                return;
+            }
             setupTuneHitsMap();
             stage = Stage.Tune;
         }
@@ -596,7 +607,7 @@ public class Notebot extends Module {
     }
 
     public void stop() {
-        if (autoPlay.get()) {
+        if (autoPlay.get() && stage != Stage.Preview) {
             playRandomSong();
         } else {
             forceStop();
@@ -617,7 +628,6 @@ public class Notebot extends Module {
 
     public void disable() {
         resetVariables();
-        info("Stopping.");
         if (!isActive()) toggle();
     }
 
@@ -705,10 +715,6 @@ public class Notebot extends Module {
             }
 
         }
-    }
-
-    private void setupBlocks() {
-        scanForNoteblocks();
     }
 
     private void onTickPreview() {


### PR DESCRIPTION
### Fixes
- Don't autoplay when song preview has been ended
- Don't play song when there aren't any valid noteblock nearby
- Fix `ConcurrentModificationException` when player is saving a recorded song and at the same time someone hits the noteblock