### PR TITLE
addons can have no authors

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/addons/AddonManager.java
+++ b/src/main/java/meteordevelopment/meteorclient/addons/AddonManager.java
@@ -66,7 +66,10 @@ public class AddonManager {
             MeteorAddon addon = entrypoint.getEntrypoint();
 
             addon.name = metadata.getName();
+
+            if (metadata.getAuthors().isEmpty()) throw new RuntimeException("Addon %s requires at least 1 author to be defined in it's fabric.mod.json. See https://fabricmc.net/wiki/documentation:fabric_mod_json_spec".formatted(addon.name));
             addon.authors = new String[metadata.getAuthors().size()];
+
             if (metadata.containsCustomValue(MeteorClient.MOD_ID + ":color")) {
                 addon.color.parse(metadata.getCustomValue(MeteorClient.MOD_ID + ":color").getAsString());
             }

--- a/src/main/java/meteordevelopment/meteorclient/utils/player/TitleScreenCredits.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/TitleScreenCredits.java
@@ -59,14 +59,17 @@ public class TitleScreenCredits {
         Credit credit = new Credit(addon);
 
         credit.sections.add(new Section(addon.name, addon.color.getPacked()));
-        credit.sections.add(new Section(" by ", GRAY));
 
-        for (int i = 0; i < addon.authors.length; i++) {
-            if (i > 0) {
-                credit.sections.add(new Section(i == addon.authors.length - 1 ? " & " : ", ", GRAY));
+        if (addon.authors.length >= 1) {
+            credit.sections.add(new Section(" by ", GRAY));
+
+            for (int i = 0; i < addon.authors.length; i++) {
+                if (i > 0) {
+                    credit.sections.add(new Section(i == addon.authors.length - 1 ? " & " : ", ", GRAY));
+                }
+
+                credit.sections.add(new Section(addon.authors[i], WHITE));
             }
-
-            credit.sections.add(new Section(addon.authors[i], WHITE));
         }
 
         credit.calculateWidth();

--- a/src/main/java/meteordevelopment/meteorclient/utils/player/TitleScreenCredits.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/TitleScreenCredits.java
@@ -59,17 +59,14 @@ public class TitleScreenCredits {
         Credit credit = new Credit(addon);
 
         credit.sections.add(new Section(addon.name, addon.color.getPacked()));
+        credit.sections.add(new Section(" by ", GRAY));
 
-        if (addon.authors.length >= 1) {
-            credit.sections.add(new Section(" by ", GRAY));
-
-            for (int i = 0; i < addon.authors.length; i++) {
-                if (i > 0) {
-                    credit.sections.add(new Section(i == addon.authors.length - 1 ? " & " : ", ", GRAY));
-                }
-
-                credit.sections.add(new Section(addon.authors[i], WHITE));
+        for (int i = 0; i < addon.authors.length; i++) {
+            if (i > 0) {
+                credit.sections.add(new Section(i == addon.authors.length - 1 ? " & " : ", ", GRAY));
             }
+
+            credit.sections.add(new Section(addon.authors[i], WHITE));
         }
 
         credit.calculateWidth();


### PR DESCRIPTION
[as per the docs](https://fabricmc.net/wiki/documentation:fabric_mod_json_spec#:~:text=0.x.-,Mandatory%20fields) the `authors` field is optional, which would make the title credits fucky
this makes it unfucky

(the `name` field is also optional, but it already defaults to `id` if not present)