### PR TITLE
Add BogusAccept for ServerSpoof, Improve PacketEvent

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/events/packets/PacketEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/packets/PacketEvent.java
@@ -6,17 +6,20 @@
 package meteordevelopment.meteorclient.events.packets;
 
 import meteordevelopment.meteorclient.events.Cancellable;
+import net.minecraft.network.ClientConnection;
 import net.minecraft.network.Packet;
 
 public class PacketEvent extends Cancellable {
     public Packet<?> packet;
+    public ClientConnection connection;
 
     public static class Receive extends PacketEvent {
         private static final Receive INSTANCE = new Receive();
 
-        public static Receive get(Packet<?> packet) {
+        public static Receive get(Packet<?> packet, ClientConnection connection) {
             INSTANCE.setCancelled(false);
             INSTANCE.packet = packet;
+            INSTANCE.connection = connection;
             return INSTANCE;
         }
     }
@@ -24,9 +27,10 @@ public class PacketEvent extends Cancellable {
     public static class Send extends PacketEvent {
         private static final Send INSTANCE = new Send();
 
-        public static Send get(Packet<?> packet) {
+        public static Send get(Packet<?> packet, ClientConnection connection) {
             INSTANCE.setCancelled(false);
             INSTANCE.packet = packet;
+            INSTANCE.connection = connection;
             return INSTANCE;
         }
     }
@@ -34,8 +38,9 @@ public class PacketEvent extends Cancellable {
     public static class Sent extends PacketEvent {
         private static final Sent INSTANCE = new Sent();
 
-        public static Sent get(Packet<?> packet) {
+        public static Sent get(Packet<?> packet, ClientConnection connection) {
             INSTANCE.packet = packet;
+            INSTANCE.connection = connection;
             return INSTANCE;
         }
     }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/ServerSpoof.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/ServerSpoof.java
@@ -15,6 +15,7 @@ import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.orbit.EventHandler;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.network.packet.c2s.play.CustomPayloadC2SPacket;
+import net.minecraft.network.packet.c2s.play.ResourcePackStatusC2SPacket;
 import net.minecraft.network.packet.s2c.play.ResourcePackSendS2CPacket;
 import net.minecraft.text.ClickEvent;
 import net.minecraft.text.HoverEvent;
@@ -48,6 +49,14 @@ public class ServerSpoof extends Module {
         .name("resource-pack")
         .description("Spoof accepting server resource pack.")
         .defaultValue(false)
+        .build()
+    );
+
+    private final Setting<Boolean> bogusAccept = sgGeneral.add(new BoolSetting.Builder()
+        .name("bogus-accept")
+        .description("Send fake packets to server that you accepted the resource pack.")
+        .defaultValue(false)
+        .visible(resourcePack::get)
         .build()
     );
 
@@ -112,6 +121,11 @@ public class ServerSpoof extends Module {
                 msg.append(link);
                 msg.append(".");
                 info(msg);
+
+                if (bogusAccept.get()) {
+                    event.connection.send(new ResourcePackStatusC2SPacket(ResourcePackStatusC2SPacket.Status.ACCEPTED));
+                    event.connection.send(new ResourcePackStatusC2SPacket(ResourcePackStatusC2SPacket.Status.SUCCESSFULLY_LOADED));
+                }
             }
         }
     }


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature

## Description

Automatically sends fake packets to the server that client accepted their resource pack.

## Related issues

Continuation of #3209

# How Has This Been Tested?

On local paper server with a required resource pack.

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
