### PR TITLE
Fix: the error reported about get-number.js hint

### DIFF
--- a/.github/devbuilds/get_number.js
+++ b/.github/devbuilds/get_number.js
@@ -1,5 +1,5 @@
 const axios = require("axios").default;
 
 axios.get("https://meteorclient.com/api/stats").then(res => {
-    console.log("::set-output name=number::" + (parseInt(res.data.devBuild) + 1));
+    console.log("number=" + (parseInt(res.data.devBuild) + 1));
 });

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           cd .github/devbuilds
           npm install
-          npm run get_number >> $GITHUB_OUTPUT
+          node get_number.js >> $GITHUB_OUTPUT
 
       - name: Build
         run: ./gradlew build -Pcommit=${{ github.sha }} -Pdevbuild=${{ steps.dev-build.outputs.number }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           cd .github/devbuilds
           npm install
-          npm run get_number
+          npm run get_number >> $GITHUB_OUTPUT
 
       - name: Build
         run: ./gradlew build -Pcommit=${{ github.sha }} -Pdevbuild=${{ steps.dev-build.outputs.number }}


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

https://github.com/MeteorDevelopment/meteor-client/actions/runs/4743999384
A fix has been made for the build hint issue
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Related issues

In the description

# How Has This Been Tested?

In the description

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [ ] I have tested the code in both development and production environments.
