### PR TITLE
Fix AutoLog smartToggle

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/AutoLog.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/AutoLog.java
@@ -140,7 +140,7 @@ public class AutoLog extends Module {
 
             else if (Utils.canUpdate()
                     && !mc.player.isDead()
-                    && mc.player.getHealth() >= health.get()) {
+                    && mc.player.getHealth() > health.get()) {
                 toggle();
                 disableHealthListener();
            }


### PR DESCRIPTION
Currently AutoLog disconnects and toggles if players health is equal to or less than set health and smartToggle toggles if player health is equal to or greater than set health. So if the player is down to the exact set health it'll be stuck in a loop toggling and disconnecting.

This PR fixes the issue by simply changing smartToggle to toggle when the player health is greater than set health.