### PR TITLE
RideStats module and add a filter to EntityTypeListSetting

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/EntityTypeListSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/EntityTypeListSettingScreen.java
@@ -16,7 +16,6 @@ import meteordevelopment.meteorclient.gui.widgets.input.WTextBox;
 import meteordevelopment.meteorclient.gui.widgets.pressable.WCheckbox;
 import meteordevelopment.meteorclient.settings.EntityTypeListSetting;
 import meteordevelopment.meteorclient.utils.Utils;
-import meteordevelopment.meteorclient.utils.entity.EntityUtils;
 import meteordevelopment.meteorclient.utils.misc.Names;
 import net.minecraft.entity.EntityType;
 import net.minecraft.util.Pair;
@@ -25,7 +24,6 @@ import net.minecraft.util.registry.Registry;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Locale;
 import java.util.function.Consumer;
 
 public class EntityTypeListSettingScreen extends WindowScreen {
@@ -70,7 +68,7 @@ public class EntityTypeListSettingScreen extends WindowScreen {
         for (EntityType<?> entityType : setting.get().keySet()) {
             if (!setting.get().getBoolean(entityType)) continue;
 
-            if (!setting.onlyAttackable || EntityUtils.isAttackable(entityType)) {
+            if (setting.filter == null || setting.filter.test(entityType)) {
                 switch (entityType.getSpawnGroup()) {
                     case CREATURE -> hasAnimal++;
                     case WATER_AMBIENT, WATER_CREATURE, UNDERGROUND_WATER_CREATURE, AXOLOTLS -> hasWaterAnimal++;
@@ -134,7 +132,7 @@ public class EntityTypeListSettingScreen extends WindowScreen {
         miscT = misc.add(theme.table()).expandX().widget();
 
         Consumer<EntityType<?>> entityTypeForEach = entityType -> {
-            if (!setting.onlyAttackable || EntityUtils.isAttackable(entityType)) {
+            if (setting.filter == null || setting.filter.test(entityType)) {
                 switch (entityType.getSpawnGroup()) {
                     case CREATURE -> {
                         animalsE.add(entityType);

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
@@ -501,6 +501,7 @@ public class Modules extends System<Modules> {
         add(new Marker());
         add(new Nametags());
         add(new NoRender());
+        add(new RideStats());
         add(new Search());
         add(new StorageESP());
         add(new TimeChanger());

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/BowAimbot.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/BowAimbot.java
@@ -44,7 +44,7 @@ public class BowAimbot extends Module {
     private final Setting<Object2BooleanMap<EntityType<?>>> entities = sgGeneral.add(new EntityTypeListSetting.Builder()
         .name("entities")
         .description("Entities to attack.")
-        .onlyAttackable()
+        .filter(EntityUtils::isAttackable)
         .build()
     );
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/KillAura.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/KillAura.java
@@ -135,7 +135,7 @@ public class KillAura extends Module {
     private final Setting<Object2BooleanMap<EntityType<?>>> entities = sgTargeting.add(new EntityTypeListSetting.Builder()
         .name("entities")
         .description("Entities to attack.")
-        .onlyAttackable()
+        .filter(EntityUtils::isAttackable)
         .build()
     );
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/NoInteract.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/NoInteract.java
@@ -14,6 +14,7 @@ import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.friends.Friends;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.meteorclient.utils.entity.EntityUtils;
 import meteordevelopment.orbit.EventHandler;
 import meteordevelopment.orbit.EventPriority;
 import net.minecraft.block.Block;
@@ -71,7 +72,7 @@ public class NoInteract extends Module {
     private final Setting<Object2BooleanMap<EntityType<?>>> entityHit = sgEntities.add(new EntityTypeListSetting.Builder()
         .name("entity-hit")
         .description("Cancel entity hitting.")
-        .onlyAttackable()
+        .filter(EntityUtils::isAttackable)
         .build()
     );
 
@@ -85,7 +86,7 @@ public class NoInteract extends Module {
     private final Setting<Object2BooleanMap<EntityType<?>>> entityInteract = sgEntities.add(new EntityTypeListSetting.Builder()
         .name("entity-interact")
         .description("Cancel entity interaction.")
-        .onlyAttackable()
+        .filter(EntityUtils::isAttackable)
         .build()
     );
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/RideStats.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/RideStats.java
@@ -1,0 +1,202 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.systems.modules.render;
+
+import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
+import meteordevelopment.meteorclient.events.render.Render2DEvent;
+import meteordevelopment.meteorclient.renderer.Renderer2D;
+import meteordevelopment.meteorclient.renderer.text.TextRenderer;
+import meteordevelopment.meteorclient.settings.*;
+import meteordevelopment.meteorclient.systems.modules.Categories;
+import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.meteorclient.utils.misc.Vec3;
+import meteordevelopment.meteorclient.utils.render.NametagUtils;
+import meteordevelopment.meteorclient.utils.render.color.Color;
+import meteordevelopment.meteorclient.utils.render.color.SettingColor;
+import meteordevelopment.orbit.EventHandler;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.attribute.EntityAttributes;
+import net.minecraft.entity.passive.AbstractHorseEntity;
+import net.minecraft.entity.passive.LlamaEntity;
+
+
+public class RideStats extends Module {
+    final SettingGroup sgGeneral = settings.getDefaultGroup();
+
+    private final Setting<Object2BooleanMap<EntityType<?>>> entities = sgGeneral.add(new EntityTypeListSetting.Builder()
+        .name("entities")
+        .description("Select entities to display on.")
+        .filter(this::entityFilter)
+        .defaultValue(EntityType.HORSE, EntityType.MULE, EntityType.DONKEY, EntityType.LLAMA, EntityType.SKELETON_HORSE)
+        .build()
+    );
+
+    private final Setting<Boolean> displaySpeed = sgGeneral.add(new BoolSetting.Builder()
+        .name("display-max-speed")
+        .description("Display the entity's max speed.")
+        .defaultValue(true)
+        .build()
+    );
+
+    private final Setting<Boolean> displayJumpHeight = sgGeneral.add(new BoolSetting.Builder()
+        .name("display-max-jump-height")
+        .description("Display the entity's max jump height.")
+        .defaultValue(true)
+        .build()
+    );
+
+    private final Setting<Boolean> displayHealth = sgGeneral.add(new BoolSetting.Builder()
+        .name("display-max-health")
+        .description("Display the entity's max health.")
+        .defaultValue(true)
+        .build()
+    );
+
+    private final Setting<Boolean> displayInventorySlots = sgGeneral.add(new BoolSetting.Builder()
+        .name("display-llama-slots")
+        .description("Display the llama's inventory slots.")
+        .defaultValue(true)
+        .visible(()-> entities.get().containsKey(EntityType.LLAMA))
+        .build()
+    );
+
+    private final Setting<Double> scale = sgGeneral.add(new DoubleSetting.Builder()
+        .name("scale")
+        .description("The scale of the nametag.")
+        .defaultValue(1.5)
+        .min(0.1)
+        .build()
+    );
+
+    private final Setting<Double> height = sgGeneral.add(new DoubleSetting.Builder()
+        .name("height")
+        .description("How high above entities' heads to display it.")
+        .defaultValue(1)
+        .sliderMax(3)
+        .build()
+    );
+
+    private final Setting<SettingColor> entityNameColor = sgGeneral.add(new ColorSetting.Builder()
+        .name("name-color")
+        .description("What color the entity's name is.")
+        .defaultValue(new SettingColor())
+        .build()
+    );
+
+    private final Setting<SettingColor> backgroundColor = sgGeneral.add(new ColorSetting.Builder()
+        .name("background-color")
+        .description("What color the background of the nametag is.")
+        .defaultValue(new SettingColor(0, 0, 0, 75))
+        .build()
+    );
+
+
+    public RideStats() {
+        super(Categories.Render, "ride-stats", "Displays information above rideable entity's heads");
+    }
+
+    private final Vec3 pos = new Vec3();
+    private final Color GREEN = new Color(25, 252, 25);
+    private final Color GREY = new Color(150, 150, 150);
+    private final Color BLUE = new Color(20, 170, 170);
+    private final Color GOLD = new Color(232, 185, 35);
+
+    @EventHandler
+    private void onRender2D(Render2DEvent event) {
+        for(Entity entity: mc.world.getEntities()) {
+            if(!entities.get().getBoolean(entity.getType())) continue;
+            pos.set(entity, event.tickDelta);
+            pos.add(0, entity.getEyeHeight(entity.getPose()) + 0.75, 0);
+            pos.add(0, -1 + height.get(), 0);
+            if (NametagUtils.to2D(pos, scale.get())) {
+                renderHorseNametag(entity);
+            }
+        }
+    }
+
+    private void renderHorseNametag(Entity entity) {
+        AbstractHorseEntity horseEntity = (AbstractHorseEntity) entity;
+        boolean llama = entity.getType() == EntityType.LLAMA;
+        TextRenderer text = TextRenderer.get();
+        NametagUtils.begin(pos);
+        text.beginBig();
+
+        // Name
+        String name;
+        name = horseEntity.getType().getName().getString();
+
+        // Health
+        double health = horseEntity.getMaxHealth();
+        String healthText = " " + String.format("%.1f", health).replace(".", ",");
+
+        // Speed
+        double speed = genericSpeedToBlockPerSecond(horseEntity.getAttributes().getBaseValue(EntityAttributes.GENERIC_MOVEMENT_SPEED));
+        String speedText = " " + String.format("%.1f", speed).replace(".", ",") + " bps";
+
+        // Jump
+        double maxJump = jumpStrengthToJumpHeight(horseEntity.getJumpStrength());
+        String maxJumpText = " " + String.format("%.1f", maxJump).replace(".", ",") + "m";
+
+        //Inv Slots
+        int invSlots = 0;
+        if(llama) {
+            invSlots = ((LlamaEntity) entity).getInventoryColumns() * 3;
+        }
+        String invSlotsText = " " + invSlots + " slots";
+
+        // Widths
+        double nameWidth = text.getWidth(name, true);
+        double healthWidth = text.getWidth(healthText, true);
+        double speedWidth = text.getWidth(speedText, true);
+        double jumpWidth = text.getWidth(maxJumpText, true);
+        double invSlotsWidth = text.getWidth(invSlotsText, true);
+        double width = nameWidth;
+
+        if (displayHealth.get()) width += healthWidth;
+        if (displaySpeed.get()) width += speedWidth;
+        if (displayJumpHeight.get()) width += jumpWidth;
+        if(displayInventorySlots.get() && llama) width += invSlotsWidth;
+
+        double widthHalf = width / 2;
+        double heightDown = text.getHeight(true);
+
+        drawBg(-widthHalf, -heightDown, width, heightDown);
+
+        // Render texts
+        double hX = -widthHalf;
+        double hY = -heightDown;
+
+        hX = text.render(name, hX, hY, entityNameColor.get(), true);
+
+        if(displayHealth.get()) hX = text.render(healthText, hX, hY, GREEN, true);
+        if (displaySpeed.get()) hX = text.render(speedText, hX, hY, BLUE, true);
+        if (displayJumpHeight.get() && !llama) text.render(maxJumpText, hX, hY, GREY, true);
+        if(displayInventorySlots.get() && llama) text.render(invSlotsText, hX, hY, GOLD, true);
+        text.end();
+        NametagUtils.end();
+    }
+
+    private double jumpStrengthToJumpHeight(double strength) {
+        // Don't Judge me, I forgot where this came from, and it works
+        return -0.1817584952 * strength * strength * strength + 3.689713992 * strength * strength + 2.128599134 * strength - 0.343930367;
+    }
+
+    private double genericSpeedToBlockPerSecond(double speed) {
+        return 0.132 * speed * speed + 42.119 * speed;
+    }
+
+    private void drawBg(double x, double y, double width, double height) {
+        Renderer2D.COLOR.begin();
+        Renderer2D.COLOR.quad(x - 1, y - 1, width + 2, height + 2, backgroundColor.get());
+        Renderer2D.COLOR.render(null);
+    }
+
+    private Boolean entityFilter(EntityType<?> entity) {
+        return EntityType.HORSE.equals(entity) || EntityType.MULE.equals(entity) || EntityType.DONKEY.equals(entity) || EntityType.LLAMA.equals(entity) || EntityType.SKELETON_HORSE.equals(entity);
+    }
+
+}

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoBreed.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoBreed.java
@@ -10,6 +10,7 @@ import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.meteorclient.utils.entity.EntityUtils;
 import meteordevelopment.meteorclient.utils.player.PlayerUtils;
 import meteordevelopment.meteorclient.utils.player.Rotations;
 import meteordevelopment.orbit.EventHandler;
@@ -31,7 +32,7 @@ public class AutoBreed extends Module {
                     EntityType.MOOSHROOM, EntityType.SHEEP, EntityType.PIG, EntityType.CHICKEN, EntityType.WOLF,
                     EntityType.CAT, EntityType.OCELOT, EntityType.RABBIT, EntityType.LLAMA, EntityType.TURTLE,
                     EntityType.PANDA, EntityType.FOX, EntityType.BEE, EntityType.STRIDER, EntityType.HOGLIN)
-            .onlyAttackable()
+            .filter(EntityUtils::isAttackable)
             .build()
     );
 


### PR DESCRIPTION
Ridestats is a module that I made a while back that shows info over rideable mobs' heads (like speed, jump height, and slots for llamas). I changed the onlyAttackable variable in EntityTypeListSetting to a filter for it (which was marked by a todo anyways). Only merge this if it's a good feature, I understand if it's not. \
\
![2022-11-21_15 45 02](https://user-images.githubusercontent.com/96392121/203155032-eec69be5-2a51-469d-b402-b732031d8d33.png)
