### PR TITLE
Fixed getting an invalid signature error

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/MinecraftClientAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MinecraftClientAccessor.java
@@ -5,8 +5,10 @@
 
 package meteordevelopment.meteorclient.mixin;
 
+import com.mojang.authlib.minecraft.UserApiService;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.resource.ResourceReloadLogger;
+import net.minecraft.client.util.ProfileKeys;
 import net.minecraft.client.util.Session;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Mutable;
@@ -40,4 +42,18 @@ public interface MinecraftClientAccessor {
 
     @Invoker("doAttack")
     boolean leftClick();
+
+    @Mutable
+    @Accessor("profileKeys")
+    void setProfileKeys(ProfileKeys keys);
+
+    @Accessor("userApiService")
+    UserApiService getUserApiService();
+
+    @Mutable
+    @Accessor
+    void setUserApiService(UserApiService apiService);
+
+    @Accessor("session")
+    Session getSession();
 }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Finally fixed the issue where switching to a new microsoft account after launching the game would cause you to get the error 'Invalid signature for profile public key' when joining servers. Soda was on the right path with his pr, and frankly I'm still uncertain exactly why his doesn't work and mine does. Overall, this was very painful, but at least it's done.

## Related issues

Closes #2598, #3001

# How Has This Been Tested?

Tested on a local paper server, and on minehut. In both cases, I could log in, and chat and run commands after switching accounts, so I am confident the issue is finally resolved.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
