### PR TITLE
Optimized GhostHand

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/GhostHand.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/GhostHand.java
@@ -9,9 +9,7 @@ import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
-import meteordevelopment.meteorclient.utils.Utils;
 import meteordevelopment.orbit.EventHandler;
-import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
@@ -31,9 +29,7 @@ public class GhostHand extends Module {
     private void onTick(TickEvent.Pre event) {
         if (!mc.options.useKey.isPressed() || mc.player.isSneaking()) return;
 
-        for (BlockEntity blockEntity : Utils.blockEntities()) {
-            if (BlockPos.ofFloored(mc.player.raycast(mc.interactionManager.getReachDistance(), mc.getTickDelta(), false).getPos()).equals(blockEntity.getPos())) return;
-        }
+        if (mc.world.getBlockState(BlockPos.ofFloored(mc.player.raycast(mc.interactionManager.getReachDistance(), mc.getTickDelta(), false).getPos())).hasBlockEntity()) return;
 
         Vec3d direction = new Vec3d(0, 0, 0.1)
                 .rotateX(-(float) Math.toRadians(mc.player.getPitch()))
@@ -47,11 +43,9 @@ public class GhostHand extends Module {
             if (posList.contains(pos)) continue;
             posList.add(pos);
 
-            for (BlockEntity blockEntity : Utils.blockEntities()) {
-                if (blockEntity.getPos().equals(pos)) {
-                    mc.interactionManager.interactBlock(mc.player, Hand.MAIN_HAND, new BlockHitResult(new Vec3d(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5), Direction.UP, pos, true));
-                    return;
-                }
+            if (mc.world.getBlockState(pos).hasBlockEntity()) {
+                mc.interactionManager.interactBlock(mc.player, Hand.MAIN_HAND, new BlockHitResult(new Vec3d(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5), Direction.UP, pos, true));
+                return;
             }
         }
     }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Optimized GhostHand.
It used to do as many ray casts as there were blockentities every tick when it only needed one.
Checking if a position has a blockentity no longer sucks.

## Related issues

#3353

# How Has This Been Tested?

Tested in a normal world and a world with ~60,000 barrels, the one with barrels went to 1-2 fps with right click held before the changes, while the normal world had unnoticeable lag. After the changes the normal world was still fine and the barrel world had unnoticeable lag compared to GhostHand being off.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
