### PR TITLE
Potion timer invis pr2

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PotionTimersHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PotionTimersHud.java
@@ -172,7 +172,7 @@ public class PotionTimersHud extends HudElement {
 
     @Override
     public void tick(HudRenderer renderer) {
-        if (mc.player == null || (isInEditor() && mc.player.getStatusEffects().isEmpty())) {
+        if (mc.player == null || (isInEditor() && hasNoVisibleEffects())) {
             setSize(renderer.textWidth("Potion Timers 0:00", shadow.get(), getScale()), renderer.textHeight(shadow.get(), getScale()));
             return;
         }
@@ -199,7 +199,7 @@ public class PotionTimersHud extends HudElement {
             renderer.quad(this.x, this.y, getWidth(), getHeight(), backgroundColor.get());
         }
 
-        if (mc.player == null || (isInEditor() && mc.player.getStatusEffects().isEmpty())) {
+        if (mc.player == null || (isInEditor() && hasNoVisibleEffects())) {
             renderer.text("Potion Timers 0:00", x, y, Color.WHITE, shadow.get(), getScale());
             return;
         }
@@ -249,6 +249,16 @@ public class PotionTimersHud extends HudElement {
 
     private double getScale() {
         return customScale.get() ? scale.get() : -1;
+    }
+
+    private boolean hasNoVisibleEffects() {
+        for (StatusEffectInstance statusEffectInstance : mc.player.getStatusEffects()) {
+            if (hiddenEffects.get().contains(statusEffectInstance.getEffectType())) continue;
+            if (!showAmbient.get() && statusEffectInstance.isAmbient()) continue;
+            return false;
+        }
+
+        return true;
     }
 
     public enum ColorMode {


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

Fixed PotionTimers getting stuck invisible in the hud editor if all effects are hidden.

## Related issues



# How Has This Been Tested?



# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
