### PR TITLE
fix infinite chatbox

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayNetworkHandlerMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayNetworkHandlerMixin.java
@@ -149,7 +149,7 @@ public abstract class ClientPlayNetworkHandlerMixin {
                 ChatUtils.error(e.getMessage());
             }
 
-           client.inGameHud.getChatHud().addToMessageHistory(message);
+            client.inGameHud.getChatHud().addToMessageHistory(message);
             ci.cancel();
         }
     }

--- a/src/main/java/meteordevelopment/meteorclient/mixin/StringHelperMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/StringHelperMixin.java
@@ -17,6 +17,6 @@ public class StringHelperMixin {
 
     @ModifyArg(method = "truncateChat", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/StringHelper;truncate(Ljava/lang/String;IZ)Ljava/lang/String;"), index = 1)
     private static int injected(int maxLength) { // this method is only used in one place, to truncate chat messages, so it's fine to do this
-        return (Modules.get().get(BetterChat.class).isInfiniteChatBox() ? Integer.MAX_VALUE : 256);
+        return (Modules.get().get(BetterChat.class).isInfiniteChatBox() ? Integer.MAX_VALUE : maxLength);
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/mixin/StringHelperMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/StringHelperMixin.java
@@ -1,0 +1,22 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.mixin;
+
+import meteordevelopment.meteorclient.systems.modules.Modules;
+import meteordevelopment.meteorclient.systems.modules.misc.BetterChat;
+import net.minecraft.util.StringHelper;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+@Mixin(StringHelper.class)
+public class StringHelperMixin {
+
+    @ModifyArg(method = "truncateChat", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/StringHelper;truncate(Ljava/lang/String;IZ)Ljava/lang/String;"), index = 1)
+    private static int injected(int maxLength) { // this method is only used in one place, to truncate chat messages, so it's fine to do this
+        return (Modules.get().get(BetterChat.class).isInfiniteChatBox() ? Integer.MAX_VALUE : 256);
+    }
+}

--- a/src/main/resources/meteor-client.mixins.json
+++ b/src/main/resources/meteor-client.mixins.json
@@ -149,6 +149,7 @@
     "SplashTextResourceSupplierMixin",
     "StatusEffectInstanceAccessor",
     "StatusEffectInstanceMixin",
+    "StringHelperMixin",
     "SweetBerryBushBlockMixin",
     "TextHandlerAccessor",
     "TextRendererMixin",


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

I assume infinite chatbox was broken after 8db58dfe2285cee7618437f1ba9ac3e473e2153d, since before that meteor commands were captured before they were truncated in the sendMessage method, allowing infinite chatbox to work more easily. This resolves the issue.

## Related issues

Closes #3339
Closes #3346 

# How Has This Been Tested?

Local paper server with an extremely long .give command

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
