### PR TITLE
Fix infinity miner not correctly calculating if full

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/InfinityMiner.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/InfinityMiner.java
@@ -232,10 +232,10 @@ public class InfinityMiner extends Module {
     private boolean isFull() {
         for (int i = 0; i <= 35; i++) {
             ItemStack itemStack = mc.player.getInventory().getStack(i);
-
+            if (itemStack.isEmpty()) return false;
+            
             for (Item item : targetItems.get()) {
-                if ((itemStack.getItem() == item && itemStack.getCount() < itemStack.getMaxCount())
-                    || itemStack.isEmpty()) {
+                if (itemStack.getItem() == item && itemStack.getCount() < itemStack.getMaxCount()) {
                     return false;
                 }
             }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Previously if you didnt have any target items it would always say your inventory was full, even if empty. It's probably not intended to have zero target items, but it always failing if so isn't particularly desireable.

# How Has This Been Tested?

Tested the build artifact and it seems to work as intended

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
