### PR TITLE
removed origins from MixinPlugin since its incompatible

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/MixinPlugin.java
+++ b/src/main/java/meteordevelopment/meteorclient/MixinPlugin.java
@@ -22,7 +22,6 @@ public class MixinPlugin implements IMixinConfigPlugin {
 
     private static boolean loaded;
 
-    private static boolean isOriginsPresent;
     private static boolean isIndigoPresent;
     public static boolean isSodiumPresent;
     private static boolean isCanvasPresent;
@@ -67,7 +66,6 @@ public class MixinPlugin implements IMixinConfigPlugin {
         }
 
         isIndigoPresent = FabricLoader.getInstance().isModLoaded("fabric-renderer-indigo");
-        isOriginsPresent = FabricLoader.getInstance().isModLoaded("origins");
         isSodiumPresent = FabricLoader.getInstance().isModLoaded("sodium");
         isCanvasPresent = FabricLoader.getInstance().isModLoaded("canvas");
         isLithiumPresent = FabricLoader.getInstance().isModLoaded("lithium");
@@ -85,9 +83,6 @@ public class MixinPlugin implements IMixinConfigPlugin {
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
         if (!mixinClassName.startsWith(mixinPackage)) {
             throw new RuntimeException("Mixin " + mixinClassName + " is not in the mixin package");
-        }
-        else if (mixinClassName.endsWith("PlayerEntityRendererMixin")) {
-            return !isOriginsPresent;
         }
         else if (mixinClassName.startsWith(mixinPackage + ".sodium")) {
             return isSodiumPresent;


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Remove Origins from MixinPlugin since Meteor won't load with Origins anyway

## Related issues

None

# How Has This Been Tested?

Videos or screenshots of the changes if applicable.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
