### PR TITLE
Anti packet kick update

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/AntiPacketKick.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/AntiPacketKick.java
@@ -5,10 +5,30 @@
 
 package meteordevelopment.meteorclient.systems.modules.misc;
 
+import meteordevelopment.meteorclient.settings.BoolSetting;
+import meteordevelopment.meteorclient.settings.Setting;
+import meteordevelopment.meteorclient.settings.SettingGroup;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
 
 public class AntiPacketKick extends Module {
+    private final SettingGroup sgGeneral = settings.getDefaultGroup();
+
+    public final Setting<Boolean> catchExceptions = sgGeneral.add(new BoolSetting.Builder()
+        .name("catch-exceptions")
+        .description("Drops corrupted packets.")
+        .defaultValue(false)
+        .build()
+    );
+
+    public final Setting<Boolean> logExceptions = sgGeneral.add(new BoolSetting.Builder()
+        .name("log-exceptions")
+        .description("Logs caught exceptions.")
+        .defaultValue(false)
+        .visible(catchExceptions::get)
+        .build()
+    );
+
     public AntiPacketKick() {
         super(Categories.Misc, "anti-packet-kick", "Attempts to prevent you from being disconnected by large packets.");
     }


### PR DESCRIPTION
closes #3242 by dropping corrupted packets.