### PR TITLE
Added Recast mode to Elytra Fly

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/LivingEntityMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/LivingEntityMixin.java
@@ -10,7 +10,9 @@ import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.events.entity.DamageEvent;
 import meteordevelopment.meteorclient.events.entity.player.CanWalkOnFluidEvent;
 import meteordevelopment.meteorclient.systems.modules.Modules;
+import meteordevelopment.meteorclient.systems.modules.movement.elytrafly.ElytraFlightModes;
 import meteordevelopment.meteorclient.systems.modules.movement.elytrafly.ElytraFly;
+import meteordevelopment.meteorclient.systems.modules.movement.elytrafly.modes.Recast;
 import meteordevelopment.meteorclient.systems.modules.player.OffhandCrash;
 import meteordevelopment.meteorclient.systems.modules.player.PotionSpoof;
 import meteordevelopment.meteorclient.systems.modules.render.HandView;
@@ -107,6 +109,18 @@ public abstract class LivingEntityMixin extends Entity {
         }
 
         return original;
+    }
+
+    private boolean previousElytra = false;
+
+    @Inject(method = "isFallFlying", at = @At("TAIL"), cancellable = true)
+    public void recastOnLand(CallbackInfoReturnable<Boolean> cir) {
+        boolean elytra = cir.getReturnValue();
+        ElytraFly elytraFly = Modules.get().get(ElytraFly.class);
+        if (previousElytra && !elytra && elytraFly.isActive() && elytraFly.flightMode.get() == ElytraFlightModes.Recast) {
+            cir.setReturnValue(ElytraFly.recastElytra(mc.player));
+        }
+        previousElytra = elytra;
     }
 
     @ModifyReturnValue(method = "hasStatusEffect", at = @At("RETURN"))

--- a/src/main/java/meteordevelopment/meteorclient/mixin/LivingEntityMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/LivingEntityMixin.java
@@ -118,7 +118,7 @@ public abstract class LivingEntityMixin extends Entity {
         boolean elytra = cir.getReturnValue();
         ElytraFly elytraFly = Modules.get().get(ElytraFly.class);
         if (previousElytra && !elytra && elytraFly.isActive() && elytraFly.flightMode.get() == ElytraFlightModes.Recast) {
-            cir.setReturnValue(ElytraFly.recastElytra(mc.player));
+            cir.setReturnValue(Recast.recastElytra(mc.player));
         }
         previousElytra = elytra;
     }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFlightMode.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFlightMode.java
@@ -63,6 +63,9 @@ public class ElytraFlightMode {
     public void onPacketSend(PacketEvent.Send event) {
     }
 
+    public void onPacketReceive(PacketEvent.Receive event) {
+    }
+
     public void onPlayerMove() {
     }
 
@@ -103,7 +106,7 @@ public class ElytraFlightMode {
     public void handleAutopilot() {
         if (!mc.player.isFallFlying()) return;
 
-        if (elytraFly.autoPilot.get() && mc.player.getY() > elytraFly.autoPilotMinimumHeight.get()) {
+        if (elytraFly.autoPilot.get() && mc.player.getY() > elytraFly.autoPilotMinimumHeight.get() && elytraFly.flightMode.get() != ElytraFlightModes.Recast) {
             mc.options.forwardKey.setPressed(true);
             lastForwardPressed = true;
         }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFlightModes.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFlightModes.java
@@ -8,5 +8,6 @@ package meteordevelopment.meteorclient.systems.modules.movement.elytrafly;
 public enum ElytraFlightModes {
     Vanilla,
     Packet,
-    Pitch40
+    Pitch40,
+    Recast
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFly.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFly.java
@@ -447,30 +447,6 @@ public class ElytraFly extends Module {
         currentMode.onPacketReceive(event);
     }
 
-    // Recast
-
-    public static boolean recastElytra(ClientPlayerEntity player) {
-        if (checkConditions(player) && ignoreGround(player)) {
-            player.networkHandler.sendPacket(new ClientCommandC2SPacket(player, ClientCommandC2SPacket.Mode.START_FALL_FLYING));
-            return true;
-        } else return false;
-    }
-
-    public static boolean checkConditions(ClientPlayerEntity player) {
-        ItemStack itemStack = player.getEquippedStack(EquipmentSlot.CHEST);
-        return (!player.getAbilities().flying && !player.hasVehicle() && !player.isClimbing() && itemStack.isOf(Items.ELYTRA) && ElytraItem.isUsable(itemStack));
-    }
-
-    private static boolean ignoreGround(ClientPlayerEntity player) {
-        if (!player.isTouchingWater() && !player.hasStatusEffect(StatusEffects.LEVITATION)) {
-            ItemStack itemStack = player.getEquippedStack(EquipmentSlot.CHEST);
-            if (itemStack.isOf(Items.ELYTRA) && ElytraItem.isUsable(itemStack)) {
-                player.startFallFlying();
-                return true;
-            } else return false;
-        } else return false;
-    }
-
     private void onModeChanged(ElytraFlightModes mode) {
         switch (mode) {
             case Vanilla -> currentMode = new Vanilla();

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFly.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFly.java
@@ -169,7 +169,7 @@ public class ElytraFly extends Module {
         .description("The bottom height boundary for pitch40.")
         .defaultValue(80)
         .min(-128)
-        .sliderMax(260)
+        .sliderMax(360)
         .visible(() -> flightMode.get() == ElytraFlightModes.Pitch40)
         .build()
     );
@@ -179,7 +179,7 @@ public class ElytraFly extends Module {
         .description("The upper height boundary for pitch40.")
         .defaultValue(120)
         .min(-128)
-        .sliderMax(260)
+        .sliderMax(360)
         .visible(() -> flightMode.get() == ElytraFlightModes.Pitch40)
         .build()
     );
@@ -279,7 +279,7 @@ public class ElytraFly extends Module {
         .name("auto-pilot")
         .description("Moves forward while elytra flying.")
         .defaultValue(false)
-        .visible(() -> flightMode.get() != ElytraFlightModes.Pitch40)
+        .visible(() -> flightMode.get() != ElytraFlightModes.Pitch40 && flightMode.get() != ElytraFlightModes.Recast)
         .build()
     );
 
@@ -287,7 +287,7 @@ public class ElytraFly extends Module {
         .name("use-fireworks")
         .description("Uses firework rockets every second of your choice.")
         .defaultValue(false)
-        .visible(autoPilot::get)
+        .visible(() -> autoPilot.get() && flightMode.get() != ElytraFlightModes.Pitch40 && flightMode.get() != ElytraFlightModes.Recast)
         .build()
     );
 
@@ -297,7 +297,7 @@ public class ElytraFly extends Module {
         .min(1)
         .defaultValue(8)
         .sliderMax(20)
-        .visible(useFireworks::get)
+        .visible(() -> useFireworks.get() && flightMode.get() != ElytraFlightModes.Pitch40 && flightMode.get() != ElytraFlightModes.Recast)
         .build()
     );
 
@@ -307,7 +307,7 @@ public class ElytraFly extends Module {
         .defaultValue(120)
         .min(-128)
         .sliderMax(260)
-        .visible(autoPilot::get)
+        .visible(() -> autoPilot.get() && flightMode.get() != ElytraFlightModes.Pitch40 && flightMode.get() != ElytraFlightModes.Recast)
         .build()
     );
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/modes/Recast.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/modes/Recast.java
@@ -3,6 +3,10 @@
  * Copyright (c) Meteor Development.
  */
 
+/*
+ * Credit to Luna (https://github.com/InLieuOfLuna) for making the original Elytra Recast mod (https://github.com/InLieuOfLuna/elytra-recast)!
+ */
+
 package meteordevelopment.meteorclient.systems.modules.movement.elytrafly.modes;
 
 import meteordevelopment.meteorclient.events.packets.PacketEvent;
@@ -23,6 +27,7 @@ public class Recast extends ElytraFlightMode {
     public static boolean rubberbanded = false;
 
     int tickDelay = elytraFly.restartDelay.get();
+
     @Override
     public void onTick() {
         super.onTick();

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/modes/Recast.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/modes/Recast.java
@@ -41,13 +41,11 @@ public class Recast extends ElytraFlightMode {
         // Make sure all the conditions are met (player has an elytra, isn't in water, etc)
         if (checkConditions(mc.player)) {
 
-            if (elytraFly.flightMode.get() == ElytraFlightModes.Recast) {
-                mc.player.setSprinting(true);
-                setPressed(mc.options.forwardKey, true);
-                if (elytraFly.autoJump.get()) setPressed(mc.options.jumpKey, true);
-                mc.player.setYaw(getSmartYawDirection());
-                mc.player.setPitch(elytraFly.pitch.get());
-            }
+            mc.player.setSprinting(true);
+            setPressed(mc.options.forwardKey, true);
+            if (elytraFly.autoJump.get()) setPressed(mc.options.jumpKey, true);
+            mc.player.setYaw(getSmartYawDirection());
+            mc.player.setPitch(elytraFly.pitch.get());
 
             // Rubberbanding
             if (rubberbanded && elytraFly.restart.get()) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/modes/Recast.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/modes/Recast.java
@@ -1,0 +1,81 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.systems.modules.movement.elytrafly.modes;
+
+import meteordevelopment.meteorclient.events.packets.PacketEvent;
+import meteordevelopment.meteorclient.systems.modules.movement.elytrafly.ElytraFlightMode;
+import meteordevelopment.meteorclient.systems.modules.movement.elytrafly.ElytraFlightModes;
+import meteordevelopment.meteorclient.systems.modules.movement.elytrafly.ElytraFly;
+import meteordevelopment.meteorclient.utils.misc.input.Input;
+import net.minecraft.client.option.KeyBinding;
+import net.minecraft.network.packet.c2s.play.ClientCommandC2SPacket;
+import net.minecraft.network.packet.s2c.play.PlayerPositionLookS2CPacket;
+
+public class Recast extends ElytraFlightMode {
+
+    public Recast() {
+        super(ElytraFlightModes.Recast);
+    }
+
+    public static boolean rubberbanded = false;
+
+    int tickDelay = elytraFly.restartDelay.get();
+    @Override
+    public void onTick() {
+        super.onTick();
+
+        // Make sure all the conditions are met (player has an elytra, isn't in water, etc)
+        if (ElytraFly.checkConditions(mc.player)) {
+
+            if (elytraFly.flightMode.get() == ElytraFlightModes.Recast) {
+                mc.player.setSprinting(true);
+                setPressed(mc.options.forwardKey, true);
+                if (elytraFly.autoJump.get()) setPressed(mc.options.jumpKey, true);
+                mc.player.setYaw(getSmartYawDirection());
+                mc.player.setPitch(elytraFly.pitch.get());
+            }
+
+            // Rubberbanding
+            if (rubberbanded && elytraFly.restart.get()) {
+                if (tickDelay > 0) {
+                    tickDelay--;
+                } else {
+                    rubberbanded = false;
+                    mc.getNetworkHandler().sendPacket(new ClientCommandC2SPacket(mc.player, ClientCommandC2SPacket.Mode.START_FALL_FLYING));
+                    tickDelay = elytraFly.restartDelay.get();
+                }
+            }
+        }
+    }
+
+    private void unpress() {
+        setPressed(mc.options.forwardKey, false);
+        if (elytraFly.autoJump.get()) setPressed(mc.options.jumpKey, false);
+    }
+
+    @Override
+    public void onPacketReceive(PacketEvent.Receive event) {
+        if (event.packet instanceof PlayerPositionLookS2CPacket) {
+            rubberbanded = true;
+            mc.player.stopFallFlying();
+        }
+    }
+
+
+    private void setPressed(KeyBinding key, boolean pressed) {
+        key.setPressed(pressed);
+        Input.setKeyState(key, pressed);
+    }
+
+    private float getSmartYawDirection() {
+        return Math.round((mc.player.getYaw() + 1f) / 45f) * 45f;
+    }
+
+    @Override
+    public void onDeactivate() {
+        unpress();
+    }
+}

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/modes/Recast.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/modes/Recast.java
@@ -14,7 +14,13 @@ import meteordevelopment.meteorclient.systems.modules.movement.elytrafly.ElytraF
 import meteordevelopment.meteorclient.systems.modules.movement.elytrafly.ElytraFlightModes;
 import meteordevelopment.meteorclient.systems.modules.movement.elytrafly.ElytraFly;
 import meteordevelopment.meteorclient.utils.misc.input.Input;
+import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.option.KeyBinding;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.effect.StatusEffects;
+import net.minecraft.item.ElytraItem;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.network.packet.c2s.play.ClientCommandC2SPacket;
 import net.minecraft.network.packet.s2c.play.PlayerPositionLookS2CPacket;
 
@@ -33,7 +39,7 @@ public class Recast extends ElytraFlightMode {
         super.onTick();
 
         // Make sure all the conditions are met (player has an elytra, isn't in water, etc)
-        if (ElytraFly.checkConditions(mc.player)) {
+        if (checkConditions(mc.player)) {
 
             if (elytraFly.flightMode.get() == ElytraFlightModes.Recast) {
                 mc.player.setSprinting(true);
@@ -73,6 +79,28 @@ public class Recast extends ElytraFlightMode {
     private void setPressed(KeyBinding key, boolean pressed) {
         key.setPressed(pressed);
         Input.setKeyState(key, pressed);
+    }
+
+    public static boolean recastElytra(ClientPlayerEntity player) {
+        if (checkConditions(player) && ignoreGround(player)) {
+            player.networkHandler.sendPacket(new ClientCommandC2SPacket(player, ClientCommandC2SPacket.Mode.START_FALL_FLYING));
+            return true;
+        } else return false;
+    }
+
+    public static boolean checkConditions(ClientPlayerEntity player) {
+        ItemStack itemStack = player.getEquippedStack(EquipmentSlot.CHEST);
+        return (!player.getAbilities().flying && !player.hasVehicle() && !player.isClimbing() && itemStack.isOf(Items.ELYTRA) && ElytraItem.isUsable(itemStack));
+    }
+
+    private static boolean ignoreGround(ClientPlayerEntity player) {
+        if (!player.isTouchingWater() && !player.hasStatusEffect(StatusEffects.LEVITATION)) {
+            ItemStack itemStack = player.getEquippedStack(EquipmentSlot.CHEST);
+            if (itemStack.isOf(Items.ELYTRA) && ElytraItem.isUsable(itemStack)) {
+                player.startFallFlying();
+                return true;
+            } else return false;
+        } else return false;
     }
 
     private float getSmartYawDirection() {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [✓] New feature

## Description

I added a "Recast" mode to the ElytraFly module. Recast mode modifies the vanilla behaviour where your elytra closes when you hit the ground. This mode makes it so the elytra remains open when hitting the ground, allowing you to keep bouncing on the ground and go at over 40 blocks per second. Because of the high speed it can reach, it is very normal that you will get rubberbanded, which is why I added a setting to it (which is on by default) that automatically relaunches your elytra when you get rubberbanded.

## Related issues

There are no issues regarding this as this mode was made public just a few days ago.

# How Has This Been Tested?

This was tested on 2b2t.org, which uses Grim AC. It rubberbands every 4/5 seconds, but the "restart" setting makes it so it instantly restarts your elytra. This was also tested on a server with the NCP anti-cheat, as well as a single-player world.

# Checklist:

- [✓] My code follows the style guidelines of this project.
- [✓] I have added comments to my code in more complex areas.
- [✓] I have tested the code in both development and production environments.
