### PR TITLE
Optimize validHole check

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixininterface/IBox.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixininterface/IBox.java
@@ -5,8 +5,14 @@
 
 package meteordevelopment.meteorclient.mixininterface;
 
+import net.minecraft.util.math.BlockPos;
+
 public interface IBox {
     void expand(double v);
 
     void set(double x1, double y1, double z1, double x2, double y2, double z2);
+
+    default void set(BlockPos pos) {
+        set(pos.getX(), pos.getY(), pos.getZ(), pos.getX() + 1, pos.getY() + 1, pos.getZ() + 1);
+    }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/HoleFiller.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/HoleFiller.java
@@ -8,6 +8,7 @@ package meteordevelopment.meteorclient.systems.modules.combat;
 import meteordevelopment.meteorclient.events.render.Render3DEvent;
 import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.mixin.AbstractBlockAccessor;
+import meteordevelopment.meteorclient.mixininterface.IBox;
 import meteordevelopment.meteorclient.renderer.ShapeMode;
 import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.friends.Friends;
@@ -225,6 +226,7 @@ public class HoleFiller extends Module {
     private final List<Hole> holes = new ArrayList<>();
 
     private final BlockPos.Mutable testPos = new BlockPos.Mutable();
+    private final Box box = new Box(0, 0, 0, 0, 0, 0);
     private Vec3d testVec;
     private int timer;
 
@@ -328,7 +330,7 @@ public class HoleFiller extends Module {
         if (((AbstractBlockAccessor) mc.world.getBlockState(testPos).getBlock()).isCollidable()) return false;
         testPos.add(0, -1, 0);
 
-        Box box = new Box(pos);
+        ((IBox) box).set(pos);
         if (!mc.world.getOtherEntities(null, box, entity -> entity instanceof PlayerEntity
             || entity instanceof TntEntity || entity instanceof EndCrystalEntity).isEmpty()) return false;
 


### PR DESCRIPTION
Uses mc.world.getOtherEntities to check for entities (also fixes bug with ignoring collisions when force fill was pressed)