### PR TITLE
Fix Scaffold FastTower

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Scaffold.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Scaffold.java
@@ -306,7 +306,7 @@ public class Scaffold extends Module {
                     mc.player.setVelocity(0, -0.28f, 0);
             }
         } else {
-            if (mc.options.jumpKey.isPressed() && !mc.options.sneakKey.isPressed() && fastTower.get()) {
+            if (mc.options.jumpKey.isPressed() && !mc.options.sneakKey.isPressed() && fastTower.get() && InvUtils.testInHotbar(stack -> stack.getItem() instanceof BlockItem)) {
                 Vec3d vel = mc.player.getVelocity();
                 mc.player.setVelocity(cancelVelocity.get() ? 0 : vel.x, 0.42, cancelVelocity.get() ? 0 : vel.z);
             }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Scaffold.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Scaffold.java
@@ -306,7 +306,7 @@ public class Scaffold extends Module {
                     mc.player.setVelocity(0, -0.28f, 0);
             }
         } else {
-            if (mc.options.jumpKey.isPressed() && !mc.options.sneakKey.isPressed() && fastTower.get() && InvUtils.testInHotbar(stack -> stack.getItem() instanceof BlockItem)) {
+            if (mc.options.jumpKey.isPressed() && !mc.options.sneakKey.isPressed() && fastTower.get() && InvUtils.testInHotbar(stack -> validItem(stack, mc.player.getBlockPos()))) {
                 Vec3d vel = mc.player.getVelocity();
                 mc.player.setVelocity(cancelVelocity.get() ? 0 : vel.x, 0.42, cancelVelocity.get() ? 0 : vel.z);
             }


### PR DESCRIPTION
If you used scaffold fasttower without any blocks in your hotbar and tried to tower upwards, it would make you start flying in the air

## Type of change

- Bug fix

## Description

Fixes it by checking if the player has any blocks in their inventory before attempting to fast tower
