### PR TITLE
auto log 20 to 19 max

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/AutoLog.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/AutoLog.java
@@ -31,8 +31,8 @@ public class AutoLog extends Module {
         .name("health")
         .description("Automatically disconnects when health is lower or equal to this value.")
         .defaultValue(6)
-        .range(0, 20)
-        .sliderMax(20)
+        .range(0, 19)
+        .sliderMax(19)
         .build()
     );
 


### PR DESCRIPTION
## Type of change

- [X ] Bug fix
- [ ] New feature

## Description
Changes auto log max health to disconnect from 20 to 19.

A summary of the changes along with the reasoning behind the changes.
My friend set his auto disconnect to 20. He can't join single player or multiplayer. This should fix the problem for the future.

## Related issues

Mention any issues that this pr relates to.

# How Has This Been Tested?

Videos or screenshots of the changes if applicable.

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [ ] I have tested the code in both development and production environments.
