### PR TITLE
Fix BetterChat KeepHistory is on even module is disabled

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/ChatHudMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ChatHudMixin.java
@@ -104,8 +104,7 @@ public abstract class ChatHudMixin implements IChatHud {
 
     @Inject(method = "clear(Z)V", at = @At("HEAD"), cancellable = true)
     private void onClear(CallbackInfo info) {
-        BetterChat betterChat = Modules.get().get(BetterChat.class);
-        if (betterChat.antiHistClear.get()) {
+        if (Modules.get().get(BetterChat.class).keepHistory()) {
             info.cancel();
         }
     }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterChat.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterChat.java
@@ -73,7 +73,7 @@ public class BetterChat extends Module {
         .build()
     );
 
-    public final Setting<Boolean> antiHistClear = sgGeneral.add(new BoolSetting.Builder()
+    private final Setting<Boolean> keepHistory = sgGeneral.add(new BoolSetting.Builder()
         .name("keep-history")
         .description("Prevents the chat history from being cleared when disconnecting.")
         .defaultValue(true)
@@ -441,6 +441,8 @@ public class BetterChat extends Module {
     }
 
     public boolean displayPlayerHeads() { return isActive() && playerHeads.get(); }
+
+    public boolean keepHistory() { return isActive() && keepHistory.get(); }
 
     public int getChatLength() {
         return longerChatLines.get();


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

Fix BetterChat KeepHistory is on even module is disabled

# How Has This Been Tested?

Send something, exit level and rejoin, chat cleared when BetterChatDisabled

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
