### PR TITLE
Fix Build Hight to work on 1.17+ worlds

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/BuildHeight.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/BuildHeight.java
@@ -21,8 +21,9 @@ public class BuildHeight extends Module {
     @EventHandler
     private void onSendPacket(PacketEvent.Send event) {
         if (!(event.packet instanceof PlayerInteractBlockC2SPacket p)) return;
-
-        if (p.getBlockHitResult().getPos().y >= 255 && p.getBlockHitResult().getSide() == Direction.UP) {
+        
+        int maxheight = (mc.world.getDimension().height() > 256) ? 319 : 255;
+        if (p.getBlockHitResult().getPos().y >= maxheight && p.getBlockHitResult().getSide() == Direction.UP) {
             ((BlockHitResultAccessor) p.getBlockHitResult()).setSide(Direction.DOWN);
         }
     }


### PR DESCRIPTION
I fixed the bug that in 1.17+ worlds blocks would be placed under the block you clicked on if you are on y level 255 or higher

I had to use an If because mc.world.getDimension().height() for some reason returns 382 on 1.18 worlds
