### PR TITLE
Resolves 99% ItemStackMixin crash

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/ItemStackMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ItemStackMixin.java
@@ -23,7 +23,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import java.util.List;
 
@@ -31,10 +30,11 @@ import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 @Mixin(ItemStack.class)
 public abstract class ItemStackMixin {
-    @Inject(method = "getTooltip", at = @At("TAIL"), locals = LocalCapture.CAPTURE_FAILSOFT)
-    private void onGetTooltip(PlayerEntity player, TooltipContext context, CallbackInfoReturnable<List<Text>> info, List<Text> list) {
+    @Inject(method = "getTooltip", at = @At("TAIL"), cancellable = true)
+    private void onGetTooltip(PlayerEntity player, TooltipContext context, CallbackInfoReturnable<List<Text>> info) {
         if (Utils.canUpdate()) {
-            MeteorClient.EVENT_BUS.post(ItemStackTooltipEvent.get((ItemStack) (Object) this, list));
+            ItemStackTooltipEvent event = MeteorClient.EVENT_BUS.post(ItemStackTooltipEvent.get((ItemStack) (Object) this, info.getReturnValue()));
+            info.setReturnValue(event.list);
         }
     }
 


### PR DESCRIPTION
This fix makes known incompatible mods(armor chroma, durability viewer) compatible