### PR TITLE
Added baritone.eta to starscript (this time minus the crash)

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/MeteorStarscript.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/MeteorStarscript.java
@@ -405,6 +405,7 @@ public class MeteorStarscript {
 
     // Returns the ETA in seconds
     private static Value baritoneETA() {
+        if (mc.player == null) return Value.number(0);
         Optional<Double> ticksTillGoal = BaritoneAPI.getProvider().getPrimaryBaritone().getPathingBehavior().estimatedTicksToGoal();
         return ticksTillGoal.map(aDouble -> Value.number(aDouble / 20)).orElseGet(() -> Value.number(0));
     }

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/MeteorStarscript.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/MeteorStarscript.java
@@ -96,6 +96,7 @@ public class MeteorStarscript {
             .set("distance_to_goal", MeteorStarscript::baritoneDistanceToGoal)
             .set("process", MeteorStarscript::baritoneProcess)
             .set("process_name", MeteorStarscript::baritoneProcessName)
+            .set("eta", MeteorStarscript::baritoneETA)
         );
 
         // Camera
@@ -400,6 +401,12 @@ public class MeteorStarscript {
         String name = SB.toString();
         SB.setLength(0);
         return Value.string(name);
+    }
+
+    // Returns the ETA in seconds
+    private static Value baritoneETA() {
+        Optional<Double> ticksTillGoal = BaritoneAPI.getProvider().getPrimaryBaritone().getPathingBehavior().estimatedTicksToGoal();
+        return ticksTillGoal.map(aDouble -> Value.number(aDouble / 20)).orElseGet(() -> Value.number(0));
     }
 
     private static Value oppositeX(boolean camera) {


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [X] New feature

## Description
Added baritone.eta to starscript. Will show the currently estimated time baritone needs in seconds. Returns 0 if none

## Related issues
#3406 and fixed crash described in #3408 

# How Has This Been Tested?
Distance in image has been floored. Is normally as long as the blocks one
![image](https://user-images.githubusercontent.com/43420467/222974260-ce09ea46-6c0c-43bc-9618-cd3cfca56ef6.png)

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
