### PR TITLE
Proxies minor patch

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/ProxiesScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/ProxiesScreen.java
@@ -61,10 +61,10 @@ public class ProxiesScreen extends WindowScreen {
         WButton importBtn = l.add(theme.button("Import")).expandX().widget();
         importBtn.action = () -> {
             String selectedFile = TinyFileDialogs.tinyfd_openFileDialog("Import Proxies", null, filters, null, false);
-            if (selectedFile != null) {
-                File file = new File(selectedFile);
-                mc.setScreen(new ProxiesImportScreen(theme, file));
-            }
+            if (selectedFile == null) return;
+
+            File file = new File(selectedFile);
+            mc.setScreen(new ProxiesImportScreen(theme, file));
         };
     }
 
@@ -86,7 +86,7 @@ public class ProxiesScreen extends WindowScreen {
             WLabel name = table.add(theme.label(proxy.name.get())).widget();
             name.color = theme.textColor();
 
-            WLabel type = table.add(theme.label("(" + proxy.type.get() + ")")).widget();
+            WLabel type = table.add(theme.label("(%s)".formatted(proxy.type.get()))).widget();
             type.color = theme.textSecondaryColor();
 
             WHorizontalList ipList = table.add(theme.horizontalList()).expandCellX().widget();
@@ -119,7 +119,7 @@ public class ProxiesScreen extends WindowScreen {
         return NbtUtils.fromClipboard(Proxies.get());
     }
 
-    protected static class EditProxyScreen extends EditSystemScreen<Proxy> {
+    protected static final class EditProxyScreen extends EditSystemScreen<Proxy> {
         public EditProxyScreen(GuiTheme theme, Proxy value, Runnable reload) {
             super(theme, value, reload);
         }

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientConnectionInitChannelMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientConnectionInitChannelMixin.java
@@ -25,8 +25,8 @@ public class ClientConnectionInitChannelMixin {
         if (proxy == null) return;
 
         switch (proxy.type.get()) {
-            case Socks4 -> channel.pipeline().addFirst(new Socks4ProxyHandler(new InetSocketAddress(proxy.address.get(), proxy.port.get()), proxy.username.get()));
-            case Socks5 -> channel.pipeline().addFirst(new Socks5ProxyHandler(new InetSocketAddress(proxy.address.get(), proxy.port.get()), proxy.username.get(), proxy.password.get()));
+            case SOCKS_4 -> channel.pipeline().addFirst(new Socks4ProxyHandler(new InetSocketAddress(proxy.address.get(), proxy.port.get()), proxy.username.get()));
+            case SOCKS_5 -> channel.pipeline().addFirst(new Socks5ProxyHandler(new InetSocketAddress(proxy.address.get(), proxy.port.get()), proxy.username.get(), proxy.password.get()));
         }
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/mixin/MultiplayerScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MultiplayerScreenMixin.java
@@ -42,19 +42,15 @@ public class MultiplayerScreenMixin extends Screen {
         loggedInAsLength = textRenderer.getWidth(loggedInAs);
 
         addDrawableChild(
-                new ButtonWidget.Builder(Text.literal("Accounts"), button -> {
-                    client.setScreen(GuiThemes.get().accountsScreen());
-                })
-                .position(this.width - 75 - 3, 3)
+            new ButtonWidget.Builder(Text.literal("Accounts"), button -> client.setScreen(GuiThemes.get().accountsScreen()))
+                .position(width - 75 - 3, 3)
                 .size(75, 20)
                 .build()
         );
 
         addDrawableChild(
-                new ButtonWidget.Builder(Text.literal("Proxies"), button -> {
-                    client.setScreen(GuiThemes.get().proxiesScreen());
-                })
-                .position(this.width - 75 - 3 - 75 - 2, 3)
+            new ButtonWidget.Builder(Text.literal("Proxies"), button -> client.setScreen(GuiThemes.get().proxiesScreen()))
+                .position(width - 75 - 3 - 75 - 2, 3)
                 .size(75, 20)
                 .build()
         );
@@ -75,7 +71,11 @@ public class MultiplayerScreenMixin extends Screen {
         Proxy proxy = Proxies.get().getEnabled();
 
         String left = proxy != null ? "Using proxy " : "Not using a proxy";
-        String right = proxy != null ? (proxy.name.get() != null && !proxy.name.get().isEmpty() ? "(" + proxy.name.get() + ") " : "") + proxy.address.get() + ":" + proxy.port.get() : null;
+        String right = null;
+        if (proxy != null) {
+            String name = proxy.name.get() != null && !proxy.name.get().isEmpty() ? "(%s) ".formatted(proxy.name.get()) : "";
+            right = String.format("%s%s:%d", name, proxy.address.get(), proxy.port.get());
+        }
 
         textRenderer.drawWithShadow(matrices, left, x, y, textColor1);
         if (right != null) textRenderer.drawWithShadow(matrices, right, x + textRenderer.getWidth(left), y, textColor2);

--- a/src/main/java/meteordevelopment/meteorclient/systems/proxies/Proxies.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/proxies/Proxies.java
@@ -20,7 +20,7 @@ public class Proxies extends System<Proxies> implements Iterable<Proxy> {
     // https://regex101.com/r/gRHjnd/latest
     public static final Pattern PROXY_PATTERN = Pattern.compile("^(?:([\\w\\s]+)=)?((?:0*(?:\\d|[1-9]\\d|1\\d\\d|2[0-4]\\d|25[0-5])(?:\\.(?!:)|)){4}):(?!0)(\\d{1,4}|[1-5]\\d{4}|6[0-4]\\d{3}|65[0-4]\\d{2}|655[0-2]\\d|6553[0-5])(?i:@(socks[45]))?$", Pattern.MULTILINE);
 
-    private List<Proxy> proxies = new ArrayList<>();
+    private List<Proxy> proxyList = new ArrayList<>();
 
     public Proxies() {
         super("proxies");
@@ -31,26 +31,24 @@ public class Proxies extends System<Proxies> implements Iterable<Proxy> {
     }
 
     public boolean add(Proxy proxy) {
-        for (Proxy p : proxies) {
-            if (p.type.get().equals(proxy.type.get()) && p.address.get().equals(proxy.address.get()) && p.port.get() == proxy.port.get()) return false;
+        for (Proxy p : proxyList) {
+            if (p.equals(proxy)) return false;
         }
 
-        if (proxies.isEmpty()) proxy.enabled.set(true);
+        if (proxyList.isEmpty()) proxy.enabled.set(true);
 
-        proxies.add(proxy);
+        proxyList.add(proxy);
         save();
 
         return true;
     }
 
     public void remove(Proxy proxy) {
-        if (proxies.remove(proxy)) {
-            save();
-        }
+        if (proxyList.remove(proxy)) save();
     }
 
     public Proxy getEnabled() {
-        for (Proxy proxy : proxies) {
+        for (Proxy proxy : proxyList) {
             if (proxy.enabled.get()) return proxy;
         }
 
@@ -58,7 +56,7 @@ public class Proxies extends System<Proxies> implements Iterable<Proxy> {
     }
 
     public void setEnabled(Proxy proxy, boolean enabled) {
-        for (Proxy p : proxies) {
+        for (Proxy p : proxyList) {
             p.enabled.set(false);
         }
 
@@ -67,28 +65,25 @@ public class Proxies extends System<Proxies> implements Iterable<Proxy> {
     }
 
     public boolean isEmpty() {
-        return proxies.isEmpty();
+        return proxyList.isEmpty();
     }
 
     @NotNull
     @Override
     public Iterator<Proxy> iterator() {
-        return proxies.iterator();
+        return proxyList.iterator();
     }
 
     @Override
     public NbtCompound toTag() {
         NbtCompound tag = new NbtCompound();
-
-        tag.put("proxies", NbtUtils.listToTag(proxies));
-
+        tag.put("proxies", NbtUtils.listToTag(proxyList));
         return tag;
     }
 
     @Override
     public Proxies fromTag(NbtCompound tag) {
-        proxies = NbtUtils.listFromTag(tag.getList("proxies", 10), Proxy::new);
-
+        proxyList = NbtUtils.listFromTag(tag.getList("proxies", 10), Proxy::new);
         return this;
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/proxies/Proxy.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/proxies/Proxy.java
@@ -20,21 +20,21 @@ public class Proxy implements ISerializable<Proxy> {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
     private final SettingGroup sgOptional = settings.createGroup("Optional");
 
-    public Setting<String> name = sgGeneral.add(new StringSetting.Builder()
+    public final Setting<String> name = sgGeneral.add(new StringSetting.Builder()
         .name("name")
         .description("The name of the proxy.")
         .defaultValue("")
         .build()
     );
 
-    public Setting<ProxyType> type = sgGeneral.add(new EnumSetting.Builder<ProxyType>()
+    public final Setting<ProxyType> type = sgGeneral.add(new EnumSetting.Builder<ProxyType>()
         .name("type")
         .description("The type of proxy.")
-        .defaultValue(ProxyType.Socks5)
+        .defaultValue(ProxyType.SOCKS_5)
         .build()
     );
 
-    public Setting<String> address = sgGeneral.add(new StringSetting.Builder()
+    public final Setting<String> address = sgGeneral.add(new StringSetting.Builder()
         .name("address")
         .description("The ip address of the proxy.")
         .defaultValue("")
@@ -42,7 +42,7 @@ public class Proxy implements ISerializable<Proxy> {
         .build()
     );
 
-    public Setting<Integer> port = sgGeneral.add(new IntSetting.Builder()
+    public final Setting<Integer> port = sgGeneral.add(new IntSetting.Builder()
         .name("port")
         .description("The port of the proxy.")
         .defaultValue(0)
@@ -51,7 +51,7 @@ public class Proxy implements ISerializable<Proxy> {
         .build()
     );
 
-    public Setting<Boolean> enabled = sgGeneral.add(new BoolSetting.Builder()
+    public final Setting<Boolean> enabled = sgGeneral.add(new BoolSetting.Builder()
         .name("enabled")
         .description("Whether the proxy is enabled.")
         .defaultValue(true)
@@ -60,18 +60,18 @@ public class Proxy implements ISerializable<Proxy> {
 
     // Optional
 
-    public Setting<String> username = sgOptional.add(new StringSetting.Builder()
+    public final Setting<String> username = sgOptional.add(new StringSetting.Builder()
         .name("username")
         .description("The username of the proxy.")
         .defaultValue("")
         .build()
     );
 
-    public Setting<String> password = sgOptional.add(new StringSetting.Builder()
+    public final Setting<String> password = sgOptional.add(new StringSetting.Builder()
         .name("password")
         .description("The password of the proxy.")
         .defaultValue("")
-        .visible(() -> type.get().equals(ProxyType.Socks5))
+        .visible(() -> type.get() == ProxyType.SOCKS_5)
         .build()
     );
 
@@ -81,21 +81,21 @@ public class Proxy implements ISerializable<Proxy> {
     }
 
     public boolean resolveAddress() {
-        int port = this.port.get();
-        String address = this.address.get();
+        int p = port.get();
+        String addr = address.get();
 
-        if (port <= 0 || port > 65535 || address == null || address.isBlank()) return false;
-        InetSocketAddress socketAddress = new InetSocketAddress(address, port);
+        if (p <= 0 || p > 65535 || addr == null || addr.isBlank()) return false;
+        InetSocketAddress socketAddress = new InetSocketAddress(addr, p);
         return !socketAddress.isUnresolved();
     }
 
     public static class Builder {
-        protected ProxyType type = ProxyType.Socks5;
+        protected ProxyType type = ProxyType.SOCKS_5;
         protected String address = "";
-        protected int port = 0;
+        protected int port;
         protected String name = "";
         protected String username = "";
-        protected boolean enabled = false;
+        protected boolean enabled;
 
         public Builder type(ProxyType type) {
             this.type = type;
@@ -130,7 +130,7 @@ public class Proxy implements ISerializable<Proxy> {
         public Proxy build() {
             Proxy proxy = new Proxy();
 
-            if (!type.equals(proxy.type.getDefaultValue())) proxy.type.set(type);
+            if (type != proxy.type.getDefaultValue()) proxy.type.set(type);
             if (!address.equals(proxy.address.getDefaultValue())) proxy.address.set(address);
             if (port != proxy.port.getDefaultValue()) proxy.port.set(port);
             if (!name.equals(proxy.name.getDefaultValue())) proxy.name.set(name);
@@ -144,18 +144,13 @@ public class Proxy implements ISerializable<Proxy> {
     @Override
     public NbtCompound toTag() {
         NbtCompound tag = new NbtCompound();
-
         tag.put("settings", settings.toTag());
-
         return tag;
     }
 
     @Override
     public Proxy fromTag(NbtCompound tag) {
-        if (tag.contains("settings")) {
-            settings.fromTag(tag.getCompound("settings"));
-        }
-
+        if (tag.contains("settings")) settings.fromTag(tag.getCompound("settings"));
         return this;
     }
 
@@ -164,6 +159,8 @@ public class Proxy implements ISerializable<Proxy> {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Proxy proxy = (Proxy) o;
-        return Objects.equals(proxy.address.get(), this.address.get()) && Objects.equals(proxy.port.get(), this.port.get());
+        return Objects.equals(proxy.address.get(), address.get())
+            && Objects.equals(proxy.port.get(), port.get())
+            && proxy.type.get() == type.get();
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/proxies/ProxyType.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/proxies/ProxyType.java
@@ -8,15 +8,13 @@ package meteordevelopment.meteorclient.systems.proxies;
 import org.jetbrains.annotations.Nullable;
 
 public enum ProxyType {
-    Socks4,
-    Socks5;
+    SOCKS_4,
+    SOCKS_5;
 
     @Nullable
     public static ProxyType parse(String group) {
         for (ProxyType type : values()) {
-            if (type.name().equalsIgnoreCase(group)) {
-                return type;
-            }
+            if (type.name().equalsIgnoreCase(group)) return type;
         }
         return null;
     }


### PR DESCRIPTION
Minor cleanup, replaced string concat with .format for readability, corrected equals method.

NOTE: the current check used to differentiate between SOCKS v4 and v5 is not that effective.
Whenever you get proxies from any online list, they don't have the tag that the current regex filter tries to match.

A possible solution would be trying to connect with v5, and fallback to v4 if that doesn't work.