### PR TITLE
Add EasyMC account integration

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/GuiTheme.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/GuiTheme.java
@@ -6,7 +6,11 @@
 package meteordevelopment.meteorclient.gui;
 
 import meteordevelopment.meteorclient.gui.renderer.packer.GuiTexture;
-import meteordevelopment.meteorclient.gui.screens.*;
+import meteordevelopment.meteorclient.gui.screens.ModuleScreen;
+import meteordevelopment.meteorclient.gui.screens.ModulesScreen;
+import meteordevelopment.meteorclient.gui.screens.NotebotSongsScreen;
+import meteordevelopment.meteorclient.gui.screens.ProxiesScreen;
+import meteordevelopment.meteorclient.gui.screens.accounts.AccountsScreen;
 import meteordevelopment.meteorclient.gui.tabs.TabScreen;
 import meteordevelopment.meteorclient.gui.utils.CharFilter;
 import meteordevelopment.meteorclient.gui.utils.SettingsWidgetFactory;

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/accounts/AccountsScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/accounts/AccountsScreen.java
@@ -3,7 +3,7 @@
  * Copyright (c) Meteor Development.
  */
 
-package meteordevelopment.meteorclient.gui.screens;
+package meteordevelopment.meteorclient.gui.screens.accounts;
 
 import meteordevelopment.meteorclient.gui.GuiTheme;
 import meteordevelopment.meteorclient.gui.WindowScreen;
@@ -37,6 +37,7 @@ public class AccountsScreen extends WindowScreen {
 
         addButton(l, "Cracked", () -> mc.setScreen(new AddCrackedAccountScreen(theme, this)));
         addButton(l, "Altening", () -> mc.setScreen(new AddAlteningAccountScreen(theme, this)));
+        addButton(l, "EasyMC", () -> mc.setScreen(new AddEasyMCAccountScreen(theme, this)));
         addButton(l, "Microsoft", () -> mc.setScreen(new AddMicrosoftAccountScreen(theme, this)));
     }
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/accounts/AddAccountScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/accounts/AddAccountScreen.java
@@ -3,7 +3,7 @@
  * Copyright (c) Meteor Development.
  */
 
-package meteordevelopment.meteorclient.gui.screens;
+package meteordevelopment.meteorclient.gui.screens.accounts;
 
 import meteordevelopment.meteorclient.gui.GuiTheme;
 import meteordevelopment.meteorclient.gui.WindowScreen;

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/accounts/AddAlteningAccountScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/accounts/AddAlteningAccountScreen.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.gui.screens.accounts;
+
+import meteordevelopment.meteorclient.gui.GuiTheme;
+import meteordevelopment.meteorclient.gui.widgets.containers.WTable;
+import meteordevelopment.meteorclient.gui.widgets.input.WTextBox;
+import meteordevelopment.meteorclient.systems.accounts.types.TheAlteningAccount;
+
+public class AddAlteningAccountScreen extends AddAccountScreen {
+    public AddAlteningAccountScreen(GuiTheme theme, AccountsScreen parent) {
+        super(theme, "Add The Altening Account", parent);
+    }
+
+    @Override
+    public void initWidgets() {
+        WTable t = add(theme.table()).widget();
+
+        // Token
+        t.add(theme.label("Token: "));
+        WTextBox token = t.add(theme.textBox("")).minWidth(400).expandX().widget();
+        token.setFocused(true);
+        t.row();
+
+        // Add
+        add = t.add(theme.button("Add")).expandX().widget();
+        add.action = () -> {
+            if (!token.get().isEmpty()) {
+                AccountsScreen.addAccount(this, parent, new TheAlteningAccount(token.get()));
+            }
+        };
+
+        enterAction = add.action;
+    }
+}

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/accounts/AddCrackedAccountScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/accounts/AddCrackedAccountScreen.java
@@ -3,7 +3,7 @@
  * Copyright (c) Meteor Development.
  */
 
-package meteordevelopment.meteorclient.gui.screens;
+package meteordevelopment.meteorclient.gui.screens.accounts;
 
 import meteordevelopment.meteorclient.gui.GuiTheme;
 import meteordevelopment.meteorclient.gui.widgets.containers.WTable;

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/accounts/AddEasyMCAccountScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/accounts/AddEasyMCAccountScreen.java
@@ -3,16 +3,16 @@
  * Copyright (c) Meteor Development.
  */
 
-package meteordevelopment.meteorclient.gui.screens;
+package meteordevelopment.meteorclient.gui.screens.accounts;
 
 import meteordevelopment.meteorclient.gui.GuiTheme;
 import meteordevelopment.meteorclient.gui.widgets.containers.WTable;
 import meteordevelopment.meteorclient.gui.widgets.input.WTextBox;
-import meteordevelopment.meteorclient.systems.accounts.types.TheAlteningAccount;
+import meteordevelopment.meteorclient.systems.accounts.types.EasyMCAccount;
 
-public class AddAlteningAccountScreen extends AddAccountScreen {
-    public AddAlteningAccountScreen(GuiTheme theme, AccountsScreen parent) {
-        super(theme, "Add The Altening Account", parent);
+public class AddEasyMCAccountScreen extends AddAccountScreen {
+    public AddEasyMCAccountScreen(GuiTheme theme, AccountsScreen parent) {
+        super(theme, "Add an EasyMC Account", parent);
     }
 
     @Override
@@ -29,7 +29,7 @@ public class AddAlteningAccountScreen extends AddAccountScreen {
         add = t.add(theme.button("Add")).expandX().widget();
         add.action = () -> {
             if (!token.get().isEmpty()) {
-                AccountsScreen.addAccount(this, parent, new TheAlteningAccount(token.get()));
+                AccountsScreen.addAccount(this, parent, new EasyMCAccount(token.get()));
             }
         };
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/accounts/AddMicrosoftAccountScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/accounts/AddMicrosoftAccountScreen.java
@@ -3,7 +3,7 @@
  * Copyright (c) Meteor Development.
  */
 
-package meteordevelopment.meteorclient.gui.screens;
+package meteordevelopment.meteorclient.gui.screens.accounts;
 
 import meteordevelopment.meteorclient.gui.GuiTheme;
 import meteordevelopment.meteorclient.gui.widgets.pressable.WButton;

--- a/src/main/java/meteordevelopment/meteorclient/systems/accounts/AccountType.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/accounts/AccountType.java
@@ -8,5 +8,6 @@ package meteordevelopment.meteorclient.systems.accounts;
 public enum AccountType {
     Cracked,
     Microsoft,
-    TheAltening
+    TheAltening,
+    EasyMC
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/accounts/Accounts.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/accounts/Accounts.java
@@ -8,6 +8,7 @@ package meteordevelopment.meteorclient.systems.accounts;
 import meteordevelopment.meteorclient.systems.System;
 import meteordevelopment.meteorclient.systems.Systems;
 import meteordevelopment.meteorclient.systems.accounts.types.CrackedAccount;
+import meteordevelopment.meteorclient.systems.accounts.types.EasyMCAccount;
 import meteordevelopment.meteorclient.systems.accounts.types.MicrosoftAccount;
 import meteordevelopment.meteorclient.systems.accounts.types.TheAlteningAccount;
 import meteordevelopment.meteorclient.utils.misc.NbtException;
@@ -76,6 +77,7 @@ public class Accounts extends System<Accounts> implements Iterable<Account<?>> {
                     case Cracked ->     new CrackedAccount(null).fromTag(t);
                     case Microsoft ->   new MicrosoftAccount(null).fromTag(t);
                     case TheAltening -> new TheAlteningAccount(null).fromTag(t);
+                    case EasyMC -> new EasyMCAccount(null).fromTag(t);
                 };
 
                 if (account.fetchInfo()) return account;

--- a/src/main/java/meteordevelopment/meteorclient/systems/accounts/types/EasyMCAccount.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/accounts/types/EasyMCAccount.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.systems.accounts.types;
+
+import com.mojang.authlib.Environment;
+import com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService;
+import meteordevelopment.meteorclient.mixin.MinecraftClientAccessor;
+import meteordevelopment.meteorclient.mixin.YggdrasilMinecraftSessionServiceAccessor;
+import meteordevelopment.meteorclient.systems.accounts.Account;
+import meteordevelopment.meteorclient.systems.accounts.AccountType;
+import meteordevelopment.meteorclient.utils.network.Http;
+import net.minecraft.client.util.Session;
+
+import java.util.Optional;
+
+import static meteordevelopment.meteorclient.MeteorClient.mc;
+
+public class EasyMCAccount extends Account<EasyMCAccount> {
+
+    private static final Environment ENVIRONMENT = Environment.create("https://authserver.mojang.com", "https://api.mojang.com", "https://sessionserver.easymc.io", "https://api.minecraftservices.com", "EasyMC");
+    private static final YggdrasilAuthenticationService SERVICE = new YggdrasilAuthenticationService(((MinecraftClientAccessor) mc).getProxy(), "", ENVIRONMENT);
+
+    public EasyMCAccount(String token) {
+        super(AccountType.EasyMC, token);
+    }
+
+    @Override
+    public boolean fetchInfo() {
+        // we set the name to the session id after we redeem the token - the token length is 20, session id length is 43
+        if (name.length() == 43) return true;
+
+        AuthResponse res = Http.post("https://api.easymc.io/v1/token/redeem")
+            .bodyJson("{\"token\":\"" + name + "\"}")
+            .sendJson(AuthResponse.class);
+
+        if (res != null) {
+            cache.username = res.mcName;
+            cache.uuid = res.uuid;
+
+            name = res.session;
+
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean login() {
+        applyLoginEnvironment(SERVICE, YggdrasilMinecraftSessionServiceAccessor.createYggdrasilMinecraftSessionService(SERVICE, ENVIRONMENT));
+        setSession(new Session(cache.username, cache.uuid, name, Optional.empty(), Optional.empty(), Session.AccountType.MOJANG));
+
+        cache.loadHead();
+        return true;
+    }
+
+    private static class AuthResponse {
+        public String mcName;
+        public String uuid;
+        public String session;
+        public String message;
+    }
+}


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Adds EasyMC account integration to the alt manager. You dont seem to be able to chat on enforce-secure-profile servers since I don't think mojang accounts can generate profile keys. There's a good chance I might have missed something, since I'm not super familiar with the system, but it is what it is.

## Related issues

resolves #3559
resolves #3576
resolves #3606

# How Has This Been Tested?

Tested on local and online servers, both in development and production.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
