### PR TITLE
fix better tooltip crash

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BetterTooltips.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BetterTooltips.java
@@ -5,7 +5,7 @@
 
 package meteordevelopment.meteorclient.systems.modules.render;
 
-import com.google.gson.JsonSyntaxException;
+import com.google.gson.JsonParseException;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import meteordevelopment.meteorclient.events.game.ItemStackTooltipEvent;
@@ -436,7 +436,7 @@ public class BetterTooltips extends Module {
 
         try {
             return Text.Serializer.fromLenientJson(pages.getString(0));
-        } catch (JsonSyntaxException e) {
+        } catch (JsonParseException e) {
             return Text.literal("Invalid book data");
         }
     }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Fixes better tooltips causing a crash when hovering over certain invalid books, due to not catching the correct exception.

## Related issues

Closes #3833

# How Has This Been Tested?

local singleplayer world

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
