### PR TITLE
Fixed not sendPlayerMsg not sending commands that require signature

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/utils/player/ChatUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/ChatUtils.java
@@ -68,7 +68,7 @@ public class ChatUtils {
     public static void sendPlayerMsg(String message) {
         mc.inGameHud.getChatHud().addToMessageHistory(message);
 
-        if (message.startsWith("/")) mc.player.networkHandler.sendCommand(message.substring(1));
+        if (message.startsWith("/")) mc.player.networkHandler.sendChatCommand(message.substring(1));
         else mc.player.networkHandler.sendChatMessage(message);
     }
 


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description
sendPlayerMsg didn't sent commands that require a signature (/msg, /me, ...)

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
