### PR TITLE
Prevent null pointer exception when disconnecting with Rotation enabled

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/Rotation.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/Rotation.java
@@ -67,14 +67,15 @@ public class Rotation extends Module {
 
     @EventHandler
     private void onTick(TickEvent.Post event) {
-        switch (yawLockMode.get()) {
-            case Simple -> setYawAngle(yawAngle.get().floatValue());
-            case Smart  -> setYawAngle(getSmartYawDirection());
-        }
-
-        switch (pitchLockMode.get()) {
-            case Simple -> mc.player.setPitch(pitchAngle.get().floatValue());
-            case Smart  -> mc.player.setPitch(getSmartPitchDirection());
+        if (mc.player != null) {
+            switch (yawLockMode.get()) {
+                case Simple -> setYawAngle(yawAngle.get().floatValue());
+                case Smart -> setYawAngle(getSmartYawDirection());
+            }
+            switch (pitchLockMode.get()) {
+                case Simple -> mc.player.setPitch(pitchAngle.get().floatValue());
+                case Smart -> mc.player.setPitch(getSmartPitchDirection());
+            }
         }
     }
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoNametag.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoNametag.java
@@ -84,8 +84,11 @@ public class AutoNametag extends Module {
         target = TargetUtils.get(entity -> {
             if (!PlayerUtils.isWithin(entity, range.get())) return false;
             if (!entities.get().getBoolean(entity.getType())) return false;
-            if (entity.hasCustomName()) {
-                return renametag.get() && entity.getCustomName() != mc.player.getInventory().getStack(findNametag.slot()).getName();
+            if (!entity.hasCustomName()) {
+                return entity.getCustomName() != mc.player.getInventory().getStack(findNametag.slot()).getName();
+            }
+            if (entity.hasCustomName() && renametag.get()) {
+                return entity.getCustomName() != mc.player.getInventory().getStack(findNametag.slot()).getName();
             }
             return false;
         }, priority.get());


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

This fix prevents a crash when disconencting from a server / world with Rotation enabled.

## Related issues

None.

# How Has This Been Tested?

Tested both in single player and multiplayer, works as intended.

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
