### PR TITLE
Added .ender-chest command

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/commands/Commands.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/commands/Commands.java
@@ -55,6 +55,7 @@ public class Commands extends System<Commands> {
         add(new NbtCommand());
         add(new NotebotCommand());
         add(new PeekCommand());
+        add(new EnderChestCommand());
         add(new ProfilesCommand());
         add(new ReloadCommand());
         add(new ResetCommand());

--- a/src/main/java/meteordevelopment/meteorclient/systems/commands/commands/EnderChestCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/commands/commands/EnderChestCommand.java
@@ -1,0 +1,29 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.systems.commands.commands;
+
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import meteordevelopment.meteorclient.systems.commands.Command;
+import meteordevelopment.meteorclient.utils.Utils;
+import net.minecraft.command.CommandSource;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+
+import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
+
+public class EnderChestCommand extends Command {
+    public EnderChestCommand() {
+        super("ender-chest", "Allows you to preview memory of your ender chest.", "ec", "echest");
+    }
+
+    @Override
+    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+        builder.executes(context -> {
+            Utils.openContainer(Items.ENDER_CHEST.getDefaultStack(), new ItemStack[27], true);
+            return SINGLE_SUCCESS;
+        });
+    }
+}

--- a/src/main/java/meteordevelopment/meteorclient/systems/commands/commands/MacroCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/commands/commands/MacroCommand.java
@@ -23,7 +23,7 @@ public class MacroCommand extends Command {
         builder.then(
             argument("macro", MacroArgumentType.create())
                 .executes(context -> {
-                    Macro macro = context.getArgument("macro", Macro.class);
+                    Macro macro = MacroArgumentType.get(context);
                     macro.onAction();
                     return SINGLE_SUCCESS;
                 }));

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/ItemHighlight.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/ItemHighlight.java
@@ -38,7 +38,7 @@ public class ItemHighlight extends Module {
     }
 
     public int getColor(ItemStack stack) {
-        if (items.get().contains(stack.getItem()) && isActive()) return color.get().getPacked();
+        if (stack != null && items.get().contains(stack.getItem()) && isActive()) return color.get().getPacked();
         return -1;
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/PeekScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/PeekScreen.java
@@ -34,9 +34,9 @@ public class PeekScreen extends ShulkerBoxScreen {
 
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
-        BetterTooltips toolips = Modules.get().get(BetterTooltips.class);
+        BetterTooltips tooltips = Modules.get().get(BetterTooltips.class);
 
-        if (button == GLFW.GLFW_MOUSE_BUTTON_MIDDLE && focusedSlot != null && !focusedSlot.getStack().isEmpty() && mc.player.currentScreenHandler.getCursorStack().isEmpty() && toolips.middleClickOpen()) {
+        if (button == GLFW.GLFW_MOUSE_BUTTON_MIDDLE && focusedSlot != null && !focusedSlot.getStack().isEmpty() && mc.player.currentScreenHandler.getCursorStack().isEmpty() && tooltips.middleClickOpen()) {
             return Utils.openContainer(focusedSlot.getStack(), contents, false);
         }
         return false;


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature

## Description

##### Added `.ender-chest` command: 
- Allows users to preview memory of their Ender chest.
- Aliases : `.ec`, `.echest`

## Related issues

Closes #1961

# How Has This Been Tested?

Tested on dedicated Paper server.
![image](https://user-images.githubusercontent.com/80271842/218486248-09f42ce0-41b2-41fa-a536-38e05a749bea.png)

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
