### PR TITLE
Removed useless square-rooting

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/utils/entity/TargetUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/entity/TargetUtils.java
@@ -101,6 +101,6 @@ public class TargetUtils {
         double e1pitch = Math.abs(Rotations.getPitch(e1) - mc.player.getPitch());
         double e2pitch = Math.abs(Rotations.getPitch(e2) - mc.player.getPitch());
 
-        return Double.compare(Math.sqrt(e1yaw * e1yaw + e1pitch * e1pitch), Math.sqrt(e2yaw * e2yaw + e2pitch * e2pitch));
+        return Double.compare(((double) e1yaw * e1yaw + e1pitch * e1pitch), ((double) e2yaw * e2yaw + e2pitch * e2pitch));
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/utils/entity/TargetUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/entity/TargetUtils.java
@@ -101,6 +101,6 @@ public class TargetUtils {
         double e1pitch = Math.abs(Rotations.getPitch(e1) - mc.player.getPitch());
         double e2pitch = Math.abs(Rotations.getPitch(e2) - mc.player.getPitch());
 
-        return Double.compare(((double) e1yaw * e1yaw + e1pitch * e1pitch), ((double) e2yaw * e2yaw + e2pitch * e2pitch));
+        return Double.compare(e1yaw * e1yaw + e1pitch * e1pitch, e2yaw * e2yaw + e2pitch * e2pitch);
     }
 }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [x] New feature

## Description

Calculating sqrt is an operation that requires a lot of resources. As Double.compare only compares two numbers, we don‘t need to calculate the sqrt, as the square of whatever that number is is always bigger as well. 

(example)
sqrt(4) > sqrt(9) 
can be converted into
4 > 9

in other words,
if sqrt(x) > sqrt(y), then x > y
if sqrt(x) < sqrt(y), then x < y
if sqrt(x) == sqrt(y), then x == y

So, dont sqrt if it isnt needed, as computers need to calculate a lot

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
