### PR TITLE
Improve Hide HUD

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/Hud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/Hud.java
@@ -105,7 +105,7 @@ public class Hud extends System<Hud> implements Iterable<HudElement> {
     );
 
     private boolean resetToDefaultElements;
-    private boolean wasMenuScreen, wasHudHidden;
+    private boolean wasHudHidden;
 
     public Hud() {
         super("hud");
@@ -249,12 +249,15 @@ public class Hud extends System<Hud> implements Iterable<HudElement> {
     @EventHandler(priority = EventPriority.LOWEST)
     private void onOpenScreen(OpenScreenEvent event) {
         if (hideInMenu.get()) {
-            if (!wasMenuScreen) wasHudHidden = !this.active;
-
-            if (event.screen instanceof GameMenuScreen || event.screen instanceof HandledScreen) this.active = false;
-            else if (!wasHudHidden) this.active = true;
+            if (event.screen instanceof GameMenuScreen || event.screen instanceof HandledScreen<?>) {
+                wasHudHidden = active;
+                active = false;
+            }
+            else if (wasHudHidden) {
+                wasHudHidden = false;
+                active = true;
+            }
         }
-        wasMenuScreen = event.screen instanceof GameMenuScreen || event.screen instanceof HandledScreen;
     }
 
     public boolean hasCustomFont() {


### PR DESCRIPTION
Hides **Meteor** hud when user is in **inventory** or **pause menu**. Closes #2075

Note : This feature should not be confused with the [Hide HUD in GUI Settings](https://github.com/MeteorDevelopment/meteor-client/blob/b67f0a599333d407284f5f6c3fcdf256a4182506/src/main/java/meteordevelopment/meteorclient/gui/GuiTheme.java#L273) option, which hides both the Minecraft and Meteor HUD when the user is in the **Meteor GUI**.