### PR TITLE
Change new value to actual new value in the settings command

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/SettingCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/SettingCommand.java
@@ -61,7 +61,7 @@ public class SettingCommand extends Command {
                                     String value = SettingValueArgumentType.get(context);
 
                                     if (setting.parse(value)) {
-                                        ModuleArgumentType.get(context).info("Setting (highlight)%s(default) changed to (highlight)%s(default).", setting.title, value);
+                                        ModuleArgumentType.get(context).info("Setting (highlight)%s(default) changed to (highlight)%s(default).", setting.title, setting.get().toString());
                                     }
 
                                     return SINGLE_SUCCESS;


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

This will change the chat feedbacks new value to the actual new value instead of the command input, useful if you are using `toggle`

## Related issues

\-

# How Has This Been Tested?

Before:
<img width="1559" alt="image" src="https://github.com/MeteorDevelopment/meteor-client/assets/73178245/80fb2c12-da1e-4aec-82b1-7757f04ec247">


After:
<img width="1510" alt="image" src="https://github.com/MeteorDevelopment/meteor-client/assets/73178245/3e5e7891-f900-4995-b3a9-09225f192dec">


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
