### PR TITLE
server reconnect desync patch

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/events/world/ServerConnectBeginEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/world/ServerConnectBeginEvent.java
@@ -1,0 +1,21 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.events.world;
+
+import net.minecraft.client.network.ServerAddress;
+import net.minecraft.client.network.ServerInfo;
+
+public class ServerConnectBeginEvent {
+    private static final ServerConnectBeginEvent INSTANCE = new ServerConnectBeginEvent();
+    public ServerAddress address;
+    public ServerInfo info;
+
+    public static ServerConnectBeginEvent get(ServerAddress address, ServerInfo info) {
+        INSTANCE.address = address;
+        INSTANCE.info = info;
+        return INSTANCE;
+    }
+}

--- a/src/main/java/meteordevelopment/meteorclient/events/world/ServerConnectEndEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/world/ServerConnectEndEvent.java
@@ -7,11 +7,11 @@ package meteordevelopment.meteorclient.events.world;
 
 import java.net.InetSocketAddress;
 
-public class ConnectToServerEvent {
-    private static final ConnectToServerEvent INSTANCE = new ConnectToServerEvent();
+public class ServerConnectEndEvent {
+    private static final ServerConnectEndEvent INSTANCE = new ServerConnectEndEvent();
     public InetSocketAddress address;
 
-    public static ConnectToServerEvent get(InetSocketAddress address) {
+    public static ServerConnectEndEvent get(InetSocketAddress address) {
         INSTANCE.address = address;
         return INSTANCE;
     }

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientConnectionMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientConnectionMixin.java
@@ -5,6 +5,7 @@
 
 package meteordevelopment.meteorclient.mixin;
 
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.proxy.Socks4ProxyHandler;
@@ -12,7 +13,7 @@ import io.netty.handler.proxy.Socks5ProxyHandler;
 import io.netty.handler.timeout.TimeoutException;
 import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.events.packets.PacketEvent;
-import meteordevelopment.meteorclient.events.world.ConnectToServerEvent;
+import meteordevelopment.meteorclient.events.world.ServerConnectEndEvent;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.misc.AntiPacketKick;
 import meteordevelopment.meteorclient.systems.modules.world.HighwayBuilder;
@@ -51,9 +52,9 @@ public class ClientConnectionMixin {
         }
     }
 
-    @Inject(method = "connect", at = @At("HEAD"))
-    private static void onConnect(InetSocketAddress address, boolean useEpoll, CallbackInfoReturnable<ClientConnection> info) {
-        MeteorClient.EVENT_BUS.post(ConnectToServerEvent.get(address));
+    @Inject(method = "connect(Ljava/net/InetSocketAddress;ZLnet/minecraft/network/ClientConnection;)Lio/netty/channel/ChannelFuture;", at = @At("HEAD"))
+    private static void onConnect(InetSocketAddress address, boolean useEpoll, ClientConnection connection, CallbackInfoReturnable<ChannelFuture> cir) {
+        MeteorClient.EVENT_BUS.post(ServerConnectEndEvent.get(address));
     }
 
     @Inject(at = @At("HEAD"), method = "send(Lnet/minecraft/network/packet/Packet;)V", cancellable = true)

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ConnectScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ConnectScreenMixin.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.mixin;
+
+import meteordevelopment.meteorclient.MeteorClient;
+import meteordevelopment.meteorclient.events.world.ServerConnectBeginEvent;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.ConnectScreen;
+import net.minecraft.client.network.ServerAddress;
+import net.minecraft.client.network.ServerInfo;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ConnectScreen.class)
+public class ConnectScreenMixin {
+    @Inject(method = "connect(Lnet/minecraft/client/MinecraftClient;Lnet/minecraft/client/network/ServerAddress;Lnet/minecraft/client/network/ServerInfo;)V", at = @At("HEAD"))
+    private void tryConnectEvent(MinecraftClient client, ServerAddress address, ServerInfo info, CallbackInfo ci) {
+        MeteorClient.EVENT_BUS.post(ServerConnectBeginEvent.get(address, info));
+    }
+}

--- a/src/main/java/meteordevelopment/meteorclient/mixin/DisconnectedScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/DisconnectedScreenMixin.java
@@ -87,9 +87,7 @@ public abstract class DisconnectedScreenMixin extends Screen {
     }
 
     private void tryConnecting() {
-        var conn = Modules.get().get(AutoReconnect.class).lastServerConnection;
-        var host = conn.getAddress().getHostName();
-        if (host.contains(":")) host = host.substring(0, host.indexOf(":"));
-        ConnectScreen.connect(new TitleScreen(), mc, new ServerAddress(host, conn.getPort()), new ServerInfo(I18n.translate("selectServer.defaultName"), host, false), false);
+        var lastServer = Modules.get().get(AutoReconnect.class).lastServerConnection;
+        ConnectScreen.connect(new TitleScreen(), mc, lastServer.left(), lastServer.right(), false);
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/AutoReconnect.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/AutoReconnect.java
@@ -5,16 +5,18 @@
 
 package meteordevelopment.meteorclient.systems.modules.misc;
 
+import it.unimi.dsi.fastutil.Pair;
+import it.unimi.dsi.fastutil.objects.ObjectObjectImmutablePair;
 import meteordevelopment.meteorclient.MeteorClient;
-import meteordevelopment.meteorclient.events.world.ConnectToServerEvent;
+import meteordevelopment.meteorclient.events.world.ServerConnectBeginEvent;
 import meteordevelopment.meteorclient.settings.DoubleSetting;
 import meteordevelopment.meteorclient.settings.Setting;
 import meteordevelopment.meteorclient.settings.SettingGroup;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.orbit.EventHandler;
-
-import java.net.InetSocketAddress;
+import net.minecraft.client.network.ServerAddress;
+import net.minecraft.client.network.ServerInfo;
 
 public class AutoReconnect extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
@@ -28,7 +30,7 @@ public class AutoReconnect extends Module {
         .build()
     );
 
-    public InetSocketAddress lastServerConnection;
+    public Pair<ServerAddress, ServerInfo> lastServerConnection;
 
     public AutoReconnect() {
         super(Categories.Misc, "auto-reconnect", "Automatically reconnects when disconnected from a server.");
@@ -37,8 +39,8 @@ public class AutoReconnect extends Module {
 
     private class StaticListener {
         @EventHandler
-        private void onGameJoined(ConnectToServerEvent event) {
-            lastServerConnection = event.address;
+        private void onGameJoined(ServerConnectBeginEvent event) {
+            lastServerConnection = new ObjectObjectImmutablePair<>(event.address, event.info);
         }
     }
 }

--- a/src/main/resources/meteor-client.mixins.json
+++ b/src/main/resources/meteor-client.mixins.json
@@ -59,6 +59,7 @@
     "CloseHandledScreenC2SPacketAccessor",
     "CobwebBlockMixin",
     "CompassAnglePredicateProviderMixin",
+    "ConnectScreenMixin",
     "CrashReportMixin",
     "CreativeInventoryScreenAccessor",
     "CreativeSlotMixin",


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

Exceptions during early stages of server connection cause the 'reconnect' buttons to point to a different server than the one where a connection was attempted.
This patch also fixes an issue where `ConnectToServerEvent` (now `ServerConnectEndEvent`) was posted twice for every server query in the multiplayer server list.

# How Has This Been Tested?

Quantum computing

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
