### PR TITLE
Update MeteorExecutor.java

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/utils/network/MeteorExecutor.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/network/MeteorExecutor.java
@@ -9,13 +9,21 @@ import meteordevelopment.meteorclient.utils.PreInit;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class MeteorExecutor {
     public static ExecutorService executor;
 
     @PreInit
     public static void init() {
-        executor = Executors.newSingleThreadExecutor();
+        AtomicInteger threadNumber = new AtomicInteger(1);
+
+        executor = Executors.newCachedThreadPool((task) -> {
+            Thread thread = new Thread(task);
+            thread.setDaemon(true);
+            thread.setName("Meteor-Executor-" + threadNumber.getAndIncrement());
+            return thread;
+        });
     }
 
     public static void execute(Runnable task) {


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

1. Give the Meteor thread executor a proper name in order to make it easier to diagnose errors.
2. Make the Meteor thread executor a cached `ThreadPoolExecutor` in order to prevent addons fighting over the single thread during init

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
