### PR TITLE
Allow  Rotation Priority w/o Callbacks

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/utils/player/Rotations.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/Rotations.java
@@ -63,6 +63,10 @@ public class Rotations {
         rotate(yaw, pitch, 0, callback);
     }
 
+    public static void rotate(double yaw, double pitch, int priority) {
+        rotate(yaw, pitch, priority, null);
+    }
+
     public static void rotate(double yaw, double pitch) {
         rotate(yaw, pitch, 0, null);
     }


### PR DESCRIPTION
No more self referencing when you don't want to define a callback but need a rotation to be done first