### PR TITLE
Fixed InventoryTweaks Crash

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayerInteractionManagerMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayerInteractionManagerMixin.java
@@ -76,8 +76,13 @@ public abstract class ClientPlayerInteractionManagerMixin implements IClientPlay
                     clickSlot(syncId, 17, armorSlot, SlotActionType.SWAP, player); //armor slot <-> inv slot
                     ci.cancel();
                 } else if (actionType == SlotActionType.SWAP) {
-                    clickSlot(syncId, 36 + button, armorSlot, SlotActionType.SWAP, player); //invert swap
-                    ci.cancel();
+                    if (button >= 10) {
+                        clickSlot(syncId, 45, armorSlot, SlotActionType.SWAP, player);
+                        ci.cancel();
+                    } else {
+                        clickSlot(syncId, 36 + button, armorSlot, SlotActionType.SWAP, player); //invert swap
+                        ci.cancel();
+                    }
                 }
             }
         }


### PR DESCRIPTION
updated ClientPlayerInteractionManagerMixin.java

## Type of change

- [x] Bug fix

## Description

Checked if the pressed button is out of the inventory range and then forced it to the offhand slot

## Related issues

closes #3770

# How Has This Been Tested?


https://github.com/MeteorDevelopment/meteor-client/assets/85295145/e566fdef-3631-4b80-a3e1-66a3f5006663



# Checklist:

- [Idk probably not] My code follows the style guidelines of this project.
- [very simple so not needed] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
