### PR TITLE
Fix crash when GameRenderer client is null but normal isnt

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/GameRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/GameRendererMixin.java
@@ -55,7 +55,7 @@ public abstract class GameRendererMixin {
     @Inject(method = "renderWorld", at = @At(value = "INVOKE_STRING", target = "Lnet/minecraft/util/profiler/Profiler;swap(Ljava/lang/String;)V", args = { "ldc=hand" }), locals = LocalCapture.CAPTURE_FAILEXCEPTION)
     private void onRenderWorld(float tickDelta, long limitTime, MatrixStack matrices, CallbackInfo info, boolean bl, Camera camera, MatrixStack matrixStack, double d, float f, float g, Matrix4f matrix4f, Matrix3f matrix3f) {
         if (!Utils.canUpdate()) return;
-
+        if (client == null) return;
         client.getProfiler().push(MeteorClient.MOD_ID + "_render");
 
         if (renderer == null) renderer = new Renderer3D();


### PR DESCRIPTION
## Type of change

- [X ] Bug fix
- [ ] New feature

## Description

Weird edge case for 1.19.4, dont know why it happens but lead me to crash everytime i join a world.

## Related issues

None

# How Has This Been Tested?

Works on my machine:tm:

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
