### PR TITLE
Add delay to macros

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/macros/Macro.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/macros/Macro.java
@@ -5,12 +5,15 @@
 
 package meteordevelopment.meteorclient.systems.macros;
 
+import meteordevelopment.meteorclient.events.game.GameLeftEvent;
+import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.gui.utils.StarscriptTextBoxRenderer;
 import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.utils.misc.ISerializable;
 import meteordevelopment.meteorclient.utils.misc.Keybind;
 import meteordevelopment.meteorclient.utils.misc.MeteorStarscript;
 import meteordevelopment.meteorclient.utils.player.ChatUtils;
+import meteordevelopment.orbit.EventHandler;
 import meteordevelopment.starscript.Script;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;
@@ -36,19 +39,33 @@ public class Macro implements ISerializable<Macro> {
     public Setting<List<String>> messages = sgGeneral.add(new StringListSetting.Builder()
         .name("messages")
         .description("The messages for the macro to send.")
-        .onChanged(v -> dirty = true)
         .renderer(StarscriptTextBoxRenderer.class)
         .build()
     );
+
+    private final Setting<Boolean> useDelay = sgGeneral.add(new BoolSetting.Builder()
+        .name("use-delay")
+        .description("Use delay between sending messages.")
+        .defaultValue(false)
+        .build()
+    );
+
+    public Setting<Integer> delay = sgGeneral.add(new IntSetting.Builder()
+        .name("delay")
+        .description("The delay between specified messages in ticks.")
+        .defaultValue(20)
+        .visible(useDelay::get)
+        .min(1)
+        .sliderMax(200)
+        .build()
+    );
+
 
     public Setting<Keybind> keybind = sgGeneral.add(new KeybindSetting.Builder()
         .name("keybind")
         .description("The bind to run the macro.")
         .build()
     );
-
-    private final List<Script> scripts = new ArrayList<>(1);
-    private boolean dirty;
 
     public Macro() {}
     public Macro(NbtElement tag) {
@@ -60,27 +77,45 @@ public class Macro implements ISerializable<Macro> {
         return onAction();
     }
 
-    public boolean onAction() {
-            if (dirty) {
-                scripts.clear();
+    private final List<Object[]> toSend = new ArrayList<>();
 
+    public boolean onAction() {
+            if (useDelay.get()) {
+                if (mc.world == null) return false;
+                for (int i = 0; i < messages.get().size(); i++) {
+                    toSend.add(new Object[]{mc.world.getTime() + (delay.get() * i), messages.get().get(i)});
+                }
+            } else {
                 for (String message : messages.get()) {
                     Script script = MeteorStarscript.compile(message);
-                    if (script != null) scripts.add(script);
-                }
-
-                dirty = false;
-            }
-
-            for (Script script : scripts) {
-                String message = MeteorStarscript.run(script);
-
-                if (message != null) {
-                    ChatUtils.sendPlayerMsg(message);
+                    if (script != null) {
+                        String messageToSend = MeteorStarscript.run(script);
+                        ChatUtils.sendPlayerMsg(messageToSend);
+                    }
                 }
             }
 
             return true;
+    }
+
+    @EventHandler
+    public void onTick(TickEvent.Post event) {
+        if (mc.world == null) return;
+        for (Object[] row : new ArrayList<>(toSend)) {
+            if ((long) row[0] <= mc.world.getTime()) {
+                Script script = MeteorStarscript.compile((String) row[1]);
+                if (script != null) {
+                    String messageToSend = MeteorStarscript.run(script);
+                    ChatUtils.sendPlayerMsg(messageToSend);
+                }
+                toSend.remove(row);
+            }
+        }
+    }
+
+    @EventHandler
+    public void onGameLeft(GameLeftEvent event) {
+        toSend.clear();
     }
 
     @Override


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Adds ability to use delay (between messages) in macros. 

## Related issues

\-

# How Has This Been Tested?

Delay disabled:
![scr1](https://github.com/Zgoly/meteor-client/assets/46041044/9fb6829a-78b1-436b-bc67-fee8e68c9445)

Delay enabled:
![scr2](https://github.com/Zgoly/meteor-client/assets/46041044/f2e7852c-32c6-42dc-b737-21e0e6eb2c6e)

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
