### PR TITLE
cleaner hud crash fix

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CombatHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CombatHud.java
@@ -196,15 +196,17 @@ public class CombatHud extends HudElement {
             Color primaryColor = TextHud.getSectionColor(0);
             Color secondaryColor = TextHud.getSectionColor(1);
 
-            if (isInEditor()) playerEntity = FakeClientPlayer.getPlayer();
+            if (isInEditor()) playerEntity = mc.player;
             else playerEntity = TargetUtils.getPlayerTarget(range.get(), SortPriority.LowestDistance);
 
-            if (playerEntity == null) return;
+            if (playerEntity == null && !isInEditor()) return;
 
             // Background
             Renderer2D.COLOR.begin();
             Renderer2D.COLOR.quad(x, y, getWidth(), getHeight(), backgroundColor.get());
             Renderer2D.COLOR.render(null);
+
+            if (playerEntity == null) return;
 
             // Player Model
             InventoryScreen.drawEntity(

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PlayerModelHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PlayerModelHud.java
@@ -10,7 +10,6 @@ import meteordevelopment.meteorclient.systems.hud.Hud;
 import meteordevelopment.meteorclient.systems.hud.HudElement;
 import meteordevelopment.meteorclient.systems.hud.HudElementInfo;
 import meteordevelopment.meteorclient.systems.hud.HudRenderer;
-import meteordevelopment.meteorclient.utils.misc.FakeClientPlayer;
 import meteordevelopment.meteorclient.utils.render.color.SettingColor;
 import net.minecraft.client.gui.screen.ingame.InventoryScreen;
 import net.minecraft.entity.player.PlayerEntity;
@@ -96,7 +95,7 @@ public class PlayerModelHud extends HudElement {
 
         renderer.post(() -> {
             PlayerEntity player = mc.player;
-            if (isInEditor()) player = FakeClientPlayer.getPlayer();
+            if (player == null) return;
 
             float yaw = copyYaw.get() ? MathHelper.wrapDegrees(player.prevYaw + (player.getYaw() - player.prevYaw) * mc.getTickDelta()) : (float) customYaw.get();
             float pitch = copyPitch.get() ? player.getPitch() : (float) customPitch.get();


### PR DESCRIPTION
- use current player instead of fake player when applicable
- still render combat hud background only when in main menu
- less duplicated code