### PR TITLE
Fixed slider double decimalPlaces (currently not supported)

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/input/WDoubleEdit.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/input/WDoubleEdit.java
@@ -29,6 +29,7 @@ public class WDoubleEdit extends WHorizontalList {
         this.value = value;
         this.min = min;
         this.max = max;
+        this.decimalPlaces = decimalPlaces;
         this.sliderMin = sliderMin;
         this.sliderMax = sliderMax;
 


### PR DESCRIPTION
## Fixed implemented feature

- [x] Bug fix
- [ ] New feature

## Description

Fixed int decimalPlaces in WDoubleEdit not setted when building double slider was implemented and new DoubleSetting.Builder() was initialized and decimalPlaces(int decimalPlaces) called.

## Related issues

As my known no issue declared, but if it was i will edit this.

# How Has This Been Tested?

Localy in a minecraft server.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
