### PR TITLE
Fixed trail pause when stationary

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Trail.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Trail.java
@@ -43,9 +43,9 @@ public class Trail extends Module {
     @EventHandler
     private void onTick(TickEvent.Post event) {
         if (pause.get()
-            && mc.player.getVelocity().x == 0
-            && mc.player.getVelocity().y == 0
-            && mc.player.getVelocity().z == 0) return;
+            && mc.player.getX() == mc.player.prevX
+            && mc.player.getY() == mc.player.prevY
+            && mc.player.getZ() == mc.player.prevZ) return;
 
         for (ParticleType<?> particleType : particles.get()) {
             mc.world.addParticle((ParticleEffect) particleType, mc.player.getX(), mc.player.getY(), mc.player.getZ(), 0, 0, 0);


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Made pause when stationary use the player's position instead of velocity, because the velocity includes gravity.
Previously when standing on the ground it wouldn't pause the trail.

## Related issues

Closes #3905

# How Has This Been Tested?

Pla gaem and it work

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
