### PR TITLE
Use a unique thread executor for BlockESP to fix weird chunk rendering issue & Removed residual `Dimension` usage

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/events/entity/player/PlayerRespawnEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/entity/player/PlayerRespawnEvent.java
@@ -1,0 +1,14 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.events.entity.player;
+
+public class PlayerRespawnEvent {
+    private static final PlayerRespawnEvent INSTANCE = new PlayerRespawnEvent();
+
+    public static PlayerRespawnEvent get() {
+        return INSTANCE;
+    }
+}

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayNetworkHandlerMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayNetworkHandlerMixin.java
@@ -11,6 +11,7 @@ import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.commands.Commands;
 import meteordevelopment.meteorclient.events.entity.EntityDestroyEvent;
 import meteordevelopment.meteorclient.events.entity.player.PickItemsEvent;
+import meteordevelopment.meteorclient.events.entity.player.PlayerRespawnEvent;
 import meteordevelopment.meteorclient.events.game.GameJoinedEvent;
 import meteordevelopment.meteorclient.events.game.GameLeftEvent;
 import meteordevelopment.meteorclient.events.game.SendMessageEvent;
@@ -152,5 +153,10 @@ public abstract class ClientPlayNetworkHandlerMixin {
             client.inGameHud.getChatHud().addToMessageHistory(message);
             ci.cancel();
         }
+    }
+
+    @Inject(method = "onPlayerRespawn", at = @At("TAIL"))
+    public void onPlayerRespawn(PlayerRespawnS2CPacket packet, CallbackInfo ci) {
+        MeteorClient.EVENT_BUS.post(PlayerRespawnEvent.get());
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/NoFall.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/NoFall.java
@@ -24,7 +24,6 @@ import meteordevelopment.meteorclient.utils.player.InvUtils;
 import meteordevelopment.meteorclient.utils.player.PlayerUtils;
 import meteordevelopment.meteorclient.utils.player.Rotations;
 import meteordevelopment.meteorclient.utils.world.BlockUtils;
-import meteordevelopment.meteorclient.utils.world.Dimension;
 import meteordevelopment.orbit.EventHandler;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
@@ -156,7 +155,7 @@ public class NoFall extends Module {
 
         // Bucket mode
         else if (mode.get() == Mode.Place) {
-            PlacedItem placedItem1 = autoDimension.get() && PlayerUtils.getDimension() == Dimension.Nether ? PlacedItem.PowderSnow : placedItem.get();
+            PlacedItem placedItem1 = autoDimension.get() && mc.world.getDimension().ultrawarm() ? PlacedItem.PowderSnow : placedItem.get();
             if (mc.player.fallDistance > 3 && !EntityUtils.isAboveWater(mc.player)) {
                 Item item = placedItem1.item;
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Breadcrumbs.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Breadcrumbs.java
@@ -5,6 +5,7 @@
 
 package meteordevelopment.meteorclient.systems.modules.render;
 
+import meteordevelopment.meteorclient.events.entity.player.PlayerRespawnEvent;
 import meteordevelopment.meteorclient.events.render.Render3DEvent;
 import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.settings.*;
@@ -13,7 +14,6 @@ import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.utils.misc.Pool;
 import meteordevelopment.meteorclient.utils.render.color.SettingColor;
 import meteordevelopment.orbit.EventHandler;
-import net.minecraft.world.dimension.DimensionType;
 
 import java.util.ArrayDeque;
 import java.util.Queue;
@@ -51,8 +51,6 @@ public class Breadcrumbs extends Module {
 
     private Section section;
 
-    private DimensionType lastDimension;
-
     public Breadcrumbs() {
         super(Categories.Render, "breadcrumbs", "Displays a trail behind where you have walked.");
     }
@@ -61,8 +59,6 @@ public class Breadcrumbs extends Module {
     public void onActivate() {
         section = sectionPool.get();
         section.set1();
-
-        lastDimension = mc.world.getDimension();
     }
 
     @Override
@@ -72,12 +68,13 @@ public class Breadcrumbs extends Module {
     }
 
     @EventHandler
-    private void onTick(TickEvent.Post event) {
-        if (lastDimension != mc.world.getDimension()) {
-            for (Section sec : sections) sectionPool.free(sec);
-            sections.clear();
-        }
+    private void onPlayerRespawn(PlayerRespawnEvent event) {
+        for (Section sec : sections) sectionPool.free(sec);
+        sections.clear();
+    }
 
+    @EventHandler
+    private void onTick(TickEvent.Post event) {
         if (isFarEnough(section.x1, section.y1, section.z1)) {
             section.set2();
 
@@ -90,8 +87,6 @@ public class Breadcrumbs extends Module {
             section = sectionPool.get();
             section.set1();
         }
-
-        lastDimension = mc.world.getDimension();
     }
 
     @EventHandler

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/LogoutSpots.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/LogoutSpots.java
@@ -6,6 +6,7 @@
 package meteordevelopment.meteorclient.systems.modules.render;
 
 import meteordevelopment.meteorclient.events.entity.EntityAddedEvent;
+import meteordevelopment.meteorclient.events.entity.player.PlayerRespawnEvent;
 import meteordevelopment.meteorclient.events.render.Render2DEvent;
 import meteordevelopment.meteorclient.events.render.Render3DEvent;
 import meteordevelopment.meteorclient.events.world.TickEvent;
@@ -19,7 +20,6 @@ import meteordevelopment.meteorclient.utils.player.PlayerUtils;
 import meteordevelopment.meteorclient.utils.render.NametagUtils;
 import meteordevelopment.meteorclient.utils.render.color.Color;
 import meteordevelopment.meteorclient.utils.render.color.SettingColor;
-import meteordevelopment.meteorclient.utils.world.Dimension;
 import meteordevelopment.orbit.EventHandler;
 import net.minecraft.client.network.PlayerListEntry;
 import net.minecraft.entity.Entity;
@@ -98,7 +98,6 @@ public class LogoutSpots extends Module {
     private final List<PlayerEntity> lastPlayers = new ArrayList<>();
 
     private int timer;
-    private Dimension lastDimension;
 
     public LogoutSpots() {
         super(Categories.Render, "logout-spots", "Displays a box where another player has logged out at.");
@@ -111,7 +110,6 @@ public class LogoutSpots extends Module {
         updateLastPlayers();
 
         timer = 10;
-        lastDimension = PlayerUtils.getDimension();
     }
 
     @Override
@@ -125,6 +123,11 @@ public class LogoutSpots extends Module {
         for (Entity entity : mc.world.getEntities()) {
             if (entity instanceof PlayerEntity) lastPlayers.add((PlayerEntity) entity);
         }
+    }
+
+    @EventHandler
+    private void onPlayerRespawn(PlayerRespawnEvent event) {
+        players.clear();
     }
 
     @EventHandler
@@ -169,10 +172,6 @@ public class LogoutSpots extends Module {
         } else {
             timer--;
         }
-
-        Dimension dimension = PlayerUtils.getDimension();
-        if (dimension != lastDimension) players.clear();
-        lastDimension = dimension;
     }
 
     private void add(Entry entry) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/VoidESP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/VoidESP.java
@@ -12,9 +12,7 @@ import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.utils.misc.Pool;
-import meteordevelopment.meteorclient.utils.player.PlayerUtils;
 import meteordevelopment.meteorclient.utils.render.color.SettingColor;
-import meteordevelopment.meteorclient.utils.world.Dimension;
 import meteordevelopment.meteorclient.utils.world.Dir;
 import meteordevelopment.orbit.EventHandler;
 import net.minecraft.block.Block;
@@ -23,6 +21,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.ChunkStatus;
+import net.minecraft.world.dimension.DimensionTypes;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -102,7 +101,7 @@ public class VoidESP extends Module {
     @EventHandler
     private void onTick(TickEvent.Post event) {
         voidHoles.clear();
-        if (PlayerUtils.getDimension() == Dimension.End) return;
+        if (mc.world.getDimensionKey() == DimensionTypes.THE_END) return;
 
         int px = mc.player.getBlockPos().getX();
         int pz = mc.player.getBlockPos().getZ();
@@ -111,10 +110,11 @@ public class VoidESP extends Module {
         for (int x = px - radius; x <= px + radius; x++) {
             for (int z = pz - radius; z <= pz + radius; z++) {
                 blockPos.set(x, mc.world.getBottomY(), z);
-                if (isHole(blockPos, false)) voidHoles.add(voidHolePool.get().set(blockPos.set(x, mc.world.getBottomY(), z), false));
+                if (isHole(blockPos, false))
+                    voidHoles.add(voidHolePool.get().set(blockPos.set(x, mc.world.getBottomY(), z), false));
 
                 // Check for nether roof
-                if (netherRoof.get() && PlayerUtils.getDimension() == Dimension.Nether) {
+                if (netherRoof.get() && mc.world.getDimensionKey() == DimensionTypes.THE_NETHER) {
                     blockPos.set(x, 127, z);
                     if (isHole(blockPos, true)) voidHoles.add(voidHolePool.get().set(blockPos.set(x, 127, z), true));
                 }

--- a/src/main/java/meteordevelopment/meteorclient/utils/player/PlayerUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/PlayerUtils.java
@@ -205,7 +205,7 @@ public class PlayerUtils {
             }
 
             // Check for beds if in nether
-            if (PlayerUtils.getDimension() != Dimension.Overworld) {
+            if (!mc.world.getDimension().bedWorks()) {
                 for (BlockEntity blockEntity : Utils.blockEntities()) {
                     BlockPos bp = blockEntity.getPos();
                     Vec3d pos = new Vec3d(bp.getX(), bp.getY(), bp.getZ());


### PR DESCRIPTION
Use a unique thread executor for BlockESP to fix weird chunk data issue & Removed residual `Dimension` usage

## Type of change

- [X] Bug fix
- [ ] New feature

## Description

![image](https://github.com/MeteorDevelopment/meteor-client/assets/62250232/b2a6f614-08ac-4ca4-b7d3-230afd233917)


## Related issues

#3958

# How Has This Been Tested?

Tested in singleplayer

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
