### PR TITLE
Verbose addon crash

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/addons/AddonManager.java
+++ b/src/main/java/meteordevelopment/meteorclient/addons/AddonManager.java
@@ -63,11 +63,16 @@ public class AddonManager {
         // Addons
         for (EntrypointContainer<MeteorAddon> entrypoint : FabricLoader.getInstance().getEntrypointContainers("meteor", MeteorAddon.class)) {
             ModMetadata metadata = entrypoint.getProvider().getMetadata();
-            MeteorAddon addon = entrypoint.getEntrypoint();
+            MeteorAddon addon;
+            try {
+                addon = entrypoint.getEntrypoint();
+            } catch (NoClassDefFoundError exception) {
+                throw new RuntimeException("Addon \"%s\" is using an outdated addon API version.".formatted(metadata.getName()), exception);
+            }
 
             addon.name = metadata.getName();
 
-            if (metadata.getAuthors().isEmpty()) throw new RuntimeException("Addon %s requires at least 1 author to be defined in it's fabric.mod.json. See https://fabricmc.net/wiki/documentation:fabric_mod_json_spec".formatted(addon.name));
+            if (metadata.getAuthors().isEmpty()) throw new RuntimeException("Addon \"%s\" requires at least 1 author to be defined in it's fabric.mod.json. See https://fabricmc.net/wiki/documentation:fabric_mod_json_spec".formatted(addon.name));
             addon.authors = new String[metadata.getAuthors().size()];
 
             if (metadata.containsCustomValue(MeteorClient.MOD_ID + ":color")) {


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

Makes the `java.lang.NoClassDefFoundError: meteordevelopment/meteorclient/systems/commands/Command` crash reason point to the addon causing it.

# How Has This Been Tested?

:trollswagcat:

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
