### PR TITLE
crashfix between armor storage and armor swap. also a little refactor

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayerInteractionManagerMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayerInteractionManagerMixin.java
@@ -13,7 +13,9 @@ import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.misc.InventoryTweaks;
 import meteordevelopment.meteorclient.systems.modules.player.BreakDelay;
 import meteordevelopment.meteorclient.systems.modules.player.Reach;
+import meteordevelopment.meteorclient.utils.player.InvUtils;
 import meteordevelopment.meteorclient.utils.player.Rotations;
+import meteordevelopment.meteorclient.utils.player.SlotUtils;
 import meteordevelopment.meteorclient.utils.world.BlockUtils;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.network.ClientPlayerEntity;
@@ -73,8 +75,11 @@ public abstract class ClientPlayerInteractionManagerMixin implements IClientPlay
                     clickSlot(syncId, 17, armorSlot, SlotActionType.SWAP, player); //armor slot <-> inv slot
                     ci.cancel();
                 } else if (actionType == SlotActionType.SWAP) {
-                    clickSlot(syncId, 36 + button, armorSlot, SlotActionType.SWAP, player); //invert swap
-                    ci.cancel();
+                    // clickSlot would call this method again, so we would end up in an infinite loop
+                    if (!SlotUtils.isArmor(button)) {
+                        clickSlot(syncId, SlotUtils.indexToId(button), armorSlot, SlotActionType.SWAP, player); //invert swap
+                        ci.cancel();
+                    }
                 }
             }
         }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/InventoryTweaks.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/InventoryTweaks.java
@@ -312,27 +312,29 @@ public class InventoryTweaks extends Module {
     }
 
     private boolean swapArmor() {  // would mixin to use method in ArmorItem, but it's buggy and unreliable on servers
-        if (mc.currentScreen != null) {
-            if (!(mc.currentScreen instanceof InventoryScreen screen)) return false;
-            Slot focusedSlot = ((HandledScreenAccessor) screen).getFocusedSlot();
-            if (focusedSlot == null || !isWearable(focusedSlot.getStack())) return false;
+        int index = -1;
+        ItemStack handStack = null;
 
-            ItemStack itemStack = focusedSlot.getStack();
-            EquipmentSlot equipmentSlot = LivingEntity.getPreferredEquipmentSlot(itemStack);
-
-            //the way mojang handles the inventory is awful, and it took me too long to figure this out
-            mc.interactionManager.clickSlot(mc.player.currentScreenHandler.syncId, SlotUtils.indexToId(focusedSlot.getIndex()),
-                SlotUtils.ARMOR_START + equipmentSlot.getEntitySlotId(), SlotActionType.SWAP, mc.player);
-
-        } else {
-            ItemStack itemStack = mc.player.getMainHandStack();
-            if (!isWearable(itemStack)) return false;
-            EquipmentSlot equipmentSlot = LivingEntity.getPreferredEquipmentSlot(itemStack);
-
-            mc.interactionManager.clickSlot(mc.player.currentScreenHandler.syncId, SlotUtils.indexToId(SlotUtils.ARMOR_START + (3 - equipmentSlot.getEntitySlotId())),
-                mc.player.getInventory().selectedSlot, SlotActionType.SWAP, mc.player);
-
+        // get slot index and stack
+        if (mc.currentScreen instanceof InventoryScreen screen) {
+            Slot handSlot = ((HandledScreenAccessor) screen).getFocusedSlot();
+            if (handSlot != null) {
+                handStack = handSlot.getStack();
+                index = handSlot.getIndex();
+            }
+        } else if (mc.currentScreen == null) {
+            handStack = mc.player.getMainHandStack();
+            index = mc.player.getInventory().selectedSlot;
         }
+
+        if (handStack == null || !isWearable(handStack)) return false;
+
+        EquipmentSlot equipmentSlot = LivingEntity.getPreferredEquipmentSlot(handStack);
+        int equipmentSlotId = SlotUtils.indexToId(SlotUtils.ARMOR_START + (3 - equipmentSlot.getEntitySlotId()));
+
+        mc.interactionManager.clickSlot(mc.player.currentScreenHandler.syncId, equipmentSlotId, index,
+            SlotActionType.SWAP, mc.player);
+
         return true;
     }
 


### PR DESCRIPTION
## Type of change

- [ x] Bug fix
- [ ] New feature

## Description

Left clicking an armor piece in an armor slot crashes the game if both armor swap and armor storage are enabled.

## Related issues

Mention any issues that this pr relates to.

# How Has This Been Tested?

Videos or screenshots of the changes if applicable.

# Checklist:

- [ probably] My code follows the style guidelines of this project.
- [x ] I have added comments to my code in more complex areas.
- [ -] I have tested the code in both development and production environments.
