### PR TITLE
Added "NoBeaconBeams" to NoRender module

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/BeaconBlockEntityRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/BeaconBlockEntityRendererMixin.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.mixin;
+
+import meteordevelopment.meteorclient.systems.modules.Modules;
+import meteordevelopment.meteorclient.systems.modules.render.NoRender;
+import net.minecraft.block.entity.BeaconBlockEntity;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.block.entity.BeaconBlockEntityRenderer;
+import net.minecraft.client.util.math.MatrixStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(BeaconBlockEntityRenderer.class)
+public class BeaconBlockEntityRendererMixin {
+    @Inject(method = "render", at = @At("HEAD"), cancellable = true)
+    private void onRender(BeaconBlockEntity beaconBlockEntity, float f, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i, int j, CallbackInfo info) {
+        if (Modules.get().get(NoRender.class).noBeaconBeams()) info.cancel();
+    }
+}

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/NoRender.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/NoRender.java
@@ -227,6 +227,13 @@ public class NoRender extends Module {
         .build()
     );
 
+    private final Setting<Boolean> noBeaconBeams = sgWorld.add(new BoolSetting.Builder()
+        .name("beacon-beams")
+        .description("Disables rendering of beacon beams.")
+        .defaultValue(false)
+        .build()
+    );
+
     private final Setting<Boolean> noFallingBlocks = sgWorld.add(new BoolSetting.Builder()
         .name("falling-blocks")
         .description("Disables rendering of falling blocks.")
@@ -452,6 +459,10 @@ public class NoRender extends Module {
 
     public boolean noSkylightUpdates() {
         return isActive() && noSkylightUpdates.get();
+    }
+
+    public boolean noBeaconBeams() {
+        return isActive() && noBeaconBeams.get();
     }
 
     public boolean noFallingBlocks() {

--- a/src/main/resources/meteor-client.mixins.json
+++ b/src/main/resources/meteor-client.mixins.json
@@ -14,6 +14,7 @@
     "ArmorFeatureRendererMixin",
     "BackgroundRendererMixin",
     "BannerBlockEntityRendererMixin",
+    "BeaconBlockEntityRendererMixin",
     "BeaconScreenMixin",
     "BiomeColorsMixin",
     "BlockCollisionSpliteratorMixin",


### PR DESCRIPTION
This pr introduces a new setting to `NoRender` module under `World` category, which allows users to toggle between rendering of the beacons' beam.
Closes #2957