### PR TITLE
Add quickSwap() Action

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/InventoryTweaks.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/InventoryTweaks.java
@@ -398,7 +398,7 @@ public class InventoryTweaks extends Module {
                     int iCopy = i;
                     Rotations.rotate(mc.player.getYaw() - 180, mc.player.getPitch(), () -> InvUtils.drop().slotId(iCopy));
                 }
-            } else InvUtils.quickMove().slotId(i);
+            } else InvUtils.shiftClick().slotId(i);
         }
     }
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoBrewer.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoBrewer.java
@@ -159,7 +159,7 @@ public class AutoBrewer extends Module {
 
     private boolean takePotions(BrewingStandScreenHandler c) {
         for (int i = 0; i < 3; i++) {
-            InvUtils.quickMove().slotId(i);
+            InvUtils.shiftClick().slotId(i);
 
             if (!c.slots.get(i).getStack().isEmpty()) {
                 error("You do not have a sufficient amount of inventory space... disabling.");

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoSmelter.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoSmelter.java
@@ -138,7 +138,7 @@ public class AutoSmelter extends Module {
         ItemStack resultStack = c.slots.get(2).getStack();
         if (resultStack.isEmpty()) return;
 
-        InvUtils.quickMove().slotId(2);
+        InvUtils.shiftClick().slotId(2);
 
         if (!resultStack.isEmpty()) {
             error("Your inventory is full. Disabling.");

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/InfinityMiner.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/InfinityMiner.java
@@ -188,7 +188,7 @@ public class InfinityMiner extends Module {
             && !Utils.hasEnchantments(stack, Enchantments.SILK_TOUCH));
         FindItemResult bestPick = InvUtils.findInHotbar(pickaxePredicate);
 
-        if (bestPick.isOffhand()) InvUtils.quickMove().fromOffhand().toHotbar(mc.player.getInventory().selectedSlot);
+        if (bestPick.isOffhand()) InvUtils.shiftClick().fromOffhand().toHotbar(mc.player.getInventory().selectedSlot);
         else if (bestPick.isHotbar()) InvUtils.swap(bestPick.slot(), false);
 
         return InvUtils.testInMainHand(pickaxePredicate);
@@ -233,7 +233,7 @@ public class InfinityMiner extends Module {
         for (int i = 0; i <= 35; i++) {
             ItemStack itemStack = mc.player.getInventory().getStack(i);
             if (itemStack.isEmpty()) return false;
-            
+
             for (Item item : targetItems.get()) {
                 if (itemStack.getItem() == item && itemStack.getCount() < itemStack.getMaxCount()) {
                     return false;

--- a/src/main/java/meteordevelopment/meteorclient/utils/player/InvUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/InvUtils.java
@@ -178,7 +178,7 @@ public class InvUtils {
         return ACTION;
     }
 
-    public static Action quickMove() {
+    public static Action shiftClick() {
         ACTION.type = SlotActionType.QUICK_MOVE;
         return ACTION;
     }

--- a/src/main/java/meteordevelopment/meteorclient/utils/player/InvUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/InvUtils.java
@@ -178,6 +178,11 @@ public class InvUtils {
         return ACTION;
     }
 
+    public static Action quickSwap() {
+        ACTION.type = SlotActionType.SWAP;
+        return ACTION;
+    }
+
     public static Action shiftClick() {
         ACTION.type = SlotActionType.QUICK_MOVE;
         return ACTION;
@@ -289,6 +294,11 @@ public class InvUtils {
 
         private void run() {
             boolean hadEmptyCursor = mc.player.currentScreenHandler.getCursorStack().isEmpty();
+
+            if (type == SlotActionType.SWAP) {
+                data = from;
+                from = to;
+            }
 
             if (type != null && from != -1 && to != -1) {
                click(from);

--- a/src/main/java/meteordevelopment/meteorclient/utils/player/InvUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/InvUtils.java
@@ -178,6 +178,11 @@ public class InvUtils {
         return ACTION;
     }
 
+    /**
+     * When writing code with quickSwap, both to and from should provide the ID of a slot, not the index.
+     * From should be the slot in the hotbar, to should be the slot you're switching an item from.
+     */
+
     public static Action quickSwap() {
         ACTION.type = SlotActionType.SWAP;
         return ACTION;


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Adds the quickSwap() action to InvUtils, which mimicks the behavior of swapping items to your hotbar using number keys. It should be noted that when using this action, your from() must be the slot in your hotbar, and your to() must be the slot in your inventory. Also renamed quickMove() action to shiftClick() to better reflect the behavior it produces.

## Related issues

N/A

# How Has This Been Tested?

Tested on a MultiMC instance and in the IDEA profile 

https://github.com/MeteorDevelopment/meteor-client/assets/116294072/3bdddf1f-fb4f-4dc6-aec0-8ea0eecfb6d4
![image](https://github.com/MeteorDevelopment/meteor-client/assets/116294072/838f9b4d-8222-4a1c-ad9b-4e1d003464e2)

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
