### PR TITLE
Added anti chat clear in BetterChat

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/ChatHudMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ChatHudMixin.java
@@ -102,6 +102,14 @@ public abstract class ChatHudMixin implements IChatHud {
         return list.size();
     }
 
+    @Inject(method = "clear(Z)V", at = @At("HEAD"), cancellable = true)
+    private void onClear(CallbackInfo info) {
+        BetterChat betterChat = Modules.get().get(BetterChat.class);
+        if (betterChat.antiHistClear.get()) {
+            info.cancel();
+        }
+    }
+
     @Inject(method = "render", at = @At("TAIL"))
     private void onRender(MatrixStack matrices, int currentTick, int mouseX, int mouseY, CallbackInfo info) {
         if (!Modules.get().get(BetterChat.class).displayPlayerHeads()) return;

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterChat.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterChat.java
@@ -74,7 +74,7 @@ public class BetterChat extends Module {
     );
 
     public final Setting<Boolean> antiHistClear = sgGeneral.add(new BoolSetting.Builder()
-        .name("anti-clear")
+        .name("keep-history")
         .description("Prevents the chat history from being cleared when disconnecting.")
         .defaultValue(true)
         .build()

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterChat.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterChat.java
@@ -73,6 +73,13 @@ public class BetterChat extends Module {
         .build()
     );
 
+    public final Setting<Boolean> antiHistClear = sgGeneral.add(new BoolSetting.Builder()
+        .name("anti-clear")
+        .description("Prevents the chat history from being cleared when disconnecting.")
+        .defaultValue(true)
+        .build()
+    );
+
     // Filter
 
     private final Setting<Boolean> antiSpam = sgFilter.add(new BoolSetting.Builder()


### PR DESCRIPTION
Prevents the deletion of the chat and chat history (up/down keys) when disconnecting

## Type of change

- [ ] Bug fix
- [X] New feature

## Description
Prevents the deletion of the chat and chat history (up/down keys) when disconnecting

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
