### PR TITLE
Updated to sodium 0.5.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,13 +14,13 @@ archives_base_name=meteor-client
 # Dependency Versions
 
 # Sodium (https://github.com/CaffeineMC/sodium-fabric)
-sodium_version=mc1.20-0.4.10
+sodium_version=mc1.20.1-0.5.0
 
 # Lithium (https://github.com/CaffeineMC/lithium-fabric)
 lithium_version=mc1.20-0.11.2
 
 # Iris (https://github.com/IrisShaders/Iris)
-iris_version=1.6.4+1.20
+iris_version=1.6.5+1.20.1
 
 # Orbit (https://github.com/MeteorDevelopment/orbit)
 orbit_version=0.2.3

--- a/src/main/java/meteordevelopment/meteorclient/mixin/sodium/LightDataAccessMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/sodium/LightDataAccessMixin.java
@@ -5,42 +5,55 @@
 
 package meteordevelopment.meteorclient.mixin.sodium;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import me.jellysquid.mods.sodium.client.model.light.data.LightDataAccess;
 import meteordevelopment.meteorclient.systems.modules.Modules;
+import meteordevelopment.meteorclient.systems.modules.render.Fullbright;
 import meteordevelopment.meteorclient.systems.modules.render.Xray;
 import net.minecraft.block.BlockState;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.BlockRenderView;
+import net.minecraft.world.LightType;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(value = LightDataAccess.class, remap = false)
-public class LightDataAccessMixin {
-    private static final int FULL_LIGHT = 15 << 20 | 15 << 4;
+public abstract class LightDataAccessMixin {
+    @Unique private static final int FULL_LIGHT = 15 | 15 << 4 | 15 << 8;
 
     @Shadow protected BlockRenderView world;
     @Shadow @Final private BlockPos.Mutable pos;
 
-    @Unique private Xray xray;
+    @Shadow public static int packBL(int blockLight) { return 0; }
+    @Shadow public static int packSL(int skyLight) { return 0; }
+
+    @Unique
+    private Xray xray;
 
     @Inject(method = "<init>", at = @At("TAIL"))
     private void onInit(CallbackInfo info) {
         xray = Modules.get().get(Xray.class);
     }
 
-    @ModifyVariable(method = "compute", at = @At(value = "STORE"), name = "lm")
-    private int compute_modifyAO(int light) {
+    @Redirect(method = "compute", at = @At(value = "INVOKE", target = "Lme/jellysquid/mods/sodium/client/model/light/data/LightDataAccess;packBL(I)I"))
+    private int onPackBL(int blockLight) {
         if (xray.isActive()) {
             BlockState state = world.getBlockState(pos);
             if (!xray.isBlocked(state.getBlock(), pos)) return FULL_LIGHT;
         }
+        return packBL(blockLight);
+    }
 
-        return light;
+    @ModifyArg(method = "compute", at = @At(value = "INVOKE", target = "Lme/jellysquid/mods/sodium/client/model/light/data/LightDataAccess;packSL(I)I"))
+    private int onPackSL(int blockLight) {
+        return Math.max(Modules.get().get(Fullbright.class).getLuminance(), blockLight);
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/mixin/sodium/MeshVertexConsumerMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/sodium/MeshVertexConsumerMixin.java
@@ -5,10 +5,10 @@
 
 package meteordevelopment.meteorclient.mixin.sodium;
 
-import me.jellysquid.mods.sodium.client.render.vertex.VertexBufferWriter;
-import me.jellysquid.mods.sodium.client.render.vertex.VertexFormatDescription;
-import me.jellysquid.mods.sodium.client.render.vertex.transform.CommonVertexElement;
 import meteordevelopment.meteorclient.utils.render.MeshVertexConsumerProvider;
+import net.caffeinemc.mods.sodium.api.vertex.attributes.CommonVertexAttribute;
+import net.caffeinemc.mods.sodium.api.vertex.buffer.VertexBufferWriter;
+import net.caffeinemc.mods.sodium.api.vertex.format.VertexFormatDescription;
 import net.minecraft.client.render.VertexConsumer;
 import org.lwjgl.system.MemoryStack;
 import org.lwjgl.system.MemoryUtil;
@@ -18,11 +18,11 @@ import org.spongepowered.asm.mixin.Mixin;
 public abstract class MeshVertexConsumerMixin implements VertexConsumer, VertexBufferWriter {
     @Override
     public void push(MemoryStack stack, long ptr, int count, VertexFormatDescription format) {
-        int positionOffset = format.elementOffsets[CommonVertexElement.POSITION.ordinal()];
+        int positionOffset = format.getElementOffset(CommonVertexAttribute.POSITION);
         if (positionOffset == -1) return;
 
         for (int i = 0; i < count; i++) {
-            long positionPtr = ptr + (long) format.stride * i + positionOffset;
+            long positionPtr = ptr + (long) format.stride() * i + positionOffset;
 
             float x = MemoryUtil.memGetFloat(positionPtr);
             float y = MemoryUtil.memGetFloat(positionPtr + 4);

--- a/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumBlockOcclusionCacheMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumBlockOcclusionCacheMixin.java
@@ -6,7 +6,7 @@
 package meteordevelopment.meteorclient.mixin.sodium;
 
 import com.llamalad7.mixinextras.injector.ModifyReturnValue;
-import me.jellysquid.mods.sodium.client.render.occlusion.BlockOcclusionCache;
+import me.jellysquid.mods.sodium.client.render.chunk.compile.pipeline.BlockOcclusionCache;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.render.Xray;
 import net.minecraft.block.BlockState;
@@ -14,17 +14,23 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.BlockView;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(value = BlockOcclusionCache.class, remap = false)
 public class SodiumBlockOcclusionCacheMixin {
+    @Unique private Xray xray;
+
+    @Inject(method = "<init>", at = @At("TAIL"))
+    private void onInit(CallbackInfo info) {
+        xray = Modules.get().get(Xray.class);
+    }
+
     @ModifyReturnValue(method = "shouldDrawSide", at = @At("RETURN"))
     private boolean shouldDrawSide(boolean original, BlockState state, BlockView view, BlockPos pos, Direction facing) {
-        Xray xray = Modules.get().get(Xray.class);
-
-        if (xray.isActive()) {
-            return xray.modifyDrawSide(state, view, pos, facing, original);
-        }
+        if (xray.isActive()) return xray.modifyDrawSide(state, view, pos, facing, original);
 
         return original;
     }

--- a/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumBlockRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumBlockRendererMixin.java
@@ -10,29 +10,14 @@ import me.jellysquid.mods.sodium.client.render.chunk.compile.pipeline.BlockRende
 import me.jellysquid.mods.sodium.client.render.chunk.compile.pipeline.BlockRenderer;
 import meteordevelopment.meteorclient.systems.modules.render.Xray;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(value = BlockRenderer.class, remap = false)
 public class SodiumBlockRendererMixin {
-    @Unique private final ThreadLocal<Integer> alphas = new ThreadLocal<>();
-
     @Inject(method = "renderModel", at = @At("HEAD"), cancellable = true)
-    private void onRenderModel(BlockRenderContext ctx, ChunkBuildBuffers buffers, CallbackInfo info) {
-        if (Xray.getAlpha(ctx.state(), ctx.pos()) >= 0) info.cancel();
-        //int alpha = Xray.getAlpha(ctx.state(), ctx.pos());
-        //if (alpha == 0) info.cancel();
-        //else alphas.set(alpha);
+    private void onRenderModel(BlockRenderContext ctx, ChunkBuildBuffers buffers, CallbackInfo ci) {
+        if (Xray.getAlpha(ctx.state(), ctx.pos()) != -1) ci.cancel();
     }
-
-
-    //@ModifyArg(method = "writeGeometry", at = @At(value = "INVOKE", target = "Lnet/caffeinemc/mods/sodium/api/util/ColorABGR;withAlpha(IF)I"), index = 1)
-    //private float setColor(float alpha) {
-    //    int alpha0 = alphas.get();
-    //    if (alpha0 == 0 || alpha0 == -1) return alpha;
-    //    else return alpha0 / 255f;
-    //}
 }

--- a/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumBlockRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumBlockRendererMixin.java
@@ -5,46 +5,34 @@
 
 package meteordevelopment.meteorclient.mixin.sodium;
 
-import me.jellysquid.mods.sodium.client.model.IndexBufferBuilder;
-import me.jellysquid.mods.sodium.client.model.quad.ModelQuadView;
-import me.jellysquid.mods.sodium.client.model.quad.properties.ModelQuadOrientation;
-import me.jellysquid.mods.sodium.client.render.chunk.compile.buffers.ChunkModelBuilder;
+import me.jellysquid.mods.sodium.client.render.chunk.compile.ChunkBuildBuffers;
 import me.jellysquid.mods.sodium.client.render.chunk.compile.pipeline.BlockRenderContext;
 import me.jellysquid.mods.sodium.client.render.chunk.compile.pipeline.BlockRenderer;
-import me.jellysquid.mods.sodium.client.render.vertex.type.ChunkVertexBufferBuilder;
-import me.jellysquid.mods.sodium.client.render.vertex.type.ChunkVertexEncoder;
 import meteordevelopment.meteorclient.systems.modules.render.Xray;
-import net.minecraft.util.math.Vec3d;
-import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 @Mixin(value = BlockRenderer.class, remap = false)
 public class SodiumBlockRendererMixin {
     @Unique private final ThreadLocal<Integer> alphas = new ThreadLocal<>();
 
     @Inject(method = "renderModel", at = @At("HEAD"), cancellable = true)
-    private void onRenderModel(BlockRenderContext ctx, ChunkModelBuilder buffers, CallbackInfoReturnable<Boolean> info) {
-        int alpha = Xray.getAlpha(ctx.state(), ctx.pos());
-
-        if (alpha == 0) info.setReturnValue(false);
-        else alphas.set(alpha);
+    private void onRenderModel(BlockRenderContext ctx, ChunkBuildBuffers buffers, CallbackInfo info) {
+        if (Xray.getAlpha(ctx.state(), ctx.pos()) >= 0) info.cancel();
+        //int alpha = Xray.getAlpha(ctx.state(), ctx.pos());
+        //if (alpha == 0) info.cancel();
+        //else alphas.set(alpha);
     }
 
 
-    @Inject(method = "writeGeometry", at = @At(value = "FIELD", target = "Lme/jellysquid/mods/sodium/client/render/vertex/type/ChunkVertexEncoder$Vertex;color:I", opcode = Opcodes.PUTFIELD, shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILSOFT, cancellable = true)
-    private void setColor(BlockRenderContext ctx, ChunkVertexBufferBuilder vertexBuffer, IndexBufferBuilder indexBuffer, Vec3d offset, ModelQuadView quad, int[] colors, float[] brightness, int[] lightmap, CallbackInfo info, ModelQuadOrientation orientation, ChunkVertexEncoder.Vertex[] vertices, int dstIndex, int srcIndex, ChunkVertexEncoder.Vertex out) {
-        int alpha = alphas.get();
-
-        if (alpha == 0) info.cancel();
-        else if (alpha != -1) {
-            out.color &= 0xFFFFFF;
-            out.color |= alpha << 24;
-        }
-    }
+    //@ModifyArg(method = "writeGeometry", at = @At(value = "INVOKE", target = "Lnet/caffeinemc/mods/sodium/api/util/ColorABGR;withAlpha(IF)I"), index = 1)
+    //private float setColor(float alpha) {
+    //    int alpha0 = alphas.get();
+    //    if (alpha0 == 0 || alpha0 == -1) return alpha;
+    //    else return alpha0 / 255f;
+    //}
 }

--- a/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumFluidRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumFluidRendererMixin.java
@@ -5,21 +5,21 @@
 
 package meteordevelopment.meteorclient.mixin.sodium;
 
+import me.jellysquid.mods.sodium.client.model.color.ColorProvider;
 import me.jellysquid.mods.sodium.client.model.light.LightPipeline;
 import me.jellysquid.mods.sodium.client.model.quad.ModelQuadView;
-import me.jellysquid.mods.sodium.client.model.quad.blender.ColorSampler;
-import me.jellysquid.mods.sodium.client.render.chunk.compile.buffers.ChunkModelBuilder;
+import me.jellysquid.mods.sodium.client.render.chunk.compile.ChunkBuildBuffers;
 import me.jellysquid.mods.sodium.client.render.chunk.compile.pipeline.FluidRenderer;
-import me.jellysquid.mods.sodium.client.util.color.ColorABGR;
-import me.jellysquid.mods.sodium.client.util.color.ColorARGB;
+import me.jellysquid.mods.sodium.client.world.WorldSlice;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.render.Xray;
 import meteordevelopment.meteorclient.systems.modules.world.Ambience;
+import net.caffeinemc.mods.sodium.api.util.ColorABGR;
+import net.caffeinemc.mods.sodium.api.util.ColorARGB;
 import net.minecraft.fluid.FluidState;
 import net.minecraft.registry.tag.FluidTags;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
-import net.minecraft.world.BlockRenderView;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -27,7 +27,6 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.Arrays;
 
@@ -38,15 +37,15 @@ public class SodiumFluidRendererMixin {
     @Unique private final ThreadLocal<Integer> alphas = new ThreadLocal<>();
 
     @Inject(method = "render", at = @At("HEAD"), cancellable = true)
-    private void onRender(BlockRenderView world, FluidState fluidState, BlockPos pos, BlockPos offset, ChunkModelBuilder buffers, CallbackInfoReturnable<Boolean> info) {
-        int alpha = Xray.getAlpha(fluidState.getBlockState(), pos);
+    private void onRender(WorldSlice world, FluidState fluidState, BlockPos blockPos, BlockPos offset, ChunkBuildBuffers buffers, CallbackInfo info) {
+        int alpha = Xray.getAlpha(fluidState.getBlockState(), blockPos);
 
-        if (alpha == 0) info.setReturnValue(false);
+        if (alpha == 0) info.cancel();
         else alphas.set(alpha);
     }
 
     @Inject(method = "updateQuad", at = @At("TAIL"))
-    private void onUpdateQuad(ModelQuadView quad, BlockRenderView world, BlockPos pos, LightPipeline lighter, Direction dir, float brightness, ColorSampler<FluidState> colorSampler, FluidState fluidState, CallbackInfo info) {
+    private void onUpdateQuad(ModelQuadView quad, WorldSlice world, BlockPos pos, LightPipeline lighter, Direction dir, float brightness, ColorProvider<FluidState> colorProvider, FluidState fluidState, CallbackInfo info) {
         // Ambience
         Ambience ambience = Modules.get().get(Ambience.class);
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumFluidRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumFluidRendererMixin.java
@@ -5,59 +5,21 @@
 
 package meteordevelopment.meteorclient.mixin.sodium;
 
-import me.jellysquid.mods.sodium.client.model.color.ColorProvider;
-import me.jellysquid.mods.sodium.client.model.light.LightPipeline;
-import me.jellysquid.mods.sodium.client.model.quad.ModelQuadView;
 import me.jellysquid.mods.sodium.client.render.chunk.compile.ChunkBuildBuffers;
 import me.jellysquid.mods.sodium.client.render.chunk.compile.pipeline.FluidRenderer;
 import me.jellysquid.mods.sodium.client.world.WorldSlice;
-import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.render.Xray;
-import meteordevelopment.meteorclient.systems.modules.world.Ambience;
-import net.caffeinemc.mods.sodium.api.util.ColorABGR;
-import net.caffeinemc.mods.sodium.api.util.ColorARGB;
 import net.minecraft.fluid.FluidState;
-import net.minecraft.registry.tag.FluidTags;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Direction;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.Arrays;
-
 @Mixin(value = FluidRenderer.class, remap = false)
 public class SodiumFluidRendererMixin {
-    @Final @Shadow private int[] quadColors;
-
-    @Unique private final ThreadLocal<Integer> alphas = new ThreadLocal<>();
-
     @Inject(method = "render", at = @At("HEAD"), cancellable = true)
-    private void onRender(WorldSlice world, FluidState fluidState, BlockPos blockPos, BlockPos offset, ChunkBuildBuffers buffers, CallbackInfo info) {
-        int alpha = Xray.getAlpha(fluidState.getBlockState(), blockPos);
-
-        if (alpha == 0) info.cancel();
-        else alphas.set(alpha);
-    }
-
-    @Inject(method = "updateQuad", at = @At("TAIL"))
-    private void onUpdateQuad(ModelQuadView quad, WorldSlice world, BlockPos pos, LightPipeline lighter, Direction dir, float brightness, ColorProvider<FluidState> colorProvider, FluidState fluidState, CallbackInfo info) {
-        // Ambience
-        Ambience ambience = Modules.get().get(Ambience.class);
-
-        if (ambience.isActive() && ambience.customLavaColor.get() && fluidState.isIn(FluidTags.LAVA)) {
-            Arrays.fill(quadColors, ColorARGB.toABGR(ambience.lavaColor.get().getPacked()));
-        } else {
-            // XRay and Wallhack
-            int alpha = alphas.get();
-
-            for (int i = 0; i < quadColors.length; i++) {
-                quadColors[i] = ColorABGR.withAlpha(quadColors[i], alpha / 255f);
-            }
-        }
+    private void onRender(WorldSlice world, FluidState fluidState, BlockPos blockPos, BlockPos offset, ChunkBuildBuffers buffers, CallbackInfo ci) {
+        if (Xray.getAlpha(fluidState.getBlockState(), blockPos) != -1) ci.cancel();
     }
 }


### PR DESCRIPTION
Fixed luminance
rip xray alpha again

## Type of change

- [X] Bug fix
- [ ] New feature

## Description

Updated to sodium 0.5.0.
Fixed luminance not working on sodium
rip xray alpha again

# How Has This Been Tested?

- Storage ESP shader mode: works
- ⚠ XRay/Wallhack: opacity no longer works
- ⚠ Ambience: No longer works
- Luminance: works

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
