### PR TITLE
separate block and entity reach

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayerInteractionManagerMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayerInteractionManagerMixin.java
@@ -107,7 +107,7 @@ public abstract class ClientPlayerInteractionManagerMixin implements IClientPlay
 
     @Inject(method = "getReachDistance", at = @At("HEAD"), cancellable = true)
     private void onGetReachDistance(CallbackInfoReturnable<Float> info) {
-        info.setReturnValue(Modules.get().get(Reach.class).getReach());
+        info.setReturnValue(Modules.get().get(Reach.class).blockReach());
     }
 
     @Redirect(method = "updateBlockBreakingProgress", at = @At(value = "FIELD", target = "Lnet/minecraft/client/network/ClientPlayerInteractionManager;blockBreakingCooldown:I", opcode = Opcodes.PUTFIELD, ordinal = 1))

--- a/src/main/java/meteordevelopment/meteorclient/mixin/GameRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/GameRendererMixin.java
@@ -172,13 +172,12 @@ public abstract class GameRendererMixin {
 
     @ModifyConstant(method = "updateTargetedEntity", constant = @Constant(doubleValue = 3))
     private double updateTargetedEntityModifySurvivalReach(double d) {
-        Reach reach = Modules.get().get(Reach.class);
-        return reach.isActive() ? reach.getReach() : d;
+        return Modules.get().get(Reach.class).entityReach();
     }
 
     @ModifyConstant(method = "updateTargetedEntity", constant = @Constant(doubleValue = 9))
     private double updateTargetedEntityModifySquaredMaxReach(double d) {
         Reach reach = Modules.get().get(Reach.class);
-        return reach.isActive() ? reach.getReach() * reach.getReach() : d;
+        return reach.entityReach() * reach.entityReach();
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/Reach.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/Reach.java
@@ -14,21 +14,35 @@ import meteordevelopment.meteorclient.systems.modules.Module;
 public class Reach extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
 
-    private final Setting<Double> reach = sgGeneral.add(new DoubleSetting.Builder()
-            .name("reach")
-            .description("Your reach modifier.")
-            .defaultValue(5)
+    private final Setting<Double> blockReach = sgGeneral.add(new DoubleSetting.Builder()
+            .name("block-reach")
+            .description("The reach modifier for blocks.")
+            .defaultValue(4.5)
             .min(0)
             .sliderMax(6)
             .build()
+    );
+
+    private final Setting<Double> entityReach = sgGeneral.add(new DoubleSetting.Builder()
+        .name("entity-reach")
+        .description("The reach modifier for entities.")
+        .defaultValue(3)
+        .min(0)
+        .sliderMax(6)
+        .build()
     );
 
     public Reach() {
         super(Categories.Player, "reach", "Gives you super long arms.");
     }
 
-    public float getReach() {
+    public float blockReach() {
         if (!isActive()) return mc.interactionManager.getCurrentGameMode().isCreative() ? 5.0F : 4.5F;
-        return reach.get().floatValue();
+        return blockReach.get().floatValue();
+    }
+
+    public float entityReach() {
+        if (!isActive()) return 3;
+        return entityReach.get().floatValue();
     }
 }


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Previously, reach used the same setting for both block and entity reach. This was usually fine, but it led to some inconsistensies if you ever decreased it below 4.5, since you would be able to attack entities further away but wouldn't be able to reach the blocks you otherwise could. This seperates the two into individual settings, giving the user finer control over their reach.

# How Has This Been Tested?

local paper server

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
