### PR TITLE
make pitch setting use a float instead of an int

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFly.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFly.java
@@ -202,7 +202,7 @@ public class ElytraFly extends Module {
         .build()
     );
 
-    public final Setting<Integer> pitch = sgGeneral.add(new IntSetting.Builder()
+    public final Setting<Double> pitch = sgGeneral.add(new DoubleSetting.Builder()
         .name("pitch")
         .description("The pitch angle to look at when using the recast mode.")
         .defaultValue(85)

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/modes/Recast.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/modes/Recast.java
@@ -45,7 +45,7 @@ public class Recast extends ElytraFlightMode {
             setPressed(mc.options.forwardKey, true);
             if (elytraFly.autoJump.get()) setPressed(mc.options.jumpKey, true);
             mc.player.setYaw(getSmartYawDirection());
-            mc.player.setPitch(elytraFly.pitch.get());
+            mc.player.setPitch(elytraFly.pitch.get().floatValue());
 
             // Rubberbanding
             if (rubberbanded && elytraFly.restart.get()) {


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [] New feature

## Description

As seen in title, no reason for the pitch to use a whole number
from my personal testing on 2b I find  52.5 to be the ideal pitch, hence the need to make it not a whole number
## Related issues

N/A
# How Has This Been Tested?
Probably doesn't require any testing but i did test and it works trust me bro

# Checklist:

- [X] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
