### PR TITLE
ESP but faster

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/ESP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/ESP.java
@@ -29,6 +29,8 @@ import net.minecraft.util.math.Box;
 import net.minecraft.util.math.MathHelper;
 import org.joml.Vector3d;
 
+import javax.annotation.Nullable;
+
 public class ESP extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
     private final SettingGroup sgColors = settings.createGroup("Colors");
@@ -296,9 +298,10 @@ public class ESP extends Module {
         if (!entities.get().getBoolean(entity.getType())) return true;
         if (entity == mc.player && ignoreSelf.get()) return true;
         if (entity == mc.cameraEntity && mc.options.getPerspective().isFirstPerson()) return true;
-        return !EntityUtils.isInRenderDistance(entity) || getFadeAlpha(entity) == 0;
+        return !EntityUtils.isInRenderDistance(entity);
     }
 
+    @Nullable
     public Color getColor(Entity entity) {
         if (!entities.get().getBoolean(entity.getType())) return null;
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/player/PlayerUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/PlayerUtils.java
@@ -50,8 +50,8 @@ public class PlayerUtils {
             return color.set(Config.get().friendColor.get()).a(defaultColor.a);
         }
 
-        if (!color.set(TextUtils.getMostPopularColor(entity.getDisplayName())).equals(WHITE) && Config.get().useTeamColor.get()) {
-            return color.set(color).a(defaultColor.a);
+        if (Config.get().useTeamColor.get() && !color.set(TextUtils.getMostPopularColor(entity.getDisplayName())).equals(WHITE)) {
+            return color.a(defaultColor.a);
         }
 
         return defaultColor;


### PR DESCRIPTION
1. `ESP.getColor()` is a fairly expensive method and it was being called for every `Entity` regardless of whether ESP was even enabled, so I turned it into a `Supplier<Color>` that's only called if it can render the `Entity`.
2. `ESP.getColor()` could always return `null`, so I marked it as `@Nullable`
3. `ESP.shouldSkip()` used to return `true` if `ESP.getFadeAlpha() == 0`, I replaced that with a null check, since `ESP.getColor()` already returned `null` if `ESP.getFadeAlpha() == 0`
4. `TextUtils.getColoredCharacterCount()` now returns an `Object2IntMap<Color>` instead of a `Map<Color, Integer>`
5. Rewrote `TextUtils.getMostPopularColor()` to not use streams
6. `TextUtils.toColorTextList()`, replaced `str.equals("")` with `str.isEmpty()`