### PR TITLE
Fix size of the "Paste" button in the book edit screen

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/BookEditScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/BookEditScreenMixin.java
@@ -109,7 +109,7 @@ public abstract class BookEditScreenMixin extends Screen {
                     }
                 })
                 .position(4, 4 + 20 + 2)
-                .size(4, 4 + 20 + 2)
+                .size(120, 4 + 20 + 2)
                 .build()
         );
     }

--- a/src/main/java/meteordevelopment/meteorclient/mixin/BookEditScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/BookEditScreenMixin.java
@@ -109,7 +109,7 @@ public abstract class BookEditScreenMixin extends Screen {
                     }
                 })
                 .position(4, 4 + 20 + 2)
-                .size(120, 4 + 20 + 2)
+                .size(120, 20)
                 .build()
         );
     }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Set the width of the "Paste" button to 120 and the height to 20

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
