### PR TITLE
AntiBreak

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
@@ -411,6 +411,7 @@ public class Modules extends System<Modules> {
     }
 
     private void initPlayer() {
+        add(new AntiBreak());
         add(new AntiHunger());
         add(new AutoEat());
         add(new AutoFish());

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AntiBreak.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AntiBreak.java
@@ -56,7 +56,7 @@ public class AntiBreak extends Module {
         return !itemStack.isDamageable() || itemStack.getMaxDamage() - itemStack.getDamage() >= itemStack.getMaxDamage() * breakDurability.get() / 100;
     }
 
-    @EventHandler(priority = EventPriority.HIGH)
+    @EventHandler(priority = EventPriority.HIGH - 10) //after autotool
     private void onStartBreakingBlock(StartBreakingBlockEvent event) {
         if (!preventMine.get() || Modules.get().isActive(InfinityMiner.class)) return;
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AntiBreak.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AntiBreak.java
@@ -1,0 +1,82 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.systems.modules.player;
+
+import meteordevelopment.meteorclient.events.entity.player.AttackEntityEvent;
+import meteordevelopment.meteorclient.events.entity.player.StartBreakingBlockEvent;
+import meteordevelopment.meteorclient.settings.BoolSetting;
+import meteordevelopment.meteorclient.settings.IntSetting;
+import meteordevelopment.meteorclient.settings.Setting;
+import meteordevelopment.meteorclient.settings.SettingGroup;
+import meteordevelopment.meteorclient.systems.modules.Categories;
+import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.meteorclient.systems.modules.Modules;
+import meteordevelopment.meteorclient.systems.modules.world.InfinityMiner;
+import meteordevelopment.meteorclient.utils.world.BlockUtils;
+import meteordevelopment.orbit.EventHandler;
+import meteordevelopment.orbit.EventPriority;
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.ItemStack;
+
+public class AntiBreak extends Module {
+    private final SettingGroup sgGeneral = settings.getDefaultGroup();
+
+    private final Setting<Integer> breakDurability = sgGeneral.add(new IntSetting.Builder()
+        .name("anti-break-percentage")
+        .description("The durability percentage to stop using a tool.")
+        .defaultValue(10)
+        .range(1, 100)
+        .sliderRange(1, 100)
+        .build()
+    );
+
+    private final Setting<Boolean> preventMine = sgGeneral.add(new BoolSetting.Builder()
+        .name("prevent-mine")
+        .description("Prevents mining if the selected tool is low durability.")
+        .defaultValue(true)
+        .build()
+    );
+
+    private final Setting<Boolean> preventHit = sgGeneral.add(new BoolSetting.Builder()
+        .name("prevent-hit")
+        .description("Prevents hitting if the selected tool is low durability.")
+        .defaultValue(true)
+        .build()
+    );
+
+    public AntiBreak() {
+        super(Categories.Player, "anti-break", "Prevents you from using items which are about to break.");
+    }
+
+    public boolean canUse(ItemStack itemStack) {
+        return !itemStack.isDamageable() || itemStack.getMaxDamage() - itemStack.getDamage() >= itemStack.getMaxDamage() * breakDurability.get() / 100;
+    }
+
+    @EventHandler(priority = EventPriority.HIGH)
+    private void onStartBreakingBlock(StartBreakingBlockEvent event) {
+        if (!preventMine.get() || Modules.get().isActive(InfinityMiner.class)) return;
+
+        BlockState state = mc.world.getBlockState(event.blockPos);
+        if (state.getHardness(mc.world, event.blockPos) == 0) return; //breaks instantly
+        if (!BlockUtils.canBreak(event.blockPos, state)) return; //can't break
+
+        if (!canUse(mc.player.getMainHandStack())) {
+            mc.options.attackKey.setPressed(false);
+            event.cancel();
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGH)
+    private void onAttackEntity(AttackEntityEvent event) {
+        if (!preventHit.get() || !event.entity.isAttackable() || !(event.entity instanceof LivingEntity)) return;
+
+        if (!canUse(mc.player.getMainHandStack())) {
+            mc.options.attackKey.setPressed(false);
+            event.cancel();
+        }
+    }
+}

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoTool.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoTool.java
@@ -48,23 +48,6 @@ public class AutoTool extends Module {
         .build()
     );
 
-    private final Setting<Boolean> antiBreak = sgGeneral.add(new BoolSetting.Builder()
-        .name("anti-break")
-        .description("Stops you from breaking your tool.")
-        .defaultValue(false)
-        .build()
-    );
-
-    private final Setting<Integer> breakDurability = sgGeneral.add(new IntSetting.Builder()
-        .name("anti-break-percentage")
-        .description("The durability percentage to stop using a tool.")
-        .defaultValue(10)
-        .range(1, 100)
-        .sliderRange(1, 100)
-        .visible(antiBreak::get)
-        .build()
-    );
-
     private final Setting<Boolean> switchBack = sgGeneral.add(new BoolSetting.Builder()
         .name("switch-back")
         .description("Switches your hand to whatever was selected when releasing your attack key.")
@@ -147,14 +130,15 @@ public class AutoTool extends Module {
         double bestScore = -1;
         bestSlot = -1;
 
+        AntiBreak antiBreak = Modules.get().get(AntiBreak.class);
+
         for (int i = 0; i < 9; i++) {
             ItemStack itemStack = mc.player.getInventory().getStack(i);
 
             if (listMode.get() == ListMode.Whitelist && !whitelist.get().contains(itemStack.getItem())) continue;
             if (listMode.get() == ListMode.Blacklist && blacklist.get().contains(itemStack.getItem())) continue;
 
-            double score = getScore(itemStack, blockState, silkTouchForEnderChest.get(), prefer.get(), itemStack2 -> !shouldStopUsing(itemStack2));
-            if (score < 0) continue;
+            double score = getScore(itemStack, blockState, silkTouchForEnderChest.get(), prefer.get(), itemStack2 -> antiBreak.isActive() && antiBreak.canUse(itemStack2));
 
             if (score > bestScore) {
                 bestScore = score;
@@ -162,24 +146,12 @@ public class AutoTool extends Module {
             }
         }
 
-        if ((bestSlot != -1 && (bestScore > getScore(currentStack, blockState, silkTouchForEnderChest.get(), prefer.get(), itemStack -> !shouldStopUsing(itemStack))) || shouldStopUsing(currentStack) || !isTool(currentStack))) {
+        if ((bestSlot != -1 && bestSlot != mc.player.getInventory().selectedSlot || !isTool(currentStack))) {
             ticks = switchDelay.get();
 
             if (ticks == 0) InvUtils.swap(bestSlot, true);
             else shouldSwitch = true;
         }
-
-        // Anti break
-        currentStack = mc.player.getMainHandStack();
-
-        if (shouldStopUsing(currentStack) && isTool(currentStack)) {
-            mc.options.attackKey.setPressed(false);
-            event.cancel();
-        }
-    }
-
-    private boolean shouldStopUsing(ItemStack itemStack) {
-        return antiBreak.get() && (itemStack.getMaxDamage() - itemStack.getDamage()) < (itemStack.getMaxDamage() * breakDurability.get() / 100);
     }
 
     public static double getScore(ItemStack itemStack, BlockState state, boolean silkTouchEnderChest, EnchantPreference enchantPreference, Predicate<ItemStack> good) {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature

## Description

Splits AutoTool's Anti Break settings into its own module. This lets you prevent tool breakage without requiring AutoTool swapping being on (I personally dislike it).

Added features:
- Optionally prevent hitting
- Lets you break shrubs even with an almost broken tool

It also still works with AutoTool, it wont switch to an almost broken tool.

# How Has This Been Tested?

Thoroughly tested wahoo

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
