### PR TITLE
Module/Command override alerts

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/commands/Commands.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/Commands.java
@@ -7,6 +7,7 @@ package meteordevelopment.meteorclient.commands;
 
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.commands.commands.*;
 import meteordevelopment.meteorclient.utils.PostInit;
 import net.minecraft.client.network.ClientCommandSource;
@@ -66,7 +67,14 @@ public class Commands {
     }
 
     public static void add(Command command) {
-        COMMANDS.removeIf(existing -> existing.getName().equals(command.getName()));
+        COMMANDS.removeIf(existing -> {
+            if (existing.getName().equals(command.getName())) {
+                MeteorClient.LOG.warn("{} has overridden {}.", command.getClass().getName(), existing.getClass().getName());
+                return true;
+            }
+            return false;
+        });
+
         command.registerTo(DISPATCHER);
         COMMANDS.add(command);
     }

--- a/src/main/java/meteordevelopment/meteorclient/commands/Commands.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/Commands.java
@@ -9,7 +9,7 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.commands.commands.*;
-import meteordevelopment.meteorclient.utils.PostInit;
+import meteordevelopment.meteorclient.utils.PreInit;
 import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.command.CommandSource;
 
@@ -24,7 +24,7 @@ public class Commands {
     public static final CommandSource COMMAND_SOURCE = new ClientCommandSource(null, mc);
     public static final List<Command> COMMANDS = new ArrayList<>();
 
-    @PostInit
+    @PreInit
     public static void init() {
         add(new VClipCommand());
         add(new HClipCommand());
@@ -74,7 +74,6 @@ public class Commands {
             }
             return false;
         });
-
         command.registerTo(DISPATCHER);
         COMMANDS.add(command);
     }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
@@ -362,10 +362,10 @@ public class Modules extends System<Modules> {
             if (module1.name.equals(module.name)) {
                 removedModule.set(module1);
                 module1.settings.unregisterColorSettings();
+                MeteorClient.LOG.warn("{} has overridden {}.", module.getClass().getName(), module1.getClass().getName());
 
                 return true;
             }
-
             return false;
         })) {
             getGroup(removedModule.get().category).remove(removedModule.get());

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
@@ -363,7 +363,6 @@ public class Modules extends System<Modules> {
                 removedModule.set(module1);
                 module1.settings.unregisterColorSettings();
                 MeteorClient.LOG.warn("{} has overridden {}.", module.getClass().getName(), module1.getClass().getName());
-
                 return true;
             }
             return false;


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature

## Description

A small patch adding a warning message in logs to notify which modules/commands are overridden.

# How Has This Been Tested?

Installing addons that will override meteor modules.

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
