### PR TITLE
Nuker: Add packet mine option

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/Nuker.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/Nuker.java
@@ -19,8 +19,12 @@ import meteordevelopment.meteorclient.utils.world.BlockIterator;
 import meteordevelopment.meteorclient.utils.world.BlockUtils;
 import meteordevelopment.orbit.EventHandler;
 import net.minecraft.block.Block;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.network.packet.c2s.play.PlayerActionC2SPacket;
+import net.minecraft.util.Hand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Box;
+import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
 
 import java.util.ArrayList;
@@ -138,6 +142,13 @@ public class Nuker extends Module {
     private final Setting<Boolean> swingHand = sgGeneral.add(new BoolSetting.Builder()
         .name("swing-hand")
         .description("Swing hand client side.")
+        .defaultValue(true)
+        .build()
+    );
+
+    private final Setting<Boolean> packetMine = sgGeneral.add(new BoolSetting.Builder()
+        .name("packet-mine")
+        .description("Attempt to instamine everything at once.")
         .defaultValue(true)
         .build()
     );
@@ -406,13 +417,19 @@ public class Nuker extends Module {
 
                 boolean canInstaMine = BlockUtils.canInstaBreak(block);
 
-                BlockUtils.breakBlock(block, swingHand.get());
-                renderBlocks.add(renderBlockPool.get().set(block));
+                if (packetMine.get()) {
+                    mc.getNetworkHandler().sendPacket(new PlayerActionC2SPacket(PlayerActionC2SPacket.Action.START_DESTROY_BLOCK, block, Direction.UP));
+                    mc.player.swingHand(Hand.MAIN_HAND);
+                    mc.getNetworkHandler().sendPacket(new PlayerActionC2SPacket(PlayerActionC2SPacket.Action.STOP_DESTROY_BLOCK, block, Direction.UP));
+                } else {
+                    BlockUtils.breakBlock(block, swingHand.get());
+                }
 
+                renderBlocks.add(renderBlockPool.get().set(block));
                 lastBlockPos.set(block);
 
                 count++;
-                if (!canInstaMine) break;
+                if (!canInstaMine && !packetMine.get() /* With packet mine attempt to break everything possible at once */) break;
             }
 
             firstBlock = false;

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/Nuker.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/Nuker.java
@@ -149,7 +149,7 @@ public class Nuker extends Module {
     private final Setting<Boolean> packetMine = sgGeneral.add(new BoolSetting.Builder()
         .name("packet-mine")
         .description("Attempt to instamine everything at once.")
-        .defaultValue(true)
+        .defaultValue(false)
         .build()
     );
 


### PR DESCRIPTION
Adds a packet mine option to the Nuker. Works perfectly on some servers without a great anticheat (or 9b9t lol), allowing you to literally obliterate everything around that can be insta-mined in [ping]ms.


https://user-images.githubusercontent.com/43317083/197256854-60ef6004-9003-4570-8b47-132d791513e2.mp4

