### PR TITLE
Fixed auto gap not eating normal gapples

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoGap.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoGap.java
@@ -276,11 +276,8 @@ public class AutoGap extends Module {
     }
 
     private int findSlot() {
-        boolean preferEGap = this.preferEGap.get();
-        if (requiresEGap) preferEGap = true;
-
+        boolean preferEGap = this.preferEGap.get() || requiresEGap;
         int slot = -1;
-        Item currentItem = null;
 
         for (int i = 0; i < 9; i++) {
             // Skip if item stack is empty
@@ -291,34 +288,17 @@ public class AutoGap extends Module {
             if (isNotGapOrEGap(stack)) continue;
             Item item = stack.getItem();
 
-            // If this is the first apple found then set it without looking at preferEGap setting
-            if (currentItem == null) {
+            // If egap was found and preferEGap is true we can return the current slot
+            if (item == Items.ENCHANTED_GOLDEN_APPLE && preferEGap) {
                 slot = i;
-                currentItem = item;
+                break;
             }
-            else {
-                // Skip if current item and item are the same
-                if (currentItem == item) continue;
-
-                // If egap was found and preferEGap is true we can return the current slot
-                if (item == Items.ENCHANTED_GOLDEN_APPLE && preferEGap) {
-                    slot = i;
-                    currentItem = item;
-
-                    break;
-                }
-                // If gap was found and preferEGap is false we can return the current slot
-                else if (item == Items.GOLDEN_APPLE && !preferEGap) {
-                    slot = i;
-                    currentItem = item;
-
-                    break;
-                }
+            // If gap was found and egap is not required we can return the current slot
+            else if (item == Items.GOLDEN_APPLE && !requiresEGap) {
+                slot = i;
+                if (!preferEGap) break;
             }
         }
-
-        // If requiresEGap is true but no egap was found return -1
-        if (requiresEGap && currentItem != Items.ENCHANTED_GOLDEN_APPLE) return -1;
 
         return slot;
     }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoGap.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoGap.java
@@ -278,7 +278,7 @@ public class AutoGap extends Module {
     }
 
     private int findSlot() {
-        boolean preferEGap = this.preferEGap.get() || requiresEGap;
+        boolean preferEGap = this.allowEgap.get() || requiresEGap;
         int slot = -1;
 
         for (int i = 0; i < 9; i++) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoGap.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoGap.java
@@ -42,9 +42,9 @@ public class AutoGap extends Module {
 
     // General
 
-    private final Setting<Boolean> preferEGap = sgGeneral.add(new BoolSetting.Builder()
-            .name("prefer-egap")
-            .description("Prefers to eat E-Gap over Gaps if found.")
+    private final Setting<Boolean> allowEgap = sgGeneral.add(new BoolSetting.Builder()
+            .name("allow-egap")
+            .description("Allow eating E-Gaps over Gaps if found.")
             .defaultValue(true)
             .build()
     );
@@ -83,6 +83,7 @@ public class AutoGap extends Module {
             .name("potions-fire-resistance")
             .description("If it should eat when Fire Resistance runs out. Requires E-Gaps.")
             .defaultValue(true)
+            .visible(allowEgap::get)
             .build()
     );
 
@@ -90,6 +91,7 @@ public class AutoGap extends Module {
             .name("potions-absorption")
             .description("If it should eat when Resistance runs out. Requires E-Gaps.")
             .defaultValue(false)
+            .visible(allowEgap::get)
             .build()
     );
 


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

Fixed Auto Gap not eating normal gapples if `preferEGap` was enabled and no e-gapples were found in Hotbar.

## Related issues

Resolves #3188

# How Has This Been Tested?

Tested on dedicated paper server.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
