### PR TITLE
Update to sodium 0.4.11, resolve iris compatibility

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ archives_base_name=meteor-client
 # Dependency Versions
 
 # Sodium (https://github.com/CaffeineMC/sodium-fabric)
-sodium_version=mc1.19.4-0.4.10
+sodium_version=mc1.19.4-0.4.11
 
 # Lithium (https://github.com/CaffeineMC/lithium-fabric)
 lithium_version=mc1.19.4-0.11.1

--- a/src/main/java/meteordevelopment/meteorclient/MixinPlugin.java
+++ b/src/main/java/meteordevelopment/meteorclient/MixinPlugin.java
@@ -24,7 +24,7 @@ public class MixinPlugin implements IMixinConfigPlugin {
 
     private static boolean isOriginsPresent;
     private static boolean isIndigoPresent;
-    private static boolean isSodiumPresent;
+    public static boolean isSodiumPresent;
     private static boolean isCanvasPresent;
     private static boolean isLithiumPresent;
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/sodium/MeshVertexConsumerMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/sodium/MeshVertexConsumerMixin.java
@@ -5,10 +5,10 @@
 
 package meteordevelopment.meteorclient.mixin.sodium;
 
-import me.jellysquid.mods.sodium.client.render.vertex.VertexBufferWriter;
-import me.jellysquid.mods.sodium.client.render.vertex.VertexFormatDescription;
-import me.jellysquid.mods.sodium.client.render.vertex.transform.CommonVertexElement;
 import meteordevelopment.meteorclient.utils.render.MeshVertexConsumerProvider;
+import net.caffeinemc.mods.sodium.api.vertex.attributes.CommonVertexAttribute;
+import net.caffeinemc.mods.sodium.api.vertex.buffer.VertexBufferWriter;
+import net.caffeinemc.mods.sodium.api.vertex.format.VertexFormatDescription;
 import net.minecraft.client.render.VertexConsumer;
 import org.lwjgl.system.MemoryStack;
 import org.lwjgl.system.MemoryUtil;
@@ -18,11 +18,11 @@ import org.spongepowered.asm.mixin.Mixin;
 public abstract class MeshVertexConsumerMixin implements VertexConsumer, VertexBufferWriter {
     @Override
     public void push(MemoryStack stack, long ptr, int count, VertexFormatDescription format) {
-        int positionOffset = format.elementOffsets[CommonVertexElement.POSITION.ordinal()];
+        int positionOffset = format.getElementOffset(CommonVertexAttribute.POSITION);
         if (positionOffset == -1) return;
 
         for (int i = 0; i < count; i++) {
-            long positionPtr = ptr + (long) format.stride * i + positionOffset;
+            long positionPtr = ptr + (long) format.stride() * i + positionOffset;
 
             float x = MemoryUtil.memGetFloat(positionPtr);
             float y = MemoryUtil.memGetFloat(positionPtr + 4);

--- a/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumBlockOcclusionCacheMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumBlockOcclusionCacheMixin.java
@@ -18,7 +18,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(value = BlockOcclusionCache.class, remap = false)
-public class SodiumBlockOcculsionCacheMixin {
+public class SodiumBlockOcclusionCacheMixin {
     @Inject(method = "shouldDrawSide", at = @At("RETURN"), cancellable = true)
     private void shouldDrawSide(BlockState state, BlockView view, BlockPos pos, Direction facing, CallbackInfoReturnable<Boolean> info) {
         Xray xray = Modules.get().get(Xray.class);

--- a/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumBlockRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumBlockRendererMixin.java
@@ -5,41 +5,20 @@
 
 package meteordevelopment.meteorclient.mixin.sodium;
 
-import me.jellysquid.mods.sodium.client.render.chunk.compile.buffers.ChunkModelBuilder;
+import me.jellysquid.mods.sodium.client.render.chunk.compile.ChunkBuildBuffers;
 import me.jellysquid.mods.sodium.client.render.chunk.compile.pipeline.BlockRenderContext;
 import me.jellysquid.mods.sodium.client.render.chunk.compile.pipeline.BlockRenderer;
-import me.jellysquid.mods.sodium.client.util.color.ColorABGR;
+import me.jellysquid.mods.sodium.client.render.chunk.data.ChunkRenderBounds;
 import meteordevelopment.meteorclient.systems.modules.render.Xray;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(value = BlockRenderer.class, remap = false)
 public class SodiumBlockRendererMixin {
-    @Unique private final ThreadLocal<Integer> alphas = new ThreadLocal<>();
-
     @Inject(method = "renderModel", at = @At("HEAD"), cancellable = true)
-    private void onRenderModel(BlockRenderContext ctx, ChunkModelBuilder buffers, CallbackInfoReturnable<Boolean> info) {
-        int alpha = Xray.getAlpha(ctx.state(), ctx.pos());
-
-        if (alpha == 0) info.setReturnValue(false);
-        else alphas.set(alpha);
-    }
-
-    @Redirect(method = "writeGeometry", at = @At(value = "INVOKE", target = "Lme/jellysquid/mods/sodium/client/util/color/ColorABGR;mul(IF)I"))
-    private int setColor(int color, float w) {
-        int alpha = alphas.get();
-        return alpha == -1 ? ColorABGR.mul(color, w) : mul(color, w, alpha);
-    }
-
-    // In sodium "mul" removes alpha property, so we make alpha available here
-    private static int mul(int color, float w, int a) {
-        float r = (float)ColorABGR.unpackRed(color) * w;
-        float g = (float)ColorABGR.unpackGreen(color) * w;
-        float b = (float)ColorABGR.unpackBlue(color) * w;
-        return ColorABGR.pack((int)r, (int)g, (int)b, a);
+    private void onRenderModel(BlockRenderContext ctx, ChunkBuildBuffers buffers, ChunkRenderBounds.Builder bounds, CallbackInfo ci) {
+        if (Xray.getAlpha(ctx.state(), ctx.pos()) != -1) ci.cancel();
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumFluidRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumFluidRendererMixin.java
@@ -5,64 +5,22 @@
 
 package meteordevelopment.meteorclient.mixin.sodium;
 
-import me.jellysquid.mods.sodium.client.model.light.LightPipeline;
-import me.jellysquid.mods.sodium.client.model.quad.ModelQuadView;
-import me.jellysquid.mods.sodium.client.model.quad.blender.ColorSampler;
-import me.jellysquid.mods.sodium.client.render.chunk.compile.buffers.ChunkModelBuilder;
+import me.jellysquid.mods.sodium.client.render.chunk.compile.ChunkBuildBuffers;
 import me.jellysquid.mods.sodium.client.render.chunk.compile.pipeline.FluidRenderer;
-import me.jellysquid.mods.sodium.client.util.color.ColorABGR;
-import me.jellysquid.mods.sodium.client.util.color.ColorARGB;
-import meteordevelopment.meteorclient.systems.modules.Modules;
+import me.jellysquid.mods.sodium.client.render.chunk.data.ChunkRenderBounds;
 import meteordevelopment.meteorclient.systems.modules.render.Xray;
-import meteordevelopment.meteorclient.systems.modules.world.Ambience;
 import net.minecraft.fluid.FluidState;
-import net.minecraft.registry.tag.FluidTags;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Direction;
 import net.minecraft.world.BlockRenderView;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
-import java.util.Arrays;
 
 @Mixin(value = FluidRenderer.class, remap = false)
 public class SodiumFluidRendererMixin {
-    @Final @Shadow private int[] quadColors;
-
-    @Unique private final ThreadLocal<Integer> alphas = new ThreadLocal<>();
-
     @Inject(method = "render", at = @At("HEAD"), cancellable = true)
-    private void onRender(BlockRenderView world, FluidState fluidState, BlockPos pos, BlockPos offset, ChunkModelBuilder buffers, CallbackInfoReturnable<Boolean> info) {
-        int alpha = Xray.getAlpha(fluidState.getBlockState(), pos);
-
-        if (alpha == 0) info.setReturnValue(false);
-        else alphas.set(alpha);
-    }
-
-    /**
-     * @author Walaryne
-     */
-    @Inject(method = "updateQuad", at = @At("TAIL"))
-    private void onUpdateQuad(ModelQuadView quad, BlockRenderView world, BlockPos pos, LightPipeline lighter, Direction dir, float brightness, ColorSampler<FluidState> colorSampler, FluidState fluidState, CallbackInfo info) {
-        // Ambience
-        Ambience ambience = Modules.get().get(Ambience.class);
-
-        if (ambience.isActive() && ambience.customLavaColor.get() && fluidState.isIn(FluidTags.LAVA)) {
-            Arrays.fill(quadColors, ColorARGB.toABGR(ambience.lavaColor.get().getPacked()));
-        }
-        else {
-            // XRay and Wallhack
-            int alpha = alphas.get();
-
-            for (int i = 0; i < quadColors.length; i++) {
-                quadColors[i] = ColorABGR.withAlpha(quadColors[i], alpha / 255f);
-            }
-        }
+    private void onRender(BlockRenderView world, FluidState fluidState, BlockPos pos, BlockPos offset, ChunkBuildBuffers buffers, ChunkRenderBounds.Builder bounds, CallbackInfo ci) {
+        if (Xray.getAlpha(fluidState.getBlockState(), pos) != -1) ci.cancel();
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/WallHack.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/WallHack.java
@@ -5,7 +5,10 @@
 
 package meteordevelopment.meteorclient.systems.modules.render;
 
+import meteordevelopment.meteorclient.MixinPlugin;
 import meteordevelopment.meteorclient.events.world.ChunkOcclusionEvent;
+import meteordevelopment.meteorclient.gui.GuiTheme;
+import meteordevelopment.meteorclient.gui.widgets.WWidget;
 import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
@@ -60,6 +63,11 @@ public class WallHack extends Module {
     @Override
     public void onDeactivate() {
         mc.worldRenderer.reload();
+    }
+
+    @Override
+    public WWidget getWidget(GuiTheme theme) {
+        return MixinPlugin.isSodiumPresent ? theme.label("Warning: Due to sodium's presence, opacity is overridden to 0.") : null;
     }
 
     @EventHandler

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Xray.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Xray.java
@@ -5,9 +5,12 @@
 
 package meteordevelopment.meteorclient.systems.modules.render;
 
+import meteordevelopment.meteorclient.MixinPlugin;
 import meteordevelopment.meteorclient.events.render.RenderBlockEntityEvent;
 import meteordevelopment.meteorclient.events.world.AmbientOcclusionEvent;
 import meteordevelopment.meteorclient.events.world.ChunkOcclusionEvent;
+import meteordevelopment.meteorclient.gui.GuiTheme;
+import meteordevelopment.meteorclient.gui.widgets.WWidget;
 import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
@@ -70,7 +73,7 @@ public class Xray extends Module {
     );
 
     private final Setting<Boolean> exposedOnly = sgGeneral.add(new BoolSetting.Builder()
-        .name("exposed only")
+        .name("exposed-only")
         .description("Show only exposed ores.")
         .defaultValue(false)
         .onChanged(onChanged -> {
@@ -90,6 +93,11 @@ public class Xray extends Module {
     @Override
     public void onDeactivate() {
         mc.worldRenderer.reload();
+    }
+
+    @Override
+    public WWidget getWidget(GuiTheme theme) {
+        return MixinPlugin.isSodiumPresent ? theme.label("Warning: Due to sodium's presence, opacity is overridden to 0.") : null;
     }
 
     @EventHandler

--- a/src/main/resources/meteor-client-sodium.mixins.json
+++ b/src/main/resources/meteor-client-sodium.mixins.json
@@ -6,7 +6,7 @@
   "client": [
     "LightDataAccessMixin",
     "MeshVertexConsumerMixin",
-    "SodiumBlockOcculsionCacheMixin",
+    "SodiumBlockOcclusionCacheMixin",
     "SodiumBlockRendererMixin",
     "SodiumFluidRendererMixin"
   ],


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Fixes compatibility with sodium 0.4.11; no longer compatible with 0.4.10 or lower. Due to changes in how sodium handles block colours and transparency, the opacity setting for xray and wallhack will be overridden to 0 if sodium is present.
This incidently also resolves compatiblity with iris, but that's primarily due to the aforementioned changes in transparency.

## Related issues

Closes #3612
Closes #3555
Closes #3530
Closes #3574
Closes #3596

# How Has This Been Tested?

Development and production, with and without shaders

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
