### PR TITLE
pin sodium version

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -54,6 +54,7 @@
     "optifabric": "*",
     "feather": "*",
     "origins": "*",
-    "wurst": "*"
+    "wurst": "*",
+    "sodium": "<0.5.0"
   }
 }


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

Instead of crashing with an obscure mixin error when an old & incompatible version of sodium is present, it instead shows a standard fabric incompatibility error

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
