### PR TITLE
Always return response body, not only with an HTTP code of 200

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/utils/network/Http.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/network/Http.java
@@ -90,7 +90,7 @@ public class Http {
 
             try {
                 var res = CLIENT.send(builder.build(), responseBodyHandler);
-                return res.statusCode() == 200 ? res.body() : null;
+                return res.body();
             } catch (IOException | InterruptedException e) {
                 e.printStackTrace();
                 return null;


### PR DESCRIPTION
## Description

In the old version the response body was for some reason only returned, if the status code is 200. If an API (like mine) uses special status codes and gives a detailed error in the response, you cannot fetch it

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
