### PR TITLE
FakeClientPlayer NPE fix

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/FakeClientPlayer.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/FakeClientPlayer.java
@@ -9,19 +9,13 @@ import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.events.game.GameJoinedEvent;
 import meteordevelopment.meteorclient.utils.PreInit;
 import meteordevelopment.orbit.EventHandler;
-import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.client.network.OtherClientPlayerEntity;
 import net.minecraft.client.network.PlayerListEntry;
-import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.network.ClientConnection;
-import net.minecraft.network.NetworkSide;
-import net.minecraft.world.Difficulty;
 
 import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class FakeClientPlayer {
-    private static ClientWorld world;
     private static PlayerEntity player;
     private static PlayerListEntry playerListEntry;
 
@@ -41,12 +35,7 @@ public class FakeClientPlayer {
         String id = mc.getSession().getUuid();
 
         if (player == null || (!id.equals(lastId))) {
-            if (world == null) {
-                world = new ClientWorld(new ClientPlayNetworkHandler(mc, null, new ClientConnection(NetworkSide.CLIENTBOUND), mc.getCurrentServerEntry(), mc.getSession().getProfile(), null), new ClientWorld.Properties(Difficulty.NORMAL, false, false), world.getRegistryKey(), world.getDimensionEntry(), 1, 1, mc::getProfiler, null, false, 0);
-            }
-
-            player = new OtherClientPlayerEntity(world, mc.getSession().getProfile());
-
+            player = new OtherClientPlayerEntity(mc.world, mc.getSession().getProfile());
             lastId = id;
             needsNewEntry = true;
         }

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/FakeClientPlayer.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/FakeClientPlayer.java
@@ -5,10 +5,6 @@
 
 package meteordevelopment.meteorclient.utils.misc;
 
-import meteordevelopment.meteorclient.MeteorClient;
-import meteordevelopment.meteorclient.events.game.GameJoinedEvent;
-import meteordevelopment.meteorclient.utils.PreInit;
-import meteordevelopment.orbit.EventHandler;
 import net.minecraft.client.network.OtherClientPlayerEntity;
 import net.minecraft.client.network.PlayerListEntry;
 import net.minecraft.entity.player.PlayerEntity;
@@ -21,15 +17,6 @@ public class FakeClientPlayer {
 
     private static String lastId;
     private static boolean needsNewEntry;
-
-    @PreInit
-    public static void init() {
-        MeteorClient.EVENT_BUS.subscribe(FakeClientPlayer.class);
-    }
-
-    @EventHandler
-    private static void onGameJoined(GameJoinedEvent event) {
-    }
 
     public static PlayerEntity getPlayer() {
         String id = mc.getSession().getUuid();


### PR DESCRIPTION
The custom instance of `ClientWorld` has been replaced by the current world. Null safety is guaranteed because `getPlayer()` is only called by `CombatHud` and `PlayerModelHud`, which are rendered only when a world is currently loaded.

This pull request should fix #3123, #3044 and #3069. Also, thanks to #3126, `getPlayer()` could be entirely removed.