### PR TITLE
Added new sneak parameter to the safe walk module

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/InputCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/InputCommand.java
@@ -28,7 +28,8 @@ public class InputCommand extends Command {
         mc.options.jumpKey, "jump",
         mc.options.sneakKey, "sneak",
         mc.options.useKey, "use",
-        mc.options.attackKey, "attack"
+        mc.options.attackKey, "attack",
+        mc.options.sprintKey, "sprint"
     );
 
     public InputCommand() {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/SafeWalk.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/SafeWalk.java
@@ -6,17 +6,108 @@
 package meteordevelopment.meteorclient.systems.modules.movement;
 
 import meteordevelopment.meteorclient.events.entity.player.ClipAtLedgeEvent;
+import meteordevelopment.meteorclient.events.render.Render3DEvent;
+import meteordevelopment.meteorclient.renderer.ShapeMode;
+import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.meteorclient.utils.render.color.Color;
 import meteordevelopment.orbit.EventHandler;
+import net.minecraft.util.math.Box;
 
 public class SafeWalk extends Module {
+    private final SettingGroup swGeneral = settings.getDefaultGroup();
+
+    private final Setting<Boolean> sneak = swGeneral.add(new BoolSetting.Builder()
+            .name("sneak")
+            .description("Sneak when approaching edge of block.")
+            .defaultValue(false)
+            .build());
+
+    private final Setting<Boolean> safeSneak = swGeneral.add(new BoolSetting.Builder()
+            .name("safe-sneak")
+            .description("Prevent you to falling if sneak doesn't trigger correctly.")
+            .defaultValue(true)
+            .visible(() -> this.sneak.get())
+            .build());
+
+    private final Setting<Boolean> sneakSprint = swGeneral.add(new BoolSetting.Builder()
+            .name("sneak-on-sprint")
+            .description("Keep sneak on sprinting key pressed.")
+            .defaultValue(true)
+            .visible(() -> this.sneak.get())
+            .build());
+
+    private final Setting<Double> edgeDistance = swGeneral.add(new DoubleSetting.Builder()
+            .name("edge-distance")
+            .description("Distance offset before reaching an edge.")
+            .defaultValue(0.30)
+            .sliderRange(0.00, 0.30)
+            .decimalPlaces(2)
+            .visible(() -> this.sneak.get())
+            .build());
+
+    private final Setting<Boolean> renderEdgeDistance = swGeneral.add(new BoolSetting.Builder()
+            .name("render")
+            .description("Render edge distance helper.")
+            .defaultValue(false)
+            .visible(() -> this.sneak.get())
+            .build());
+
+    private final Setting<Boolean> renderPlayerBox = swGeneral.add(new BoolSetting.Builder()
+            .name("render-player-box")
+            .description("Render player box helper.")
+            .defaultValue(true)
+            .visible(() -> this.renderEdgeDistance.get())
+            .build());
+
     public SafeWalk() {
         super(Categories.Movement, "safe-walk", "Prevents you from walking off blocks.");
     }
 
     @EventHandler
     private void onClipAtLedge(ClipAtLedgeEvent event) {
-        if (!mc.player.isSneaking()) event.setClip(true);
+        if (sneak.get()) {
+            boolean closeToEdge = false;
+            boolean isSprinting = this.sneakSprint.get() ? false : mc.options.sprintKey.isPressed();
+
+            Box playerBox = mc.player.getBoundingBox();
+            Box adjustedBox = this.getAdjustedPlayerBox(playerBox);
+
+            if (mc.world.isSpaceEmpty(mc.player, adjustedBox) && mc.player.isOnGround())
+                closeToEdge = true;
+
+            if (!isSprinting) {
+                if (closeToEdge == true) {
+                    mc.player.input.sneaking = true;
+                } else if (this.safeSneak.get()) {
+                    event.setClip(true);
+                }
+            }
+        } else {
+            if (!mc.player.isSneaking())
+                event.setClip(true);
+        }
+
+    }
+
+    private Box getAdjustedPlayerBox(Box playerBox) {
+        return playerBox.stretch(0, -mc.player.getStepHeight(), 0)
+                .expand(-edgeDistance.get(), 0, -edgeDistance.get());
+    }
+
+    @EventHandler
+    private void onRender(Render3DEvent event) {
+        if (this.renderEdgeDistance.get()) {
+            Box playerBox = mc.player.getBoundingBox();
+            Box adjustedBox = getAdjustedPlayerBox(playerBox);
+
+            event.renderer.box(adjustedBox, Color.BLUE, Color.RED, ShapeMode.Lines, 0);
+
+            if (this.renderPlayerBox.get()) {
+                event.renderer.box(playerBox, Color.BLUE, Color.GREEN, ShapeMode.Lines, 0);
+            }
+        }
+
     }
 }


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Added a missing feature to the safe walk module : sneak

- **Sneak parameter** : When enabled this will change the default behavior to if player is close to the edge of a block next to an empty one.
- **Safe Sneak** (_Sneak dependent parameter_) : When enabled is will ensure the player to don't fall if sneaking failed
- **Sneak On Sprint** (_Sneak dependent parameter_) : When disabled pressing sprinting key will cancel the safe walk to being effective, as example to doing a jump
- **Edge Distance** (_Sneak dependent parameter_) : A tweak parameter to manage sensibility of sneaking behavior
- **Render** (_Sneak dependent parameter_) : Will render the box of player after edge distance applied
- **Render Player Box** (_Render dependent parameter_) : Draw the original player box without edge distance applied

## Related issues

None

# How Has This Been Tested?

Locally on a minecraft server on the latest version (1.20.1)

![scr](https://github.com/MeteorDevelopment/meteor-client/assets/25451887/a9fed261-c3f2-484b-ada3-794efd65c7e8)



# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
