### PR TITLE
use try-with-resources

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/commands/arguments/NotebotSongArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/commands/arguments/NotebotSongArgumentType.java
@@ -37,8 +37,8 @@ public class NotebotSongArgumentType implements ArgumentType<Path> {
 
     @Override
     public <S> CompletableFuture<Suggestions> listSuggestions(CommandContext<S> context, SuggestionsBuilder builder) {
-        try {
-            return CommandSource.suggestMatching(Files.list(MeteorClient.FOLDER.toPath().resolve("notebot"))
+        try (var suggestions = Files.list(MeteorClient.FOLDER.toPath().resolve("notebot"))) {
+            return CommandSource.suggestMatching(suggestions
                     .filter(SongDecoders::hasDecoder)
                     .map(path -> path.getFileName().toString()),
                 builder


### PR DESCRIPTION
From `Files.list()`'s javadocs:
> This method must be used within a try-with-resources statement or similar control structure to ensure that the stream's open directory is closed promptly after the stream's operations have completed.