### PR TITLE
Feat: Emit sound on Notifier's player enter and exit

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notifier.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notifier.java
@@ -161,7 +161,7 @@ public class Notifier extends Module {
                     ChatUtils.sendMsg(event.entity.getId() + 100, Formatting.GRAY, "(highlight)%s(default) has entered your visual range!", event.entity.getEntityName());
 
                     if (visualMakeSound.get())
-                        mc.world.playSoundFromEntity(mc.player, event.entity, SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP, SoundCategory.AMBIENT, 3.0F, 1.0F);
+                        mc.world.playSoundFromEntity(mc.player, mc.player, SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP, SoundCategory.AMBIENT, 3.0F, 1.0F);
                 }
             } else {
                 MutableText text = Text.literal(event.entity.getType().getName().getString()).formatted(Formatting.WHITE);
@@ -187,7 +187,7 @@ public class Notifier extends Module {
                     ChatUtils.sendMsg(event.entity.getId() + 100, Formatting.GRAY, "(highlight)%s(default) has left your visual range!", event.entity.getEntityName());
 
                     if (visualMakeSound.get())
-                        mc.world.playSoundFromEntity(mc.player, event.entity, SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP, SoundCategory.AMBIENT, 3.0F, 1.0F);
+                        mc.world.playSoundFromEntity(mc.player, mc.player, SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP, SoundCategory.AMBIENT, 3.0F, 1.0F);
                 }
             } else {
                 MutableText text = Text.literal(event.entity.getType().getName().getString()).formatted(Formatting.WHITE);

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notifier.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notifier.java
@@ -25,6 +25,8 @@ import net.minecraft.entity.EntityType;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.projectile.thrown.EnderPearlEntity;
 import net.minecraft.network.packet.s2c.play.EntityStatusS2CPacket;
+import net.minecraft.sound.SoundCategory;
+import net.minecraft.sound.SoundEvents;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
@@ -109,6 +111,13 @@ public class Notifier extends Module {
         .build()
     );
 
+    private final Setting<Boolean> visualMakeSound = sgVisualRange.add(new BoolSetting.Builder()
+        .name("sound")
+        .description("Emits a sound effect on enter / leave")
+        .defaultValue(true)
+        .build()
+    );
+
     // Pearl
 
     private final Setting<Boolean> pearl = sgPearl.add(new BoolSetting.Builder()
@@ -150,6 +159,9 @@ public class Notifier extends Module {
             if (event.entity instanceof PlayerEntity) {
                 if ((!visualRangeIgnoreFriends.get() || !Friends.get().isFriend(((PlayerEntity) event.entity))) && (!visualRangeIgnoreFakes.get() || !(event.entity instanceof FakePlayerEntity))) {
                     ChatUtils.sendMsg(event.entity.getId() + 100, Formatting.GRAY, "(highlight)%s(default) has entered your visual range!", event.entity.getEntityName());
+
+                    if (visualMakeSound.get())
+                        mc.world.playSoundFromEntity(mc.player, event.entity, SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP, SoundCategory.AMBIENT, 3.0F, 1.0F);
                 }
             } else {
                 MutableText text = Text.literal(event.entity.getType().getName().getString()).formatted(Formatting.WHITE);
@@ -173,6 +185,9 @@ public class Notifier extends Module {
             if (event.entity instanceof PlayerEntity) {
                 if ((!visualRangeIgnoreFriends.get() || !Friends.get().isFriend(((PlayerEntity) event.entity))) && (!visualRangeIgnoreFakes.get() || !(event.entity instanceof FakePlayerEntity))) {
                     ChatUtils.sendMsg(event.entity.getId() + 100, Formatting.GRAY, "(highlight)%s(default) has left your visual range!", event.entity.getEntityName());
+
+                    if (visualMakeSound.get())
+                        mc.world.playSoundFromEntity(mc.player, event.entity, SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP, SoundCategory.AMBIENT, 3.0F, 1.0F);
                 }
             } else {
                 MutableText text = Text.literal(event.entity.getType().getName().getString()).formatted(Formatting.WHITE);


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Adds a (toggleable) option to emit a sound when a player enters/exits the render distance.

Without this, it's really easy to miss a player when going fast (at least for me)

# How Has This Been Tested?

Joined 9b, works alright.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
