### PR TITLE
Fix irregular capitalization in module definitions

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/swarm/Swarm.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/swarm/Swarm.java
@@ -50,7 +50,7 @@ public class Swarm extends Module {
     public SwarmWorker worker;
 
     public Swarm() {
-        super(Categories.Misc, "Swarm", "Allows you to control multiple instances of Meteor from one central host.");
+        super(Categories.Misc, "swarm", "Allows you to control multiple instances of Meteor from one central host.");
     }
 
     @Override

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/TunnelESP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/TunnelESP.java
@@ -79,7 +79,7 @@ public class TunnelESP extends Module {
     private final Long2ObjectMap<TChunk> chunks = new Long2ObjectOpenHashMap<>();
 
     public TunnelESP() {
-        super(Categories.Render, "tunnel-ESP", "Highlights tunnels.");
+        super(Categories.Render, "tunnel-esp", "Highlights tunnels.");
     }
 
     @Override


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

Swarm and TunnelESP are the only modules that have a capitalized letter in their definition. I was going through .settings and realized that. (Re-opened from #3723 as I pushed too much)

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
