### PR TITLE
Resolve the account manager softlock issues

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/AccountsScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/AccountsScreen.java
@@ -39,18 +39,7 @@ public class AccountsScreen extends WindowScreen {
 
         addButton(l, "Cracked", () -> mc.setScreen(new AddCrackedAccountScreen(theme, this)));
         addButton(l, "Altening", () -> mc.setScreen(new AddAlteningAccountScreen(theme, this)));
-        addButton(l, "Microsoft", () -> {
-            locked = true;
-
-            MicrosoftLogin.getRefreshToken(refreshToken -> {
-                locked = false;
-
-                if (refreshToken != null) {
-                    MicrosoftAccount account = new MicrosoftAccount(refreshToken);
-                    addAccount(null, this, account);
-                }
-            });
-        });
+        addButton(l, "Microsoft", () -> mc.setScreen(new AddMicrosoftAccountScreen(theme, this)));
     }
 
     private void addButton(WContainer c, String text, Runnable action) {

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/AddMicrosoftAccountScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/AddMicrosoftAccountScreen.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.gui.screens;
+
+import meteordevelopment.meteorclient.gui.GuiTheme;
+import meteordevelopment.meteorclient.gui.widgets.containers.WTable;
+import meteordevelopment.meteorclient.gui.widgets.pressable.WButton;
+import meteordevelopment.meteorclient.systems.accounts.MicrosoftLogin;
+import meteordevelopment.meteorclient.systems.accounts.types.MicrosoftAccount;
+
+public class AddMicrosoftAccountScreen extends AddAccountScreen {
+    public AddMicrosoftAccountScreen(GuiTheme theme, AccountsScreen parent) {
+        super(theme, "Add Microsoft Account", parent);
+    }
+
+    @Override
+    public void initWidgets() {
+        MicrosoftLogin.getRefreshToken(refreshToken -> {
+
+            if (refreshToken != null) {
+                MicrosoftAccount account = new MicrosoftAccount(refreshToken);
+                AccountsScreen.addAccount(null, parent, account);
+            }
+
+            close();
+        });
+
+        add(theme.label("Please select the account to log into in your browser."));
+
+        WButton cancel = add(theme.button("Cancel")).expandX().widget();
+        cancel.action = () -> {
+            MicrosoftLogin.stopServer();
+            close();
+        };
+    }
+
+    @Override
+    public void tick() {}
+
+    @Override
+    public boolean shouldCloseOnEsc() {
+        return false;
+    }
+}

--- a/src/main/java/meteordevelopment/meteorclient/systems/accounts/MicrosoftLogin.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/accounts/MicrosoftLogin.java
@@ -131,7 +131,7 @@ public class MicrosoftLogin {
         public void handle(HttpExchange req) throws IOException {
             if (req.getRequestMethod().equals("GET")) {
                 // Login
-                List<NameValuePair> query = URLEncodedUtils.parse(req.getRequestURI(), StandardCharsets.UTF_8.name());
+                List<NameValuePair> query = URLEncodedUtils.parse(req.getRequestURI(), StandardCharsets.UTF_8);
 
                 boolean ok = false;
 
@@ -144,7 +144,10 @@ public class MicrosoftLogin {
                     }
                 }
 
-                if (!ok) writeText(req, "Cannot authenticate.");
+                if (!ok) {
+                    writeText(req, "Cannot authenticate.");
+                    callback.accept(null);
+                }
                 else writeText(req, "You may now close this page.");
             }
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/accounts/MicrosoftLogin.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/accounts/MicrosoftLogin.java
@@ -117,7 +117,7 @@ public class MicrosoftLogin {
         }
     }
 
-    private static void stopServer() {
+    public static void stopServer() {
         if (server == null) return;
 
         server.stop(0);


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Before this pr, when adding a microsoft account it would lock the screen while waiting to get the refresh token to make sure the user doesnt break anything. However, it would only unlock the screen after successfully getting the refresh token, which means in situations where it doesnt get the token, such as if you close the login tab or press the back button, the screen would never unlock and you'd need to restart the game. This resolves the issue by openeing a new screen to more comprehensively manage the process, to ensure either the account is successfully added or the process is halted when you return to the main account screen.

## Related issues

closes #1865 

# How Has This Been Tested?

Development and production build

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
