### PR TITLE
Fix anti spam

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/ChatHudMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ChatHudMixin.java
@@ -85,7 +85,13 @@ public abstract class ChatHudMixin implements IChatHud {
         if (event.isCancelled()) info.cancel();
         else {
             visibleMessages.removeIf(msg -> ((IChatHudLine) (Object) msg).getId() == nextId && nextId != 0);
-            messages.removeIf(msg -> ((IChatHudLine) (Object) msg).getId() == nextId && nextId != 0);
+
+            for (int i = messages.size() - 1; i > -1 ; i--) {
+                if (((IChatHudLine) (Object) messages.get(i)).getId() == nextId && nextId != 0) {
+                    messages.remove(i);
+                    Modules.get().get(BetterChat.class).lines.remove(i);
+                }
+            }
 
             if (event.isModified()) {
                 info.cancel();
@@ -236,6 +242,11 @@ public abstract class ChatHudMixin implements IChatHud {
 
     @Inject(method = "clear", at = @At("HEAD"))
     private void onClear(boolean clearHistory, CallbackInfo ci) {
+        Modules.get().get(BetterChat.class).lines.clear();
+    }
+
+    @Inject(method = "refresh", at = @At("HEAD"))
+    private void onRefresh(CallbackInfo ci) {
         Modules.get().get(BetterChat.class).lines.clear();
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterChat.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterChat.java
@@ -18,10 +18,11 @@ import meteordevelopment.meteorclient.utils.Utils;
 import meteordevelopment.meteorclient.utils.player.ChatUtils;
 import meteordevelopment.orbit.EventHandler;
 import net.minecraft.client.gui.hud.ChatHudLine;
-import net.minecraft.client.util.ChatMessages;
-import net.minecraft.text.*;
+import net.minecraft.text.ClickEvent;
+import net.minecraft.text.HoverEvent;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
-import net.minecraft.util.math.MathHelper;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -210,6 +211,7 @@ public class BetterChat extends Module {
 
     private final Char2CharMap SMALL_CAPS = new Char2CharOpenHashMap();
     private final SimpleDateFormat dateFormat = new SimpleDateFormat("HH:mm");
+    public final ArrayList<Integer> lines = new ArrayList<>();
 
     public BetterChat() {
         super(Categories.Misc, "better-chat", "Improves your chat experience in various ways.");
@@ -233,15 +235,6 @@ public class BetterChat extends Module {
             }
         }
 
-        if (timestamps.get()) {
-            Matcher matcher = timestampRegex.matcher(message.getString());
-            if (matcher.matches()) message.getSiblings().subList(0, 8).clear();
-
-            Text timestamp = Text.literal("<" + dateFormat.format(new Date()) + "> ").formatted(Formatting.GRAY);
-
-            message = Text.literal("").append(timestamp).append(message);
-        }
-
         if (playerHeads.get()) {
             message = Text.literal("  ").append(message);
         }
@@ -254,62 +247,72 @@ public class BetterChat extends Module {
             }
         }
 
+        if (timestamps.get()) {
+            Matcher matcher = timestampRegex.matcher(message.getString());
+            if (matcher.matches()) message.getSiblings().subList(0, 8).clear();
+
+            Text timestamp = Text.literal("<" + dateFormat.format(new Date()) + "> ").formatted(Formatting.GRAY);
+
+            message = Text.literal("").append(timestamp).append(message);
+        }
+
         event.setMessage(message);
     }
 
-    /**
-     * @author Crosby
-     * Adding author tag because this is spaghetti code
-     */
+
     private Text appendAntiSpam(Text text) {
         Text returnText = null;
         int messageIndex = -1;
-        MutableText originalMessage = null;
 
-        for (int i = 0; i < antiSpamDepth.get(); i++) {
-            List<ChatHudLine> messages = ((ChatHudAccessor) mc.inGameHud.getChatHud()).getMessages();
-            if (messages.isEmpty() || i > messages.size() - 1) return null;
+        List<ChatHudLine> messages = ((ChatHudAccessor) mc.inGameHud.getChatHud()).getMessages();
+        if (messages.isEmpty()) return null;
 
-            MutableText message = messages.get(i).content().copy();
-            String oldMessage = message.getString();
-            String newMessage = text.getString();
+        for (int i = 0; i < Math.min(antiSpamDepth.get(), messages.size()); i++) {
+            String stringToCheck = messages.get(i).content().copy().getString();
 
-            if (oldMessage.equals(newMessage)) {
-                originalMessage = message.copy();
+            Matcher timestampMatcher = timestampRegex.matcher(stringToCheck);
+            if (timestampMatcher.find()) {
+                stringToCheck = stringToCheck.substring(8);
+            }
+
+            if (text.getString().equals(stringToCheck)) {
                 messageIndex = i;
-                returnText = message.append(Text.literal(" (2)").formatted(Formatting.GRAY));
+                returnText = text.copy().append(Text.literal(" (2)").formatted(Formatting.GRAY));
                 break;
             }
             else {
-                Matcher matcher = antiSpamRegex.matcher(oldMessage);
-
-                if (!matcher.matches()) continue;
+                Matcher matcher = antiSpamRegex.matcher(stringToCheck);
+                if (!matcher.matches() && !matcher.find()) continue;
 
                 String group = matcher.group(matcher.groupCount());
                 int number = Integer.parseInt(group.substring(1, group.length() - 1));
 
                 String counter = " (" + number + ")";
 
-                if (oldMessage.substring(0, oldMessage.length() - counter.length()).equals(newMessage)) {
-                    message.getSiblings().remove(message.getSiblings().size() - 1);
-                    originalMessage = message.copy();
+                if (stringToCheck.substring(0, stringToCheck.length() - counter.length()).equals(text.getString())) {
                     messageIndex = i;
-                    returnText = message.append(Text.literal(" (" + (number + 1) + ")").formatted(Formatting.GRAY));
+                    returnText = text.copy().append(Text.literal(" (" + (number + 1) + ")").formatted(Formatting.GRAY));
                     break;
                 }
             }
         }
 
         if (returnText != null) {
-            ((ChatHudAccessor) mc.inGameHud.getChatHud()).getMessages().remove(messageIndex);
+            List<ChatHudLine.Visible> visible = ((ChatHudAccessor) mc.inGameHud.getChatHud()).getVisibleMessages();
 
-            List<OrderedText> list = ChatMessages.breakRenderedChatMessageLines(originalMessage, MathHelper.floor((double)mc.inGameHud.getChatHud().getWidth() / mc.inGameHud.getChatHud().getChatScale()), mc.textRenderer);
-            List<ChatHudLine.Visible> visibleMessages = ((ChatHudAccessor) mc.inGameHud.getChatHud()).getVisibleMessages();
-            int lines = Math.min(list.size(), visibleMessages.size());
-
-            for (int i = 0; i < lines; i++) {
-                visibleMessages.remove(messageIndex);
+            int start = -1;
+            for (int i = 0; i < messageIndex; i++) {
+                start += lines.get(i);
             }
+
+            int i = lines.get(messageIndex);
+            while (i > 0) {
+                visible.remove(start + 1);
+                i--;
+            }
+
+            messages.remove(messageIndex);
+            lines.remove(messageIndex);
         }
 
         return returnText;

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterChat.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterChat.java
@@ -7,6 +7,8 @@ package meteordevelopment.meteorclient.systems.modules.misc;
 
 import it.unimi.dsi.fastutil.chars.Char2CharMap;
 import it.unimi.dsi.fastutil.chars.Char2CharOpenHashMap;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import meteordevelopment.meteorclient.commands.Commands;
 import meteordevelopment.meteorclient.events.game.ReceiveMessageEvent;
 import meteordevelopment.meteorclient.events.game.SendMessageEvent;
@@ -211,7 +213,7 @@ public class BetterChat extends Module {
 
     private final Char2CharMap SMALL_CAPS = new Char2CharOpenHashMap();
     private final SimpleDateFormat dateFormat = new SimpleDateFormat("HH:mm");
-    public final ArrayList<Integer> lines = new ArrayList<>();
+    public final IntList lines = new IntArrayList();
 
     public BetterChat() {
         super(Categories.Misc, "better-chat", "Improves your chat experience in various ways.");


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Prior to this, anti spam was prone to failing. It would get the index of the message to remove from the list `ChatHud.messages` and then use that to remove from `ChatHud.visibleMessages`, however very often they wouldn't align, causing incorrect lines to be removed. This fixes the issue by storing the number of lines each messages takes up when it's first split, so we don't need to do it again, and using that to find the correct lines to remove.

# How Has This Been Tested?

Development and production, with all sorts of strange messages with different sizes. 

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
