### PR TITLE
Rename Search to Block ESP

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
@@ -30,7 +30,7 @@ import meteordevelopment.meteorclient.systems.modules.movement.speed.Speed;
 import meteordevelopment.meteorclient.systems.modules.player.*;
 import meteordevelopment.meteorclient.systems.modules.render.*;
 import meteordevelopment.meteorclient.systems.modules.render.marker.Marker;
-import meteordevelopment.meteorclient.systems.modules.render.search.Search;
+import meteordevelopment.meteorclient.systems.modules.render.blockesp.BlockESP;
 import meteordevelopment.meteorclient.systems.modules.world.Timer;
 import meteordevelopment.meteorclient.systems.modules.world.*;
 import meteordevelopment.meteorclient.utils.Utils;
@@ -501,7 +501,7 @@ public class Modules extends System<Modules> {
         add(new Marker());
         add(new Nametags());
         add(new NoRender());
-        add(new Search());
+        add(new BlockESP());
         add(new StorageESP());
         add(new TimeChanger());
         add(new Tracers());

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPBlock.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPBlock.java
@@ -3,7 +3,7 @@
  * Copyright (c) Meteor Development.
  */
 
-package meteordevelopment.meteorclient.systems.modules.render.search;
+package meteordevelopment.meteorclient.systems.modules.render.blockesp;
 
 import meteordevelopment.meteorclient.events.render.Render3DEvent;
 import meteordevelopment.meteorclient.renderer.ShapeMode;
@@ -17,10 +17,10 @@ import net.minecraft.util.shape.VoxelShapes;
 
 import static meteordevelopment.meteorclient.MeteorClient.mc;
 
-public class SBlock {
+public class ESPBlock {
     private static final BlockPos.Mutable blockPos = new BlockPos.Mutable();
 
-    private static final Search search = Modules.get().get(Search.class);
+    private static final BlockESP blockEsp = Modules.get().get(BlockESP.class);
 
     public static final int FO = 1 << 1;
     public static final int FO_RI = 1 << 2;
@@ -48,36 +48,36 @@ public class SBlock {
     private BlockState state;
     public int neighbours;
 
-    public SGroup group;
+    public ESPGroup group;
 
     public boolean loaded = true;
 
-    public SBlock(int x, int y, int z) {
+    public ESPBlock(int x, int y, int z) {
         this.x = x;
         this.y = y;
         this.z = z;
     }
 
-    public SBlock getSideBlock(int side) {
+    public ESPBlock getSideBlock(int side) {
         switch (side) {
-            case FO: return search.getBlock(x, y, z + 1);
-            case BA: return search.getBlock(x, y, z - 1);
-            case LE: return search.getBlock(x - 1, y, z);
-            case RI: return search.getBlock(x + 1, y, z);
-            case TO: return search.getBlock(x, y + 1, z);
-            case BO: return search.getBlock(x, y - 1, z);
+            case FO: return blockEsp.getBlock(x, y, z + 1);
+            case BA: return blockEsp.getBlock(x, y, z - 1);
+            case LE: return blockEsp.getBlock(x - 1, y, z);
+            case RI: return blockEsp.getBlock(x + 1, y, z);
+            case TO: return blockEsp.getBlock(x, y + 1, z);
+            case BO: return blockEsp.getBlock(x, y - 1, z);
         }
 
         return null;
     }
 
     private void assignGroup() {
-        SGroup firstGroup = null;
+        ESPGroup firstGroup = null;
 
         for (int side : SIDES) {
             if ((neighbours & side) != side) continue;
 
-            SBlock neighbour = getSideBlock(side);
+            ESPBlock neighbour = getSideBlock(side);
             if (neighbour == null || neighbour.group == null) continue;
 
             if (firstGroup == null) {
@@ -89,7 +89,7 @@ public class SBlock {
         }
 
         if (firstGroup == null) {
-            firstGroup = search.newGroup(state.getBlock());
+            firstGroup = blockEsp.newGroup(state.getBlock());
         }
 
         firstGroup.add(this);
@@ -188,7 +188,7 @@ public class SBlock {
             z2 = z + shape.getMax(Direction.Axis.Z);
         }
 
-        SBlockData blockData = search.getBlockData(state.getBlock());
+        ESPBlockData blockData = blockEsp.getBlockData(state.getBlock());
 
         ShapeMode shapeMode = blockData.shapeMode;
         Color lineColor = blockData.lineColor;

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPBlockData.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPBlockData.java
@@ -3,7 +3,7 @@
  * Copyright (c) Meteor Development.
  */
 
-package meteordevelopment.meteorclient.systems.modules.render.search;
+package meteordevelopment.meteorclient.systems.modules.render.blockesp;
 
 import meteordevelopment.meteorclient.gui.GuiTheme;
 import meteordevelopment.meteorclient.gui.WidgetScreen;
@@ -18,7 +18,7 @@ import meteordevelopment.meteorclient.utils.render.color.SettingColor;
 import net.minecraft.block.Block;
 import net.minecraft.nbt.NbtCompound;
 
-public class SBlockData implements ICopyable<SBlockData>, ISerializable<SBlockData>, IChangeable, IBlockData<SBlockData>, IScreenFactory {
+public class ESPBlockData implements ICopyable<ESPBlockData>, ISerializable<ESPBlockData>, IChangeable, IBlockData<ESPBlockData>, IScreenFactory {
     public ShapeMode shapeMode;
     public SettingColor lineColor;
     public SettingColor sideColor;
@@ -28,7 +28,7 @@ public class SBlockData implements ICopyable<SBlockData>, ISerializable<SBlockDa
 
     private boolean changed;
 
-    public SBlockData(ShapeMode shapeMode, SettingColor lineColor, SettingColor sideColor, boolean tracer, SettingColor tracerColor) {
+    public ESPBlockData(ShapeMode shapeMode, SettingColor lineColor, SettingColor sideColor, boolean tracer, SettingColor tracerColor) {
         this.shapeMode = shapeMode;
         this.lineColor = lineColor;
         this.sideColor = sideColor;
@@ -38,13 +38,13 @@ public class SBlockData implements ICopyable<SBlockData>, ISerializable<SBlockDa
     }
 
     @Override
-    public WidgetScreen createScreen(GuiTheme theme, Block block, BlockDataSetting<SBlockData> setting) {
-        return new SBlockDataScreen(theme, this, block, setting);
+    public WidgetScreen createScreen(GuiTheme theme, Block block, BlockDataSetting<ESPBlockData> setting) {
+        return new ESPBlockDataScreen(theme, this, block, setting);
     }
 
     @Override
     public WidgetScreen createScreen(GuiTheme theme) {
-        return new SBlockDataScreen(theme, this, null, null);
+        return new ESPBlockDataScreen(theme, this, null, null);
     }
 
     @Override
@@ -63,7 +63,7 @@ public class SBlockData implements ICopyable<SBlockData>, ISerializable<SBlockDa
     }
 
     @Override
-    public SBlockData set(SBlockData value) {
+    public ESPBlockData set(ESPBlockData value) {
         shapeMode = value.shapeMode;
         lineColor.set(value.lineColor);
         sideColor.set(value.sideColor);
@@ -77,8 +77,8 @@ public class SBlockData implements ICopyable<SBlockData>, ISerializable<SBlockDa
     }
 
     @Override
-    public SBlockData copy() {
-        return new SBlockData(shapeMode, new SettingColor(lineColor), new SettingColor(sideColor), tracer, new SettingColor(tracerColor));
+    public ESPBlockData copy() {
+        return new ESPBlockData(shapeMode, new SettingColor(lineColor), new SettingColor(sideColor), tracer, new SettingColor(tracerColor));
     }
 
     @Override
@@ -98,7 +98,7 @@ public class SBlockData implements ICopyable<SBlockData>, ISerializable<SBlockDa
     }
 
     @Override
-    public SBlockData fromTag(NbtCompound tag) {
+    public ESPBlockData fromTag(NbtCompound tag) {
         shapeMode = ShapeMode.valueOf(tag.getString("shapeMode"));
         lineColor.fromTag(tag.getCompound("lineColor"));
         sideColor.fromTag(tag.getCompound("sideColor"));

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPBlockDataScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPBlockDataScreen.java
@@ -3,7 +3,7 @@
  * Copyright (c) Meteor Development.
  */
 
-package meteordevelopment.meteorclient.systems.modules.render.search;
+package meteordevelopment.meteorclient.systems.modules.render.blockesp;
 
 import meteordevelopment.meteorclient.gui.GuiTheme;
 import meteordevelopment.meteorclient.gui.WindowScreen;
@@ -12,12 +12,12 @@ import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.utils.render.color.SettingColor;
 import net.minecraft.block.Block;
 
-public class SBlockDataScreen extends WindowScreen {
-    private final SBlockData blockData;
+public class ESPBlockDataScreen extends WindowScreen {
+    private final ESPBlockData blockData;
     private final Block block;
-    private final BlockDataSetting<SBlockData> setting;
+    private final BlockDataSetting<ESPBlockData> setting;
 
-    public SBlockDataScreen(GuiTheme theme, SBlockData blockData, Block block, BlockDataSetting<SBlockData> setting) {
+    public ESPBlockDataScreen(GuiTheme theme, ESPBlockData blockData, Block block, BlockDataSetting<ESPBlockData> setting) {
         super(theme, "Configure Block");
 
         this.blockData = blockData;
@@ -95,7 +95,7 @@ public class SBlockDataScreen extends WindowScreen {
         add(theme.settings(settings)).expandX();
     }
 
-    private void changed(SBlockData blockData, Block block, BlockDataSetting<SBlockData> setting) {
+    private void changed(ESPBlockData blockData, Block block, BlockDataSetting<ESPBlockData> setting) {
         if (!blockData.isChanged() && block != null && setting != null) {
             setting.get().put(block, blockData);
             setting.onChanged();

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPChunk.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPChunk.java
@@ -3,7 +3,7 @@
  * Copyright (c) Meteor Development.
  */
 
-package meteordevelopment.meteorclient.systems.modules.render.search;
+package meteordevelopment.meteorclient.systems.modules.render.blockesp;
 
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
@@ -20,26 +20,26 @@ import java.util.List;
 import static meteordevelopment.meteorclient.MeteorClient.mc;
 import static meteordevelopment.meteorclient.utils.Utils.getRenderDistance;
 
-public class SChunk {
+public class ESPChunk {
     private static final BlockPos.Mutable blockPos = new BlockPos.Mutable();
 
     private final int x, z;
-    public Long2ObjectMap<SBlock> blocks;
+    public Long2ObjectMap<ESPBlock> blocks;
 
-    public SChunk(int x, int z) {
+    public ESPChunk(int x, int z) {
         this.x = x;
         this.z = z;
     }
 
-    public SBlock get(int x, int y, int z) {
-        return blocks == null ? null : blocks.get(SBlock.getKey(x, y, z));
+    public ESPBlock get(int x, int y, int z) {
+        return blocks == null ? null : blocks.get(ESPBlock.getKey(x, y, z));
     }
 
     public void add(BlockPos blockPos, boolean update) {
-        SBlock block = new SBlock(blockPos.getX(), blockPos.getY(), blockPos.getZ());
+        ESPBlock block = new ESPBlock(blockPos.getX(), blockPos.getY(), blockPos.getZ());
 
         if (blocks == null) blocks = new Long2ObjectOpenHashMap<>(64);
-        blocks.put(SBlock.getKey(blockPos), block);
+        blocks.put(ESPBlock.getKey(blockPos), block);
 
         if (update) block.update();
     }
@@ -50,20 +50,20 @@ public class SChunk {
 
     public void remove(BlockPos blockPos) {
         if (blocks != null) {
-            SBlock block = blocks.remove(SBlock.getKey(blockPos));
+            ESPBlock block = blocks.remove(ESPBlock.getKey(blockPos));
             if (block != null) block.group.remove(block);
         }
     }
 
     public void update() {
         if (blocks != null) {
-            for (SBlock block : blocks.values()) block.update();
+            for (ESPBlock block : blocks.values()) block.update();
         }
     }
 
     public void update(int x, int y, int z) {
         if (blocks != null) {
-            SBlock block = blocks.get(SBlock.getKey(x, y, z));
+            ESPBlock block = blocks.get(ESPBlock.getKey(x, y, z));
             if (block != null) block.update();
         }
     }
@@ -82,13 +82,13 @@ public class SChunk {
 
     public void render(Render3DEvent event) {
         if (blocks != null) {
-            for (SBlock block : blocks.values()) block.render(event);
+            for (ESPBlock block : blocks.values()) block.render(event);
         }
     }
 
 
-    public static SChunk searchChunk(Chunk chunk, List<Block> blocks) {
-        SChunk schunk = new SChunk(chunk.getPos().x, chunk.getPos().z);
+    public static ESPChunk searchChunk(Chunk chunk, List<Block> blocks) {
+        ESPChunk schunk = new ESPChunk(chunk.getPos().x, chunk.getPos().z);
         if (schunk.shouldBeDeleted()) return schunk;
 
         for (int x = chunk.getPos().getStartX(); x <= chunk.getPos().getEndX(); x++) {


### PR DESCRIPTION
There are many reasons why I feel this is a necessary change.

1. The name `Search` is ambiguous. 
When someone asks:

> Which module has ESP for blocks?  

And is replied with "Search", that person might think that we are asking them to search it up, not knowing that it is, in fact, the name of the module in question.
This change will hopefully lower the amount of people asking about `Block ESP` on the Discord.

2. The name `Search` is already used in the client, as in the modules tab search bar.

3. The name `Block ESP` is much more indicative of this module's use.
The term `ESP` is already used multiple time in the client (`ESP`, `Hole ESP`, `City ESP`, etc.) and is used to designate the exact same feature as the `Search` module. Not only that, but `Search` doesn't specify the target to be searched, whilst `Block ESP` clearly indicates the module's intended use just by the name.