### PR TITLE
Fixed anchor below y 0

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Anchor.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Anchor.java
@@ -112,7 +112,7 @@ public class Anchor extends Module {
 
         for (int i = 0; i < maxHeight.get(); i++) {
             y--;
-            if (y <= 0 || !isAir(x, y, z)) break;
+            if (y <= mc.world.getBottomY() || !isAir(x, y, z)) break;
 
             if (isHole(x, y, z)) {
                 foundHole = true;


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

When the new world height got added in 1.18, anchor was never adjusted to work in the negative y area.

# How Has This Been Tested?

I tested it, it works.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
