### PR TITLE
Add texture rotations to no render

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/AbstractBlockMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/AbstractBlockMixin.java
@@ -33,6 +33,6 @@ public class AbstractBlockMixin {
 
     @Inject(method = "getRenderingSeed", at = @At("HEAD"), cancellable = true)
     private void onRenderingSeed(BlockState state, BlockPos pos, CallbackInfoReturnable<Long> cir) {
-        if (Modules.get().get(NoRender.class).noTextureRotations()) cir.setReturnValue(random.nextLong()); //cir.setReturnValue(0L);
+        if (Modules.get().get(NoRender.class).noTextureRotations()) cir.setReturnValue(random.nextLong());
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/mixin/AbstractBlockMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/AbstractBlockMixin.java
@@ -7,6 +7,8 @@ package meteordevelopment.meteorclient.mixin;
 
 import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.events.world.AmbientOcclusionEvent;
+import meteordevelopment.meteorclient.systems.modules.Modules;
+import meteordevelopment.meteorclient.systems.modules.render.NoRender;
 import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.BlockState;
 import net.minecraft.util.math.BlockPos;
@@ -23,5 +25,10 @@ public class AbstractBlockMixin {
         AmbientOcclusionEvent event = MeteorClient.EVENT_BUS.post(AmbientOcclusionEvent.get());
 
         if (event.lightLevel != -1) info.setReturnValue(event.lightLevel);
+    }
+
+    @Inject(method = "getRenderingSeed", at = @At("HEAD"), cancellable = true)
+    private void onRenderingSeed(BlockState state, BlockPos pos, CallbackInfoReturnable<Long> cir) {
+        if (Modules.get().get(NoRender.class).noTextureRotations()) cir.setReturnValue(0L);
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/mixin/AbstractBlockMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/AbstractBlockMixin.java
@@ -22,7 +22,7 @@ import java.util.Random;
 
 @Mixin(AbstractBlock.class)
 public class AbstractBlockMixin {
-    private static final Random random = new Random();
+    private static final Random RANDOM = new Random();
 
     @Inject(method = "getAmbientOcclusionLightLevel", at = @At("HEAD"), cancellable = true)
     private void onGetAmbientOcclusionLightLevel(BlockState state, BlockView world, BlockPos pos, CallbackInfoReturnable<Float> info) {
@@ -33,6 +33,6 @@ public class AbstractBlockMixin {
 
     @Inject(method = "getRenderingSeed", at = @At("HEAD"), cancellable = true)
     private void onRenderingSeed(BlockState state, BlockPos pos, CallbackInfoReturnable<Long> cir) {
-        if (Modules.get().get(NoRender.class).noTextureRotations()) cir.setReturnValue(random.nextLong());
+        if (Modules.get().get(NoRender.class).noTextureRotations()) cir.setReturnValue(RANDOM.nextLong());
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/mixin/AbstractBlockMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/AbstractBlockMixin.java
@@ -18,8 +18,12 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import java.util.Random;
+
 @Mixin(AbstractBlock.class)
 public class AbstractBlockMixin {
+    private static final Random random = new Random();
+
     @Inject(method = "getAmbientOcclusionLightLevel", at = @At("HEAD"), cancellable = true)
     private void onGetAmbientOcclusionLightLevel(BlockState state, BlockView world, BlockPos pos, CallbackInfoReturnable<Float> info) {
         AmbientOcclusionEvent event = MeteorClient.EVENT_BUS.post(AmbientOcclusionEvent.get());
@@ -29,6 +33,6 @@ public class AbstractBlockMixin {
 
     @Inject(method = "getRenderingSeed", at = @At("HEAD"), cancellable = true)
     private void onRenderingSeed(BlockState state, BlockPos pos, CallbackInfoReturnable<Long> cir) {
-        if (Modules.get().get(NoRender.class).noTextureRotations()) cir.setReturnValue(0L);
+        if (Modules.get().get(NoRender.class).noTextureRotations()) cir.setReturnValue(random.nextLong()); //cir.setReturnValue(0L);
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/mixin/AbstractBlockStateMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/AbstractBlockStateMixin.java
@@ -17,13 +17,13 @@ import java.util.Random;
 
 @Mixin(AbstractBlock.AbstractBlockState.class)
 public class AbstractBlockStateMixin {
-    private static final Random random = new Random();
+    private static final Random RANDOM = new Random();
 
     @ModifyVariable(method = "getModelOffset", at = @At("HEAD"), argsOnly = true)
     private BlockPos modifyPos(BlockPos pos) {
         if (Modules.get() == null) return pos;
 
-        if (Modules.get().get(NoRender.class).noTextureRotations()) return pos.multiply(random.nextInt());
+        if (Modules.get().get(NoRender.class).noTextureRotations()) return pos.multiply(RANDOM.nextInt());
         return pos;
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/mixin/AbstractBlockStateMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/AbstractBlockStateMixin.java
@@ -9,19 +9,21 @@ import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.render.NoRender;
 import net.minecraft.block.AbstractBlock;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Vec3d;
-import net.minecraft.world.BlockView;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import java.util.Random;
 
 @Mixin(AbstractBlock.AbstractBlockState.class)
 public class AbstractBlockStateMixin {
-    @Inject(method = "getModelOffset", at = @At("HEAD"), cancellable = true)
-    private void onModelOffset(BlockView world, BlockPos pos, CallbackInfoReturnable<Vec3d> cir) {
-        if (Modules.get() == null) return;
+    private static final Random random = new Random();
 
-        if (Modules.get().get(NoRender.class).noTextureRotations()) cir.setReturnValue(Vec3d.ZERO);
+    @ModifyVariable(method = "getModelOffset", at = @At("HEAD"), argsOnly = true)
+    private BlockPos modifyPos(BlockPos pos) {
+        if (Modules.get() == null) return pos;
+
+        if (Modules.get().get(NoRender.class).noTextureRotations()) return pos.multiply(random.nextInt());
+        return pos;
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/mixin/AbstractBlockStateMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/AbstractBlockStateMixin.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.mixin;
+
+import meteordevelopment.meteorclient.systems.modules.Modules;
+import meteordevelopment.meteorclient.systems.modules.render.NoRender;
+import net.minecraft.block.AbstractBlock;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.BlockView;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(AbstractBlock.AbstractBlockState.class)
+public class AbstractBlockStateMixin {
+    @Inject(method = "getModelOffset", at = @At("HEAD"), cancellable = true)
+    private void onModelOffset(BlockView world, BlockPos pos, CallbackInfoReturnable<Vec3d> cir) {
+        if (Modules.get() == null) return;
+
+        if (Modules.get().get(NoRender.class).noTextureRotations()) cir.setReturnValue(Vec3d.ZERO);
+    }
+}

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/NoRender.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/NoRender.java
@@ -292,7 +292,7 @@ public class NoRender extends Module {
 
     private final Setting<Boolean> noTextureRotations = sgWorld.add(new BoolSetting.Builder()
         .name("texture-rotations")
-        .description("Changes texture rotations and model offsets to use a constant value instead of the block position.")
+        .description("Changes texture rotations and model offsets to use a random value instead of the block position.")
         .defaultValue(false)
         .onChanged(b -> mc.worldRenderer.reload())
         .build()

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/NoRender.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/NoRender.java
@@ -290,6 +290,14 @@ public class NoRender extends Module {
         .build()
     );
 
+    private final Setting<Boolean> noTextureRotations = sgWorld.add(new BoolSetting.Builder()
+        .name("texture-rotations")
+        .description("Changes texture rotations and model offsets to use a constant value instead of the block position.")
+        .defaultValue(false)
+        .onChanged(b -> mc.worldRenderer.reload())
+        .build()
+    );
+
     // Entity
 
     private final Setting<Set<EntityType<?>>> entities = sgEntity.add(new EntityTypeListSetting.Builder()
@@ -518,6 +526,10 @@ public class NoRender extends Module {
 
     public boolean noBarrierInvis() {
         return isActive() && noBarrierInvis.get();
+    }
+
+    public boolean noTextureRotations() {
+        return isActive() && noTextureRotations.get();
     }
 
     // Entity

--- a/src/main/resources/meteor-client.mixins.json
+++ b/src/main/resources/meteor-client.mixins.json
@@ -6,6 +6,7 @@
   "client": [
     "AbstractBlockAccessor",
     "AbstractBlockMixin",
+    "AbstractBlockStateMixin",
     "AbstractClientPlayerEntityMixin",
     "AbstractFurnaceScreenHandlerMixin",
     "AbstractFurnaceScreenMixin",


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Adds an option in no render to change texture rotations and model offsets to use a constant value, instead of one dependant on the block postion. This helps protect against accidently leaking your coordinates.

# How Has This Been Tested?

Disabled:
![2023-07-22_22 01 20](https://github.com/MeteorDevelopment/meteor-client/assets/74723656/940ff856-a393-4be3-87aa-3db2107ef928)

Enabled:
![2023-07-22_22 01 37](https://github.com/MeteorDevelopment/meteor-client/assets/74723656/44e4f254-7c9a-494a-902c-9be8b716c91d)


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
