### PR TITLE
EntityTypeListSetting Patch

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/EntityTypeListSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/EntityTypeListSettingScreen.java
@@ -65,9 +65,7 @@ public class EntityTypeListSettingScreen extends WindowScreen {
     public void initWidgets() {
         hasAnimal = hasWaterAnimal = hasMonster = hasAmbient = hasMisc = 0;
 
-        for (EntityType<?> entityType : setting.get().keySet()) {
-            if (!setting.get().getBoolean(entityType)) continue;
-
+        for (EntityType<?> entityType : setting.get()) {
             if (setting.filter == null || setting.filter.test(entityType)) {
                 switch (entityType.getSpawnGroup()) {
                     case CREATURE -> hasAnimal++;
@@ -204,10 +202,10 @@ public class EntityTypeListSettingScreen extends WindowScreen {
 
         for (EntityType<?> entityType : entityTypes) {
             if (checked) {
-                setting.get().put(entityType, true);
+                setting.get().add(entityType);
                 changed = true;
             } else {
-                if (setting.get().removeBoolean(entityType)) {
+                if (setting.get().remove(entityType)) {
                     changed = true;
                 }
             }
@@ -223,10 +221,10 @@ public class EntityTypeListSettingScreen extends WindowScreen {
     private void addEntityType(WTable table, WCheckbox tableCheckbox, EntityType<?> entityType) {
         table.add(theme.label(Names.get(entityType)));
 
-        WCheckbox a = table.add(theme.checkbox(setting.get().getBoolean(entityType))).expandCellX().right().widget();
+        WCheckbox a = table.add(theme.checkbox(setting.get().contains(entityType))).expandCellX().right().widget();
         a.action = () -> {
             if (a.checked) {
-                setting.get().put(entityType, true);
+                setting.get().add(entityType);
                 switch (entityType.getSpawnGroup()) {
                     case CREATURE -> {
                         if (hasAnimal == 0) tableCheckbox.checked = true;
@@ -250,7 +248,7 @@ public class EntityTypeListSettingScreen extends WindowScreen {
                     }
                 }
             } else {
-                if (setting.get().removeBoolean(entityType)) {
+                if (setting.get().remove(entityType)) {
                     switch (entityType.getSpawnGroup()) {
                         case CREATURE -> {
                             hasAnimal--;

--- a/src/main/java/meteordevelopment/meteorclient/settings/EntityTypeListSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/EntityTypeListSetting.java
@@ -5,9 +5,7 @@
 
 package meteordevelopment.meteorclient.settings;
 
-import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
-import it.unimi.dsi.fastutil.objects.Object2BooleanOpenHashMap;
-import meteordevelopment.meteorclient.utils.Utils;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import meteordevelopment.meteorclient.utils.entity.EntityUtils;
 import net.minecraft.entity.EntityType;
 import net.minecraft.nbt.NbtCompound;
@@ -17,13 +15,14 @@ import net.minecraft.nbt.NbtString;
 import net.minecraft.registry.Registries;
 import net.minecraft.util.Identifier;
 
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
-public class EntityTypeListSetting extends Setting<Object2BooleanMap<EntityType<?>>> {
+public class EntityTypeListSetting extends Setting<Set<EntityType<?>>> {
     public final Predicate<EntityType<?>> filter;
 
-    public EntityTypeListSetting(String name, String description, Object2BooleanMap<EntityType<?>> defaultValue, Consumer<Object2BooleanMap<EntityType<?>>> onChanged, Consumer<Setting<Object2BooleanMap<EntityType<?>>>> onModuleActivated, IVisible visible, Predicate<EntityType<?>> filter) {
+    public EntityTypeListSetting(String name, String description, Set<EntityType<?>> defaultValue, Consumer<Set<EntityType<?>>> onChanged, Consumer<Setting<Set<EntityType<?>>>> onModuleActivated, IVisible visible, Predicate<EntityType<?>> filter) {
         super(name, description, defaultValue, onChanged, onModuleActivated, visible);
 
         this.filter = filter;
@@ -31,18 +30,18 @@ public class EntityTypeListSetting extends Setting<Object2BooleanMap<EntityType<
 
     @Override
     public void resetImpl() {
-        value = new Object2BooleanOpenHashMap<>(defaultValue);
+        value = new ObjectOpenHashSet<>(defaultValue);
     }
 
     @Override
-    protected Object2BooleanMap<EntityType<?>> parseImpl(String str) {
+    protected Set<EntityType<?>> parseImpl(String str) {
         String[] values = str.split(",");
-        Object2BooleanMap<EntityType<?>> entities = new Object2BooleanOpenHashMap<>(values.length);
+        Set<EntityType<?>> entities = new ObjectOpenHashSet<>(values.length);
 
         try {
             for (String value : values) {
                 EntityType<?> entity = parseId(Registries.ENTITY_TYPE, value);
-                if (entity != null) entities.put(entity, true);
+                if (entity != null) entities.add(entity);
             }
         } catch (Exception ignored) {}
 
@@ -50,7 +49,7 @@ public class EntityTypeListSetting extends Setting<Object2BooleanMap<EntityType<
     }
 
     @Override
-    protected boolean isValueValid(Object2BooleanMap<EntityType<?>> value) {
+    protected boolean isValueValid(Set<EntityType<?>> value) {
         return true;
     }
 
@@ -62,10 +61,8 @@ public class EntityTypeListSetting extends Setting<Object2BooleanMap<EntityType<
     @Override
     public NbtCompound save(NbtCompound tag) {
         NbtList valueTag = new NbtList();
-        for (EntityType<?> entityType : get().keySet()) {
-            if (get().getBoolean(entityType)) {
-                valueTag.add(NbtString.of(Registries.ENTITY_TYPE.getId(entityType).toString()));
-            }
+        for (EntityType<?> entityType : get()) {
+            valueTag.add(NbtString.of(Registries.ENTITY_TYPE.getId(entityType).toString()));
         }
         tag.put("value", valueTag);
 
@@ -73,27 +70,27 @@ public class EntityTypeListSetting extends Setting<Object2BooleanMap<EntityType<
     }
 
     @Override
-    public Object2BooleanMap<EntityType<?>> load(NbtCompound tag) {
+    public Set<EntityType<?>> load(NbtCompound tag) {
         get().clear();
 
         NbtList valueTag = tag.getList("value", 8);
         for (NbtElement tagI : valueTag) {
             EntityType<?> type = Registries.ENTITY_TYPE.get(new Identifier(tagI.asString()));
-            if (filter == null || filter.test(type)) get().put(type, true);
+            if (filter == null || filter.test(type)) get().add(type);
         }
 
         return get();
     }
 
-    public static class Builder extends SettingBuilder<Builder, Object2BooleanMap<EntityType<?>>, EntityTypeListSetting> {
+    public static class Builder extends SettingBuilder<Builder, Set<EntityType<?>>, EntityTypeListSetting> {
         private Predicate<EntityType<?>> filter;
 
         public Builder() {
-            super(new Object2BooleanOpenHashMap<>(0));
+            super(new ObjectOpenHashSet<>(0));
         }
 
         public Builder defaultValue(EntityType<?>... defaults) {
-            return defaultValue(defaults != null ? Utils.asO2BMap(defaults) : new Object2BooleanOpenHashMap<>(0));
+            return defaultValue(defaults != null ? new ObjectOpenHashSet<>(defaults) : new ObjectOpenHashSet<>(0));
         }
 
         public Builder onlyAttackable() {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/BowAimbot.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/BowAimbot.java
@@ -6,7 +6,6 @@
 package meteordevelopment.meteorclient.systems.modules.combat;
 
 import baritone.api.BaritoneAPI;
-import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
 import meteordevelopment.meteorclient.events.render.Render3DEvent;
 import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.friends.Friends;
@@ -28,6 +27,8 @@ import net.minecraft.item.ArrowItem;
 import net.minecraft.item.Items;
 import net.minecraft.util.math.Vec3d;
 
+import java.util.Set;
+
 public class BowAimbot extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
 
@@ -40,7 +41,7 @@ public class BowAimbot extends Module {
         .build()
     );
 
-    private final Setting<Object2BooleanMap<EntityType<?>>> entities = sgGeneral.add(new EntityTypeListSetting.Builder()
+    private final Setting<Set<EntityType<?>>> entities = sgGeneral.add(new EntityTypeListSetting.Builder()
         .name("entities")
         .description("Entities to attack.")
         .onlyAttackable()
@@ -98,7 +99,7 @@ public class BowAimbot extends Module {
             if (entity == mc.player || entity == mc.cameraEntity) return false;
             if ((entity instanceof LivingEntity && ((LivingEntity) entity).isDead()) || !entity.isAlive()) return false;
             if (!PlayerUtils.isWithin(entity, range.get())) return false;
-            if (!entities.get().getBoolean(entity.getType())) return false;
+            if (!entities.get().contains(entity.getType())) return false;
             if (!nametagged.get() && entity.hasCustomName()) return false;
             if (!PlayerUtils.canSeeEntity(entity)) return false;
             if (entity instanceof PlayerEntity) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Hitboxes.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Hitboxes.java
@@ -5,7 +5,6 @@
 
 package meteordevelopment.meteorclient.systems.modules.combat;
 
-import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
 import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
@@ -15,10 +14,12 @@ import net.minecraft.entity.EntityType;
 import net.minecraft.item.AxeItem;
 import net.minecraft.item.SwordItem;
 
+import java.util.Set;
+
 public class Hitboxes extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
 
-    private final Setting<Object2BooleanMap<EntityType<?>>> entities = sgGeneral.add(new EntityTypeListSetting.Builder()
+    private final Setting<Set<EntityType<?>>> entities = sgGeneral.add(new EntityTypeListSetting.Builder()
         .name("entities")
         .description("Which entities to target.")
         .defaultValue(EntityType.PLAYER)
@@ -45,7 +46,7 @@ public class Hitboxes extends Module {
 
     public double getEntityValue(Entity entity) {
         if (!(isActive() && testWeapon())) return 0;
-        if (entities.get().getBoolean(entity.getType())) return value.get();
+        if (entities.get().contains(entity.getType())) return value.get();
         return 0;
     }
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/KillAura.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/KillAura.java
@@ -6,7 +6,6 @@
 package meteordevelopment.meteorclient.systems.modules.combat;
 
 import baritone.api.BaritoneAPI;
-import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
 import meteordevelopment.meteorclient.events.packets.PacketEvent;
 import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.settings.*;
@@ -45,6 +44,7 @@ import net.minecraft.world.GameMode;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 
 public class KillAura extends Module {
@@ -106,7 +106,7 @@ public class KillAura extends Module {
 
     // Targeting
 
-    private final Setting<Object2BooleanMap<EntityType<?>>> entities = sgTargeting.add(new EntityTypeListSetting.Builder()
+    private final Setting<Set<EntityType<?>>> entities = sgTargeting.add(new EntityTypeListSetting.Builder()
         .name("entities")
         .description("Entities to attack.")
         .onlyAttackable()
@@ -337,7 +337,7 @@ public class KillAura extends Module {
             range.get()
         )) return false;
 
-        if (!entities.get().getBoolean(entity.getType())) return false;
+        if (!entities.get().contains(entity.getType())) return false;
         if (ignoreNamed.get() && entity.hasCustomName()) return false;
         if (!PlayerUtils.canSeeEntity(entity) && !PlayerUtils.isWithin(entity, wallsRange.get())) return false;
         if (ignoreTamed.get()) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notifier.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notifier.java
@@ -5,7 +5,6 @@
 
 package meteordevelopment.meteorclient.systems.modules.misc;
 
-import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import meteordevelopment.meteorclient.events.entity.EntityAddedEvent;
@@ -32,10 +31,7 @@ import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.math.Vec3d;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Random;
-import java.util.UUID;
+import java.util.*;
 
 import static meteordevelopment.meteorclient.utils.player.ChatUtils.formatCoords;
 
@@ -90,7 +86,7 @@ public class Notifier extends Module {
         .build()
     );
 
-    private final Setting<Object2BooleanMap<EntityType<?>>> entities = sgVisualRange.add(new EntityTypeListSetting.Builder()
+    private final Setting<Set<EntityType<?>>> entities = sgVisualRange.add(new EntityTypeListSetting.Builder()
         .name("entities")
         .description("Which entities to notify about.")
         .defaultValue(EntityType.PLAYER)
@@ -155,7 +151,7 @@ public class Notifier extends Module {
 
     @EventHandler
     private void onEntityAdded(EntityAddedEvent event) {
-        if (!event.entity.getUuid().equals(mc.player.getUuid()) && entities.get().getBoolean(event.entity.getType()) && visualRange.get() && this.event.get() != Event.Despawn) {
+        if (!event.entity.getUuid().equals(mc.player.getUuid()) && entities.get().contains(event.entity.getType()) && visualRange.get() && this.event.get() != Event.Despawn) {
             if (event.entity instanceof PlayerEntity) {
                 if ((!visualRangeIgnoreFriends.get() || !Friends.get().isFriend(((PlayerEntity) event.entity))) && (!visualRangeIgnoreFakes.get() || !(event.entity instanceof FakePlayerEntity))) {
                     ChatUtils.sendMsg(event.entity.getId() + 100, Formatting.GRAY, "(highlight)%s(default) has entered your visual range!", event.entity.getEntityName());
@@ -181,7 +177,7 @@ public class Notifier extends Module {
 
     @EventHandler
     private void onEntityRemoved(EntityRemovedEvent event) {
-        if (!event.entity.getUuid().equals(mc.player.getUuid()) && entities.get().getBoolean(event.entity.getType()) && visualRange.get() && this.event.get() != Event.Spawn) {
+        if (!event.entity.getUuid().equals(mc.player.getUuid()) && entities.get().contains(event.entity.getType()) && visualRange.get() && this.event.get() != Event.Spawn) {
             if (event.entity instanceof PlayerEntity) {
                 if ((!visualRangeIgnoreFriends.get() || !Friends.get().isFriend(((PlayerEntity) event.entity))) && (!visualRangeIgnoreFakes.get() || !(event.entity instanceof FakePlayerEntity))) {
                     ChatUtils.sendMsg(event.entity.getId() + 100, Formatting.GRAY, "(highlight)%s(default) has left your visual range!", event.entity.getEntityName());

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/NoInteract.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/NoInteract.java
@@ -5,7 +5,6 @@
 
 package meteordevelopment.meteorclient.systems.modules.player;
 
-import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
 import meteordevelopment.meteorclient.events.entity.player.AttackEntityEvent;
 import meteordevelopment.meteorclient.events.entity.player.InteractBlockEvent;
 import meteordevelopment.meteorclient.events.entity.player.InteractEntityEvent;
@@ -26,6 +25,7 @@ import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
 
 import java.util.List;
+import java.util.Set;
 
 public class NoInteract extends Module {
     private final SettingGroup sgBlocks = settings.createGroup("Blocks");
@@ -68,7 +68,7 @@ public class NoInteract extends Module {
 
     // Entities
 
-    private final Setting<Object2BooleanMap<EntityType<?>>> entityHit = sgEntities.add(new EntityTypeListSetting.Builder()
+    private final Setting<Set<EntityType<?>>> entityHit = sgEntities.add(new EntityTypeListSetting.Builder()
         .name("entity-hit")
         .description("Cancel entity hitting.")
         .onlyAttackable()
@@ -82,7 +82,7 @@ public class NoInteract extends Module {
         .build()
     );
 
-    private final Setting<Object2BooleanMap<EntityType<?>>> entityInteract = sgEntities.add(new EntityTypeListSetting.Builder()
+    private final Setting<Set<EntityType<?>>> entityInteract = sgEntities.add(new EntityTypeListSetting.Builder()
         .name("entity-interact")
         .description("Cancel entity interaction.")
         .onlyAttackable()
@@ -194,12 +194,12 @@ public class NoInteract extends Module {
 
         // Entities
         if (entityHitMode.get() == ListMode.BlackList &&
-            entityHit.get().getBoolean(entity.getType())) {
+            entityHit.get().contains(entity.getType())) {
             return false;
         }
 
         else return entityHitMode.get() != ListMode.WhiteList ||
-            entityHit.get().getBoolean(entity.getType());
+            entityHit.get().contains(entity.getType());
     }
 
     private boolean shouldInteractEntity(Entity entity, Hand hand) {
@@ -227,11 +227,11 @@ public class NoInteract extends Module {
 
         // Entities
         if (entityInteractMode.get() == ListMode.BlackList &&
-            entityInteract.get().getBoolean(entity.getType())) {
+            entityInteract.get().contains(entity.getType())) {
             return false;
         }
         else return entityInteractMode.get() != ListMode.WhiteList ||
-            entityInteract.get().getBoolean(entity.getType());
+            entityInteract.get().contains(entity.getType());
     }
 
     public enum HandMode {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Chams.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Chams.java
@@ -5,7 +5,6 @@
 
 package meteordevelopment.meteorclient.systems.modules.render;
 
-import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
 import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
@@ -17,6 +16,8 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.util.Identifier;
 
+import java.util.Set;
+
 public class Chams extends Module {
     private final SettingGroup sgThroughWalls = settings.createGroup("Through Walls");
     private final SettingGroup sgPlayers = settings.createGroup("Players");
@@ -25,7 +26,7 @@ public class Chams extends Module {
 
     // Through walls
 
-    public final Setting<Object2BooleanMap<EntityType<?>>> entities = sgThroughWalls.add(new EntityTypeListSetting.Builder()
+    public final Setting<Set<EntityType<?>>> entities = sgThroughWalls.add(new EntityTypeListSetting.Builder()
         .name("entities")
         .description("Select entities to show through walls.")
         .build()
@@ -221,7 +222,7 @@ public class Chams extends Module {
     }
 
     public boolean shouldRender(Entity entity) {
-        return isActive() && !isShader() && entities.get().getBoolean(entity.getType()) && (entity != mc.player || ignoreSelfDepth.get());
+        return isActive() && !isShader() && entities.get().contains(entity.getType()) && (entity != mc.player || ignoreSelfDepth.get());
     }
 
     public boolean isShader() {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/ESP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/ESP.java
@@ -5,7 +5,6 @@
 
 package meteordevelopment.meteorclient.systems.modules.render;
 
-import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
 import meteordevelopment.meteorclient.events.render.Render2DEvent;
 import meteordevelopment.meteorclient.events.render.Render3DEvent;
 import meteordevelopment.meteorclient.renderer.Renderer2D;
@@ -28,6 +27,8 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.math.Box;
 import net.minecraft.util.math.MathHelper;
 import org.joml.Vector3d;
+
+import java.util.Set;
 
 public class ESP extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
@@ -96,7 +97,7 @@ public class ESP extends Module {
         .build()
     );
 
-    private final Setting<Object2BooleanMap<EntityType<?>>> entities = sgGeneral.add(new EntityTypeListSetting.Builder()
+    private final Setting<Set<EntityType<?>>> entities = sgGeneral.add(new EntityTypeListSetting.Builder()
         .name("entities")
         .description("Select specific entities.")
         .defaultValue(EntityType.PLAYER)
@@ -296,14 +297,14 @@ public class ESP extends Module {
     // Utils
 
     public boolean shouldSkip(Entity entity) {
-        if (!entities.get().getBoolean(entity.getType())) return true;
+        if (!entities.get().contains(entity.getType())) return true;
         if (entity == mc.player && ignoreSelf.get()) return true;
         if (entity == mc.cameraEntity && mc.options.getPerspective().isFirstPerson()) return true;
         return !EntityUtils.isInRenderDistance(entity);
     }
 
     public Color getColor(Entity entity) {
-        if (!entities.get().getBoolean(entity.getType())) return null;
+        if (!entities.get().contains(entity.getType())) return null;
 
         double alpha = getFadeAlpha(entity);
         if (alpha == 0) return null;

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Nametags.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Nametags.java
@@ -5,7 +5,6 @@
 
 package meteordevelopment.meteorclient.systems.modules.render;
 
-import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
 import meteordevelopment.meteorclient.events.render.Render2DEvent;
 import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.renderer.Renderer2D;
@@ -47,7 +46,7 @@ public class Nametags extends Module {
 
     // General
 
-    private final Setting<Object2BooleanMap<EntityType<?>>> entities = sgGeneral.add(new EntityTypeListSetting.Builder()
+    private final Setting<Set<EntityType<?>>> entities = sgGeneral.add(new EntityTypeListSetting.Builder()
         .name("entities")
         .description("Select entities to draw nametags on.")
         .defaultValue(EntityType.PLAYER, EntityType.ITEM)
@@ -302,7 +301,7 @@ public class Nametags extends Module {
 
         for (Entity entity : mc.world.getEntities()) {
             EntityType<?> type = entity.getType();
-            if (!entities.get().containsKey(type)) continue;
+            if (!entities.get().contains(type)) continue;
 
             if (type == EntityType.PLAYER) {
                 if ((ignoreSelf.get() || (freecamNotActive && notThirdPerson)) && entity == mc.player) continue;
@@ -664,6 +663,6 @@ public class Nametags extends Module {
     }
 
     public boolean playerNametags() {
-        return isActive() && entities.get().containsKey(EntityType.PLAYER);
+        return isActive() && entities.get().contains(EntityType.PLAYER);
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/NoRender.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/NoRender.java
@@ -5,7 +5,6 @@
 
 package meteordevelopment.meteorclient.systems.modules.render;
 
-import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
 import meteordevelopment.meteorclient.events.world.ChunkOcclusionEvent;
 import meteordevelopment.meteorclient.events.world.ParticleEvent;
 import meteordevelopment.meteorclient.settings.*;
@@ -18,6 +17,7 @@ import net.minecraft.particle.ParticleType;
 import net.minecraft.particle.ParticleTypes;
 
 import java.util.List;
+import java.util.Set;
 
 public class NoRender extends Module {
     private final SettingGroup sgOverlay = settings.createGroup("Overlay");
@@ -292,7 +292,7 @@ public class NoRender extends Module {
 
     // Entity
 
-    private final Setting<Object2BooleanMap<EntityType<?>>> entities = sgEntity.add(new EntityTypeListSetting.Builder()
+    private final Setting<Set<EntityType<?>>> entities = sgEntity.add(new EntityTypeListSetting.Builder()
         .name("entities")
         .description("Disables rendering of selected entities.")
         .build()
@@ -523,11 +523,11 @@ public class NoRender extends Module {
     // Entity
 
     public boolean noEntity(Entity entity) {
-        return isActive() && entities.get().getBoolean(entity.getType());
+        return isActive() && entities.get().contains(entity.getType());
     }
 
     public boolean noEntity(EntityType<?> entity) {
-        return isActive() && entities.get().getBoolean(entity);
+        return isActive() && entities.get().contains(entity);
     }
 
     public boolean getDropSpawnPacket() {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Tracers.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Tracers.java
@@ -5,21 +5,15 @@
 
 package meteordevelopment.meteorclient.systems.modules.render;
 
-import com.mojang.blaze3d.systems.RenderSystem;
-import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
-import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.events.render.Render2DEvent;
 import meteordevelopment.meteorclient.events.render.Render3DEvent;
-import meteordevelopment.meteorclient.gui.renderer.GuiRenderer;
 import meteordevelopment.meteorclient.renderer.Renderer2D;
 import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.config.Config;
 import meteordevelopment.meteorclient.systems.friends.Friends;
-import meteordevelopment.meteorclient.systems.hud.HudRenderer;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.systems.modules.Modules;
-import meteordevelopment.meteorclient.utils.Utils;
 import meteordevelopment.meteorclient.utils.entity.EntityUtils;
 import meteordevelopment.meteorclient.utils.entity.Target;
 import meteordevelopment.meteorclient.utils.player.PlayerUtils;
@@ -28,18 +22,16 @@ import meteordevelopment.meteorclient.utils.render.RenderUtils;
 import meteordevelopment.meteorclient.utils.render.color.Color;
 import meteordevelopment.meteorclient.utils.render.color.SettingColor;
 import meteordevelopment.orbit.EventHandler;
-import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.math.Vec2f;
-import net.minecraft.util.math.Vec3d;
 import org.joml.Vector2f;
 import org.joml.Vector3d;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Timer;
+import java.util.Set;
 
 public class Tracers extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
@@ -53,7 +45,7 @@ public class Tracers extends Module {
 
     // General
 
-    private final Setting<Object2BooleanMap<EntityType<?>>> entities = sgGeneral.add(new EntityTypeListSetting.Builder()
+    private final Setting<Set<EntityType<?>>> entities = sgGeneral.add(new EntityTypeListSetting.Builder()
         .name("entities")
         .description("Select specific entities.")
         .defaultValue(EntityType.PLAYER)
@@ -219,7 +211,7 @@ public class Tracers extends Module {
     }
 
     private boolean shouldBeIgnored(Entity entity) {
-        return !PlayerUtils.isWithin(entity, maxDist.get()) || (!Modules.get().isActive(Freecam.class) && entity == mc.player) || !entities.get().getBoolean(entity.getType()) || (ignoreFriends.get() && entity instanceof PlayerEntity && Friends.get().isFriend((PlayerEntity) entity)) || (!showInvis.get() && entity.isInvisible()) | !EntityUtils.isInRenderDistance(entity);
+        return !PlayerUtils.isWithin(entity, maxDist.get()) || (!Modules.get().isActive(Freecam.class) && entity == mc.player) || !entities.get().contains(entity.getType()) || (ignoreFriends.get() && entity instanceof PlayerEntity && Friends.get().isFriend((PlayerEntity) entity)) || (!showInvis.get() && entity.isInvisible()) | !EntityUtils.isInRenderDistance(entity);
     }
 
     private Color getEntityColor(Entity entity) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoBreed.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoBreed.java
@@ -5,7 +5,6 @@
 
 package meteordevelopment.meteorclient.systems.modules.world;
 
-import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
 import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Categories;
@@ -20,11 +19,12 @@ import net.minecraft.util.Hand;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 public class AutoBreed extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
 
-    private final Setting<Object2BooleanMap<EntityType<?>>> entities = sgGeneral.add(new EntityTypeListSetting.Builder()
+    private final Setting<Set<EntityType<?>>> entities = sgGeneral.add(new EntityTypeListSetting.Builder()
         .name("entities")
         .description("Entities to breed.")
         .defaultValue(EntityType.HORSE, EntityType.DONKEY, EntityType.COW,
@@ -76,7 +76,7 @@ public class AutoBreed extends Module {
             if (!(entity instanceof AnimalEntity)) continue;
             else animal = (AnimalEntity) entity;
 
-            if (!entities.get().getBoolean(animal.getType())
+            if (!entities.get().contains(animal.getType())
                     || (animal.isBaby() && !ignoreBabies.get())
                     || animalsFed.contains(animal)
                     || !PlayerUtils.isWithin(animal, range.get())

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoNametag.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoNametag.java
@@ -5,7 +5,6 @@
 
 package meteordevelopment.meteorclient.systems.modules.world;
 
-import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
 import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Categories;
@@ -22,10 +21,12 @@ import net.minecraft.entity.EntityType;
 import net.minecraft.item.Items;
 import net.minecraft.util.Hand;
 
+import java.util.Set;
+
 public class AutoNametag extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
 
-    private final Setting<Object2BooleanMap<EntityType<?>>> entities = sgGeneral.add(new EntityTypeListSetting.Builder()
+    private final Setting<Set<EntityType<?>>> entities = sgGeneral.add(new EntityTypeListSetting.Builder()
         .name("entities")
         .description("Which entities to nametag.")
         .build()
@@ -83,7 +84,7 @@ public class AutoNametag extends Module {
         // Target
         target = TargetUtils.get(entity -> {
             if (!PlayerUtils.isWithin(entity, range.get())) return false;
-            if (!entities.get().getBoolean(entity.getType())) return false;
+            if (!entities.get().contains(entity.getType())) return false;
             if (entity.hasCustomName()) {
                 return renametag.get() && entity.getCustomName() != mc.player.getInventory().getStack(findNametag.slot()).getName();
             }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/Flamethrower.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/Flamethrower.java
@@ -5,7 +5,6 @@
 
 package meteordevelopment.meteorclient.systems.modules.world;
 
-import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
 import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Categories;
@@ -25,6 +24,8 @@ import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
+
+import java.util.Set;
 
 public class Flamethrower extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
@@ -71,7 +72,7 @@ public class Flamethrower extends Module {
         .build()
     );
 
-    private final Setting<Object2BooleanMap<EntityType<?>>> entities = sgGeneral.add(new EntityTypeListSetting.Builder()
+    private final Setting<Set<EntityType<?>>> entities = sgGeneral.add(new EntityTypeListSetting.Builder()
         .name("entities")
         .description("Entities to cook.")
         .defaultValue(
@@ -102,7 +103,7 @@ public class Flamethrower extends Module {
         entity = null;
         ticks++;
         for (Entity entity : mc.world.getEntities()) {
-            if (!entities.get().getBoolean(entity.getType()) || !PlayerUtils.isWithin(entity, distance.get())) continue;
+            if (!entities.get().contains(entity.getType()) || !PlayerUtils.isWithin(entity, distance.get())) continue;
             if (entity.isFireImmune()) continue;
             if (entity == mc.player) continue;
             if (!targetBabies.get() && entity instanceof LivingEntity && ((LivingEntity)entity).isBaby()) continue;

--- a/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
@@ -6,7 +6,6 @@
 package meteordevelopment.meteorclient.utils;
 
 import com.mojang.blaze3d.systems.RenderSystem;
-import it.unimi.dsi.fastutil.objects.Object2BooleanOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2IntArrayMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import meteordevelopment.meteorclient.MeteorClient;
@@ -100,7 +99,7 @@ public class Utils {
             tY *= timer.getMultiplier();
             tZ *= timer.getMultiplier();
         }
-        
+
         tX *= 20;
         tY *= 20;
         tZ *= 20;
@@ -552,14 +551,6 @@ public class Utils {
                 break;
             }
         }
-    }
-
-    @SafeVarargs
-    public static <T> Object2BooleanOpenHashMap<T> asO2BMap(T... checked) {
-        Map<T, Boolean> map = new HashMap<>();
-        for (T item : checked)
-            map.put(item, true);
-        return new Object2BooleanOpenHashMap<>(map);
     }
 
     public static Color lerp(Color first, Color second, @Range(from = 0, to = 1) float v) {

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/postprocess/ChamsShader.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/postprocess/ChamsShader.java
@@ -97,6 +97,6 @@ public class ChamsShader extends EntityShader {
     @Override
     public boolean shouldDraw(Entity entity) {
         if (!shouldDraw()) return false;
-        return chams.entities.get().getBoolean(entity.getType()) && (entity != mc.player || !chams.ignoreSelfDepth.get());
+        return chams.entities.get().contains(entity.getType()) && (entity != mc.player || !chams.ignoreSelfDepth.get());
     }
 }


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

Make `EntityTypeListSetting` use a fastutil `ObjectOpenHashSet` instead of a fastutil `Object2BooleanOpenHashMap`

Benefits:
- Lower memory usage (No need for the map's value array)
- HashMap value was always `true`
- Simpler to use, before modules used both `entityTypeList.get().containsKey()` and `entityTypeList.get().getBoolean()` for the same usage, it has been changed to `entityTypeList.get().contains()`. Looping is now `for (var type : entityTypeList.get())` instead of `for (var type : entityTypeList.get().entrySet())`

# How Has This Been Tested?

![2023-05-15_16 49 29](https://github.com/MeteorDevelopment/meteor-client/assets/32882447/55008d62-9b7f-448e-ae77-046ebc88e3eb)
workey no crashey

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
