### PR TITLE
Update BuildHeight

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/BuildHeight.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/BuildHeight.java
@@ -21,8 +21,8 @@ public class BuildHeight extends Module {
     @EventHandler
     private void onSendPacket(PacketEvent.Send event) {
         if (!(event.packet instanceof PlayerInteractBlockC2SPacket p)) return;
-
-        if (p.getBlockHitResult().getPos().y >= 255 && p.getBlockHitResult().getSide() == Direction.UP) {
+        if (mc.world == null) return;
+        if (p.getBlockHitResult().getPos().y >= mc.world.getTopY() && p.getBlockHitResult().getSide() == Direction.UP) {
             ((BlockHitResultAccessor) p.getBlockHitResult()).setSide(Direction.DOWN);
         }
     }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description
Update BuildHeight to use new height limit as it previously was hard-coded to 255. This module is likely not needed anymore for most cases as interacting with blocks at world height was fixed in recent versions of Minecraft, but the fix may not apply to other mods so this can be used if needed.

## Related issues

# How Has This Been Tested?

Tested in singleplayer and multiplayer.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
