### PR TITLE
Fix rainbow colour not working for friends

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/Systems.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/Systems.java
@@ -34,9 +34,13 @@ public class Systems {
     }
 
     public static void init() {
-        System<?> config = add(new Config());
-        config.init();
-        config.load();
+        Config config = new Config();
+        System<?> configSystem = add(config);
+        configSystem.init();
+        configSystem.load();
+
+        // Registers the colors from config tab. This allows rainbow colours to work for friends.
+        config.settings.registerColorSettings(null);
 
         add(new Modules());
         add(new Macros());


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

Patch that fixes rainbow colours not working for friends

# How Has This Been Tested?

Added friend, they glow rainbow and the game doesn't immediately crash

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
