### PR TITLE
KillAura switch back.

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/KillAura.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/KillAura.java
@@ -246,7 +246,6 @@ public class KillAura extends Module {
     private final Vec3d hitVec = new Vec3d(0, 0, 0);
     private int switchTimer, hitTimer;
     private boolean wasPathing = false;
-    private int lastItem = -1;
 
     public KillAura() {
         super(Categories.Combat, "kill-aura", "Attacks specified entities around you.");
@@ -284,8 +283,7 @@ public class KillAura extends Module {
                 wasPathing = false;
             }
             if (autoSwitch.get() && switchBack.get()) {
-                InvUtils.swap(lastItem, false);
-                lastItem = -1;
+                InvUtils.swapBack();
             }
             return;
         }
@@ -308,11 +306,7 @@ public class KillAura extends Module {
                 FindItemResult axeResult = InvUtils.findInHotbar(itemStack -> itemStack.getItem() instanceof AxeItem);
                 if (axeResult.found()) weaponResult = axeResult;
             }
-            
-            if (switchBack.get() && lastItem == -1) {
-                lastItem = mc.player.getInventory().selectedSlot;
-            }
-            InvUtils.swap(weaponResult.slot(), false);
+            InvUtils.swap(weaponResult.slot(), switchBack.get());
         }
 
         if (!itemInHand()) return;

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/KillAura.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/KillAura.java
@@ -74,6 +74,14 @@ public class KillAura extends Module {
         .defaultValue(false)
         .build()
     );
+    
+    private final Setting<Boolean> switchBack = sgGeneral.add(new BoolSetting.Builder()
+        .name("switch-back")
+        .description("switch back to previous item")
+        .visible(() -> autoSwitch.get())
+        .defaultValue(true)
+        .build()
+    );
 
     private final Setting<Boolean> onlyOnClick = sgGeneral.add(new BoolSetting.Builder()
         .name("only-on-click")
@@ -238,6 +246,7 @@ public class KillAura extends Module {
     private final Vec3d hitVec = new Vec3d(0, 0, 0);
     private int switchTimer, hitTimer;
     private boolean wasPathing = false;
+    private int lastItem = -1;
 
     public KillAura() {
         super(Categories.Combat, "kill-aura", "Attacks specified entities around you.");
@@ -274,6 +283,10 @@ public class KillAura extends Module {
                 BaritoneAPI.getProvider().getPrimaryBaritone().getCommandManager().execute("resume");
                 wasPathing = false;
             }
+            if (autoSwitch.get() && switchBack.get()) {
+                InvUtils.swap(lastItem, false);
+                lastItem = -1;
+            }
             return;
         }
 
@@ -295,7 +308,10 @@ public class KillAura extends Module {
                 FindItemResult axeResult = InvUtils.findInHotbar(itemStack -> itemStack.getItem() instanceof AxeItem);
                 if (axeResult.found()) weaponResult = axeResult;
             }
-
+            
+            if (switchBack.get() && lastItem == -1) {
+                lastItem = mc.player.getInventory().selectedSlot;
+            }
             InvUtils.swap(weaponResult.slot(), false);
         }
 


### PR DESCRIPTION
When enabled, KillAura will automatically switch back to previous item after no target entities are left.