### PR TITLE
Fix a niche better tooltip crash

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BetterTooltips.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BetterTooltips.java
@@ -345,7 +345,9 @@ public class BetterTooltips extends Module {
             event.tooltipData = new BannerTooltipComponent(event.itemStack);
         }
         else if (event.itemStack.getItem() instanceof BannerPatternItem patternItem && previewBanners()) {
-            RegistryEntry<BannerPattern> bannerPattern = (Registries.BANNER_PATTERN.getEntryList(patternItem.getPattern()).isPresent() ? Registries.BANNER_PATTERN.getEntryList(patternItem.getPattern()).get().get(0) : null);
+            boolean present = Registries.BANNER_PATTERN.getEntryList(patternItem.getPattern()).isPresent() && Registries.BANNER_PATTERN.getEntryList(patternItem.getPattern()).get().size() != 0;
+
+            RegistryEntry<BannerPattern> bannerPattern = (present ? Registries.BANNER_PATTERN.getEntryList(patternItem.getPattern()).get().get(0) : null);
             if (bannerPattern != null) event.tooltipData = new BannerTooltipComponent(createBannerFromPattern(bannerPattern));
         }
         else if (event.itemStack.getItem() == Items.SHIELD && previewBanners()) {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

There is a strange issue with the banner registry when trying to get an entry of a pattern, where isPresent returns true but the set doesn't actually contain the relevant entry. This isn't present on most servers, and honestly I'm not 100% sure why it happens, but this check resolves the issue.

# How Has This Been Tested?

Online paper server

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
