### PR TITLE
Sodium hotfix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     modCompileOnly fabricApi.module("fabric-renderer-indigo", project.fapi_version)
     modCompileOnly("maven.modrinth:sodium:${project.sodium_version}") { transitive = false }
     modCompileOnly("maven.modrinth:lithium:${project.lithium_version}") { transitive = false }
+    modCompileOnly("maven.modrinth:iris:${project.iris_version}") { transitive = false }
     //modCompileOnly("io.vram:canvas-fabric-mc119:1.0.+") { transitive = false } // TODO: 1.19.3
 
 	// Baritone (https://github.com/MeteorDevelopment/baritone)

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,9 @@ sodium_version=mc1.19.4-0.4.10
 # Lithium (https://github.com/CaffeineMC/lithium-fabric)
 lithium_version=mc1.19.4-0.11.1
 
+# Iris (https://github.com/IrisShaders/Iris)
+iris_version=1.6.1+1.19.4
+
 # Orbit (https://github.com/MeteorDevelopment/orbit)
 orbit_version=0.2.3
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ archives_base_name=meteor-client
 # Dependency Versions
 
 # Sodium (https://github.com/CaffeineMC/sodium-fabric)
-sodium_version=mc1.19.4-0.4.11
+sodium_version=mc1.19.4-0.4.10
 
 # Lithium (https://github.com/CaffeineMC/lithium-fabric)
 lithium_version=mc1.19.4-0.11.1

--- a/src/main/java/meteordevelopment/meteorclient/MixinPlugin.java
+++ b/src/main/java/meteordevelopment/meteorclient/MixinPlugin.java
@@ -27,6 +27,7 @@ public class MixinPlugin implements IMixinConfigPlugin {
     private static boolean isSodiumPresent;
     private static boolean isCanvasPresent;
     private static boolean isLithiumPresent;
+    public static boolean isIrisPresent;
 
     @Override
     public void onLoad(String mixinPackage) {
@@ -70,6 +71,7 @@ public class MixinPlugin implements IMixinConfigPlugin {
         isSodiumPresent = FabricLoader.getInstance().isModLoaded("sodium");
         isCanvasPresent = FabricLoader.getInstance().isModLoaded("canvas");
         isLithiumPresent = FabricLoader.getInstance().isModLoaded("lithium");
+        isIrisPresent = FabricLoader.getInstance().isModLoaded("iris");
 
         loaded = true;
     }

--- a/src/main/java/meteordevelopment/meteorclient/MixinPlugin.java
+++ b/src/main/java/meteordevelopment/meteorclient/MixinPlugin.java
@@ -24,7 +24,7 @@ public class MixinPlugin implements IMixinConfigPlugin {
 
     private static boolean isOriginsPresent;
     private static boolean isIndigoPresent;
-    public static boolean isSodiumPresent;
+    private static boolean isSodiumPresent;
     private static boolean isCanvasPresent;
     private static boolean isLithiumPresent;
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/sodium/MeshVertexConsumerMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/sodium/MeshVertexConsumerMixin.java
@@ -5,10 +5,10 @@
 
 package meteordevelopment.meteorclient.mixin.sodium;
 
+import me.jellysquid.mods.sodium.client.render.vertex.VertexBufferWriter;
+import me.jellysquid.mods.sodium.client.render.vertex.VertexFormatDescription;
+import me.jellysquid.mods.sodium.client.render.vertex.transform.CommonVertexElement;
 import meteordevelopment.meteorclient.utils.render.MeshVertexConsumerProvider;
-import net.caffeinemc.mods.sodium.api.vertex.attributes.CommonVertexAttribute;
-import net.caffeinemc.mods.sodium.api.vertex.buffer.VertexBufferWriter;
-import net.caffeinemc.mods.sodium.api.vertex.format.VertexFormatDescription;
 import net.minecraft.client.render.VertexConsumer;
 import org.lwjgl.system.MemoryStack;
 import org.lwjgl.system.MemoryUtil;
@@ -18,11 +18,11 @@ import org.spongepowered.asm.mixin.Mixin;
 public abstract class MeshVertexConsumerMixin implements VertexConsumer, VertexBufferWriter {
     @Override
     public void push(MemoryStack stack, long ptr, int count, VertexFormatDescription format) {
-        int positionOffset = format.getElementOffset(CommonVertexAttribute.POSITION);
+        int positionOffset = format.elementOffsets[CommonVertexElement.POSITION.ordinal()];
         if (positionOffset == -1) return;
 
         for (int i = 0; i < count; i++) {
-            long positionPtr = ptr + (long) format.stride() * i + positionOffset;
+            long positionPtr = ptr + (long) format.stride * i + positionOffset;
 
             float x = MemoryUtil.memGetFloat(positionPtr);
             float y = MemoryUtil.memGetFloat(positionPtr + 4);

--- a/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumBlockRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumBlockRendererMixin.java
@@ -36,7 +36,7 @@ public class SodiumBlockRendererMixin {
     }
 
 
-    @Inject(method = "writeGeometry", at = @At(value = "INVOKE", target = "Lme/jellysquid/mods/sodium/client/util/color/ColorABGR;mul(IF)I", shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILSOFT, cancellable = true)
+    @Inject(method = "writeGeometry", at = @At(value = "INVOKE", target = "Lme/jellysquid/mods/sodium/client/util/color/ColorABGR;mul(IF)I", shift = At.Shift.BY, by = 2), locals = LocalCapture.CAPTURE_FAILSOFT, cancellable = true)
     private void setColor(BlockRenderContext ctx, ChunkVertexBufferBuilder vertexBuffer, IndexBufferBuilder indexBuffer, Vec3d offset, ModelQuadView quad, int[] colors, float[] brightness, int[] lightmap, CallbackInfo info, ModelQuadOrientation orientation, ChunkVertexEncoder.Vertex[] vertices, int dstIndex, int srcIndex, ChunkVertexEncoder.Vertex out) {
         int alpha = alphas.get();
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumBlockRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumBlockRendererMixin.java
@@ -5,20 +5,42 @@
 
 package meteordevelopment.meteorclient.mixin.sodium;
 
-import me.jellysquid.mods.sodium.client.render.chunk.compile.ChunkBuildBuffers;
+import me.jellysquid.mods.sodium.client.render.chunk.compile.buffers.ChunkModelBuilder;
 import me.jellysquid.mods.sodium.client.render.chunk.compile.pipeline.BlockRenderContext;
 import me.jellysquid.mods.sodium.client.render.chunk.compile.pipeline.BlockRenderer;
-import me.jellysquid.mods.sodium.client.render.chunk.data.ChunkRenderBounds;
+import me.jellysquid.mods.sodium.client.util.color.ColorABGR;
 import meteordevelopment.meteorclient.systems.modules.render.Xray;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(value = BlockRenderer.class, remap = false)
 public class SodiumBlockRendererMixin {
+    @Unique private final ThreadLocal<Integer> alphas = new ThreadLocal<>();
+
     @Inject(method = "renderModel", at = @At("HEAD"), cancellable = true)
-    private void onRenderModel(BlockRenderContext ctx, ChunkBuildBuffers buffers, ChunkRenderBounds.Builder bounds, CallbackInfo ci) {
-        if (Xray.getAlpha(ctx.state(), ctx.pos()) != -1) ci.cancel();
+    private void onRenderModel(BlockRenderContext ctx, ChunkModelBuilder buffers, CallbackInfoReturnable<Boolean> info) {
+        int alpha = Xray.getAlpha(ctx.state(), ctx.pos());
+
+        if (alpha == 0) info.setReturnValue(false);
+        else alphas.set(alpha);
+    }
+
+
+    @Redirect(method = "writeGeometry", at = @At(value = "INVOKE", target = "Lme/jellysquid/mods/sodium/client/util/color/ColorABGR;mul(IF)I"))
+    private int setColor(int color, float w) {
+        int alpha = alphas.get();
+        return alpha == -1 ? ColorABGR.mul(color, w) : mul(color, w, alpha);
+    }
+
+    @Unique
+    private static int mul(int color, float w, int a) {
+        float r = (float) ColorABGR.unpackRed(color) * w;
+        float g = (float) ColorABGR.unpackGreen(color) * w;
+        float b = (float) ColorABGR.unpackBlue(color) * w;
+        return ColorABGR.pack((int) r, (int) g, (int) b, a);
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumBlockRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumBlockRendererMixin.java
@@ -15,6 +15,7 @@ import me.jellysquid.mods.sodium.client.render.vertex.type.ChunkVertexBufferBuil
 import me.jellysquid.mods.sodium.client.render.vertex.type.ChunkVertexEncoder;
 import meteordevelopment.meteorclient.systems.modules.render.Xray;
 import net.minecraft.util.math.Vec3d;
+import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -36,7 +37,7 @@ public class SodiumBlockRendererMixin {
     }
 
 
-    @Inject(method = "writeGeometry", at = @At(value = "INVOKE", target = "Lme/jellysquid/mods/sodium/client/util/color/ColorABGR;mul(IF)I", shift = At.Shift.BY, by = 2), locals = LocalCapture.CAPTURE_FAILSOFT, cancellable = true)
+    @Inject(method = "writeGeometry", at = @At(value = "FIELD", target = "Lme/jellysquid/mods/sodium/client/render/vertex/type/ChunkVertexEncoder$Vertex;color:I", opcode = Opcodes.PUTFIELD, shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILSOFT, cancellable = true)
     private void setColor(BlockRenderContext ctx, ChunkVertexBufferBuilder vertexBuffer, IndexBufferBuilder indexBuffer, Vec3d offset, ModelQuadView quad, int[] colors, float[] brightness, int[] lightmap, CallbackInfo info, ModelQuadOrientation orientation, ChunkVertexEncoder.Vertex[] vertices, int dstIndex, int srcIndex, ChunkVertexEncoder.Vertex out) {
         int alpha = alphas.get();
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumFluidRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumFluidRendererMixin.java
@@ -5,22 +5,60 @@
 
 package meteordevelopment.meteorclient.mixin.sodium;
 
-import me.jellysquid.mods.sodium.client.render.chunk.compile.ChunkBuildBuffers;
+import me.jellysquid.mods.sodium.client.model.light.LightPipeline;
+import me.jellysquid.mods.sodium.client.model.quad.ModelQuadView;
+import me.jellysquid.mods.sodium.client.model.quad.blender.ColorSampler;
+import me.jellysquid.mods.sodium.client.render.chunk.compile.buffers.ChunkModelBuilder;
 import me.jellysquid.mods.sodium.client.render.chunk.compile.pipeline.FluidRenderer;
-import me.jellysquid.mods.sodium.client.render.chunk.data.ChunkRenderBounds;
+import me.jellysquid.mods.sodium.client.util.color.ColorABGR;
+import me.jellysquid.mods.sodium.client.util.color.ColorARGB;
+import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.render.Xray;
+import meteordevelopment.meteorclient.systems.modules.world.Ambience;
 import net.minecraft.fluid.FluidState;
+import net.minecraft.registry.tag.FluidTags;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
 import net.minecraft.world.BlockRenderView;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Arrays;
 
 @Mixin(value = FluidRenderer.class, remap = false)
 public class SodiumFluidRendererMixin {
+    @Final @Shadow private int[] quadColors;
+
+    @Unique private final ThreadLocal<Integer> alphas = new ThreadLocal<>();
+
     @Inject(method = "render", at = @At("HEAD"), cancellable = true)
-    private void onRender(BlockRenderView world, FluidState fluidState, BlockPos pos, BlockPos offset, ChunkBuildBuffers buffers, ChunkRenderBounds.Builder bounds, CallbackInfo ci) {
-        if (Xray.getAlpha(fluidState.getBlockState(), pos) != -1) ci.cancel();
+    private void onRender(BlockRenderView world, FluidState fluidState, BlockPos pos, BlockPos offset, ChunkModelBuilder buffers, CallbackInfoReturnable<Boolean> info) {
+        int alpha = Xray.getAlpha(fluidState.getBlockState(), pos);
+
+        if (alpha == 0) info.setReturnValue(false);
+        else alphas.set(alpha);
+    }
+
+    @Inject(method = "updateQuad", at = @At("TAIL"))
+    private void onUpdateQuad(ModelQuadView quad, BlockRenderView world, BlockPos pos, LightPipeline lighter, Direction dir, float brightness, ColorSampler<FluidState> colorSampler, FluidState fluidState, CallbackInfo info) {
+        // Ambience
+        Ambience ambience = Modules.get().get(Ambience.class);
+
+        if (ambience.isActive() && ambience.customLavaColor.get() && fluidState.isIn(FluidTags.LAVA)) {
+            Arrays.fill(quadColors, ColorARGB.toABGR(ambience.lavaColor.get().getPacked()));
+        } else {
+            // XRay and Wallhack
+            int alpha = alphas.get();
+
+            for (int i = 0; i < quadColors.length; i++) {
+                quadColors[i] = ColorABGR.withAlpha(quadColors[i], alpha / 255f);
+            }
+        }
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/WallHack.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/WallHack.java
@@ -5,6 +5,7 @@
 
 package meteordevelopment.meteorclient.systems.modules.render;
 
+import meteordevelopment.meteorclient.MixinPlugin;
 import meteordevelopment.meteorclient.events.world.ChunkOcclusionEvent;
 import meteordevelopment.meteorclient.gui.GuiTheme;
 import meteordevelopment.meteorclient.gui.widgets.WWidget;
@@ -12,6 +13,7 @@ import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.orbit.EventHandler;
+import net.irisshaders.iris.api.v0.IrisApi;
 import net.minecraft.block.Block;
 
 import java.util.List;
@@ -66,7 +68,7 @@ public class WallHack extends Module {
 
     @Override
     public WWidget getWidget(GuiTheme theme) {
-        return Xray.isIrisPresent ? theme.label("Warning: Due to iris' presence, opacity is overridden to 0.") : null;
+        return (MixinPlugin.isIrisPresent && IrisApi.getInstance().isShaderPackInUse()) ? theme.label("Warning: Due to shaders in use, opacity is overridden to 0.") : null;
     }
 
     @EventHandler

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/WallHack.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/WallHack.java
@@ -6,6 +6,8 @@
 package meteordevelopment.meteorclient.systems.modules.render;
 
 import meteordevelopment.meteorclient.events.world.ChunkOcclusionEvent;
+import meteordevelopment.meteorclient.gui.GuiTheme;
+import meteordevelopment.meteorclient.gui.widgets.WWidget;
 import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
@@ -60,6 +62,11 @@ public class WallHack extends Module {
     @Override
     public void onDeactivate() {
         mc.worldRenderer.reload();
+    }
+
+    @Override
+    public WWidget getWidget(GuiTheme theme) {
+        return Xray.isIrisPresent ? theme.label("Warning: Due to iris' presence, opacity is overridden to 0.") : null;
     }
 
     @EventHandler

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/WallHack.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/WallHack.java
@@ -5,10 +5,7 @@
 
 package meteordevelopment.meteorclient.systems.modules.render;
 
-import meteordevelopment.meteorclient.MixinPlugin;
 import meteordevelopment.meteorclient.events.world.ChunkOcclusionEvent;
-import meteordevelopment.meteorclient.gui.GuiTheme;
-import meteordevelopment.meteorclient.gui.widgets.WWidget;
 import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
@@ -63,11 +60,6 @@ public class WallHack extends Module {
     @Override
     public void onDeactivate() {
         mc.worldRenderer.reload();
-    }
-
-    @Override
-    public WWidget getWidget(GuiTheme theme) {
-        return MixinPlugin.isSodiumPresent ? theme.label("Warning: Due to sodium's presence, opacity is overridden to 0.") : null;
     }
 
     @EventHandler

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Xray.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Xray.java
@@ -17,7 +17,7 @@ import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.utils.world.BlockUtils;
 import meteordevelopment.orbit.EventHandler;
-import net.fabricmc.loader.api.FabricLoader;
+import net.irisshaders.iris.api.v0.IrisApi;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
@@ -29,8 +29,6 @@ import net.minecraft.world.BlockView;
 import java.util.List;
 
 public class Xray extends Module {
-    public static final boolean isIrisPresent = FabricLoader.getInstance().isModLoaded("iris");
-
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
 
     private final Setting<List<Block>> blocks = sgGeneral.add(new BlockListSetting.Builder()
@@ -100,7 +98,7 @@ public class Xray extends Module {
 
     @Override
     public WWidget getWidget(GuiTheme theme) {
-        return isIrisPresent ? theme.label("Warning: Due to iris' presence, opacity is overridden to 0.") : null;
+        return (MixinPlugin.isIrisPresent && IrisApi.getInstance().isShaderPackInUse()) ? theme.label("Warning: Due to shaders in use, opacity is overridden to 0.") : null;
     }
 
     @EventHandler
@@ -137,7 +135,7 @@ public class Xray extends Module {
         Xray xray = Modules.get().get(Xray.class);
 
         if (wallHack.isActive() && wallHack.blocks.get().contains(state.getBlock())) {
-            if (isIrisPresent) return 0;
+            if (MixinPlugin.isIrisPresent && IrisApi.getInstance().isShaderPackInUse()) return 0;
 
             int alpha;
 
@@ -147,7 +145,7 @@ public class Xray extends Module {
             return alpha;
         }
         else if (xray.isActive() && !wallHack.isActive() && xray.isBlocked(state.getBlock(), pos)) {
-            return isIrisPresent ? 0 : xray.opacity.get();
+            return (MixinPlugin.isIrisPresent && IrisApi.getInstance().isShaderPackInUse()) ? 0 : xray.opacity.get();
         }
 
         return -1;

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Xray.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Xray.java
@@ -5,15 +5,19 @@
 
 package meteordevelopment.meteorclient.systems.modules.render;
 
+import meteordevelopment.meteorclient.MixinPlugin;
 import meteordevelopment.meteorclient.events.render.RenderBlockEntityEvent;
 import meteordevelopment.meteorclient.events.world.AmbientOcclusionEvent;
 import meteordevelopment.meteorclient.events.world.ChunkOcclusionEvent;
+import meteordevelopment.meteorclient.gui.GuiTheme;
+import meteordevelopment.meteorclient.gui.widgets.WWidget;
 import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.utils.world.BlockUtils;
 import meteordevelopment.orbit.EventHandler;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
@@ -25,6 +29,8 @@ import net.minecraft.world.BlockView;
 import java.util.List;
 
 public class Xray extends Module {
+    public static final boolean isIrisPresent = FabricLoader.getInstance().isModLoaded("iris");
+
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
 
     private final Setting<List<Block>> blocks = sgGeneral.add(new BlockListSetting.Builder()
@@ -92,6 +98,11 @@ public class Xray extends Module {
         mc.worldRenderer.reload();
     }
 
+    @Override
+    public WWidget getWidget(GuiTheme theme) {
+        return isIrisPresent ? theme.label("Warning: Due to iris' presence, opacity is overridden to 0.") : null;
+    }
+
     @EventHandler
     private void onRenderBlockEntity(RenderBlockEntityEvent event) {
         if (isBlocked(event.blockEntity.getCachedState().getBlock(), event.blockEntity.getPos())) event.cancel();
@@ -126,6 +137,8 @@ public class Xray extends Module {
         Xray xray = Modules.get().get(Xray.class);
 
         if (wallHack.isActive() && wallHack.blocks.get().contains(state.getBlock())) {
+            if (isIrisPresent) return 0;
+
             int alpha;
 
             if (xray.isActive()) alpha = xray.opacity.get();
@@ -134,7 +147,7 @@ public class Xray extends Module {
             return alpha;
         }
         else if (xray.isActive() && !wallHack.isActive() && xray.isBlocked(state.getBlock(), pos)) {
-            return xray.opacity.get();
+            return isIrisPresent ? 0 : xray.opacity.get();
         }
 
         return -1;

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Xray.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Xray.java
@@ -5,12 +5,9 @@
 
 package meteordevelopment.meteorclient.systems.modules.render;
 
-import meteordevelopment.meteorclient.MixinPlugin;
 import meteordevelopment.meteorclient.events.render.RenderBlockEntityEvent;
 import meteordevelopment.meteorclient.events.world.AmbientOcclusionEvent;
 import meteordevelopment.meteorclient.events.world.ChunkOcclusionEvent;
-import meteordevelopment.meteorclient.gui.GuiTheme;
-import meteordevelopment.meteorclient.gui.widgets.WWidget;
 import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
@@ -93,11 +90,6 @@ public class Xray extends Module {
     @Override
     public void onDeactivate() {
         mc.worldRenderer.reload();
-    }
-
-    @Override
-    public WWidget getWidget(GuiTheme theme) {
-        return MixinPlugin.isSodiumPresent ? theme.label("Warning: Due to sodium's presence, opacity is overridden to 0.") : null;
     }
 
     @EventHandler


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

Sodium 0.4.11 was pulled from Modrinth by the CaffeineMC team and the currently Meteor is incompatible with the latest Sodium release. This pull request more or less reverts #3615 whilst keeping and improving upon the changes proposed in #3574

# How Has This Been Tested?

![2023-05-08_22 33 36](https://user-images.githubusercontent.com/32882447/236979279-4cad878c-ffda-4e1f-bbf3-27aea099ebf0.png)

![2023-05-08_22 52 28](https://user-images.githubusercontent.com/32882447/236981958-9ebeb99e-f3e4-4365-8546-3e5df2c0ec03.png)

![2023-05-08_22 52 40](https://user-images.githubusercontent.com/32882447/236981968-018077fb-1786-4f9e-aca6-c190ba04d96b.png)


# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
