### PR TITLE
Fix .vclip not working in downward direction

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/commands/commands/VClipCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/commands/commands/VClipCommand.java
@@ -30,7 +30,7 @@ public class VClipCommand extends Command {
             // Allows you to teleport up to 200 blocks in one go (as you can send 20 move packets per tick)
             // Paper allows you to teleport 10 blocks for each move packet you send in that tick
             // Video explanation by LiveOverflow: https://www.youtube.com/watch?v=3HSnDsfkJT8
-            int packetsRequired = (int) Math.ceil(blocks / 10);
+            int packetsRequired = (int) Math.ceil(Math.abs(blocks / 10));
             if (mc.player.hasVehicle()) {
                 // Vehicle version
                 // For each 10 blocks, send a vehicle move packet with no delta


### PR DESCRIPTION
## Type of change

- [X] Bug fix

## Description

Fixed vclip lagging back the player when teleporting >10 blocks downward on Paper servers.

The problem was caused by incorrect calculation of number of onGround move packets required, where `Math.ceil(blocks/10)` would return a `negative` value, resulting in skipped onGround move packets. This fix involves taking the `absolute value` of the steps before finding the ceil, ensuring that the correct number of onGround move packets are sent when teleporting downward.

## Related issues

N/A

# How Has This Been Tested?

Tested on dedicated Paper server 🙏 

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
