### PR TITLE
Fix fastuse when item is in offhand #3807

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/MinecraftClientAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MinecraftClientAccessor.java
@@ -36,12 +36,6 @@ public interface MinecraftClientAccessor {
     @Accessor("networkProxy")
     Proxy getProxy();
 
-    @Accessor("itemUseCooldown")
-    void setItemUseCooldown(int itemUseCooldown);
-
-    @Accessor("itemUseCooldown")
-    int getItemUseCooldown();
-
     @Accessor("resourceReloadLogger")
     ResourceReloadLogger getResourceReloadLogger();
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/MinecraftClientMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MinecraftClientMixin.java
@@ -124,7 +124,7 @@ public abstract class MinecraftClientMixin implements IMinecraftClient {
     @Inject(method = "doItemUse", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;isItemEnabled(Lnet/minecraft/resource/featuretoggle/FeatureSet;)Z"), locals = LocalCapture.CAPTURE_FAILHARD)
     private void onDoItemUseHand(CallbackInfo ci, Hand[] var1, int var2, int var3, Hand hand, ItemStack itemStack) {
         FastUse fastUse = Modules.get().get(FastUse.class);
-        if(fastUse.isActive()) {
+        if (fastUse.isActive()) {
             itemUseCooldown = fastUse.getItemUseCooldown(itemStack);
         }
     }

--- a/src/main/java/meteordevelopment/meteorclient/mixin/MinecraftClientMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MinecraftClientMixin.java
@@ -18,6 +18,7 @@ import meteordevelopment.meteorclient.gui.WidgetScreen;
 import meteordevelopment.meteorclient.mixininterface.IMinecraftClient;
 import meteordevelopment.meteorclient.systems.config.Config;
 import meteordevelopment.meteorclient.systems.modules.Modules;
+import meteordevelopment.meteorclient.systems.modules.player.FastUse;
 import meteordevelopment.meteorclient.systems.modules.render.UnfocusedCPU;
 import meteordevelopment.meteorclient.utils.Utils;
 import meteordevelopment.meteorclient.utils.misc.MeteorStarscript;
@@ -30,6 +31,8 @@ import net.minecraft.client.network.ClientPlayerInteractionManager;
 import net.minecraft.client.option.GameOptions;
 import net.minecraft.client.util.Window;
 import net.minecraft.client.world.ClientWorld;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Hand;
 import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.profiler.Profiler;
 import org.jetbrains.annotations.Nullable;
@@ -42,6 +45,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -65,6 +69,9 @@ public abstract class MinecraftClientMixin implements IMinecraftClient {
     @Shadow
     @Nullable
     public ClientPlayerInteractionManager interactionManager;
+
+    @Shadow
+    private int itemUseCooldown;
 
     @Inject(method = "<init>", at = @At("TAIL"))
     private void onInit(CallbackInfo info) {
@@ -112,6 +119,14 @@ public abstract class MinecraftClientMixin implements IMinecraftClient {
         MeteorClient.EVENT_BUS.post(event);
 
         if (event.isCancelled()) info.cancel();
+    }
+
+    @Inject(method = "doItemUse", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;isItemEnabled(Lnet/minecraft/resource/featuretoggle/FeatureSet;)Z"), locals = LocalCapture.CAPTURE_FAILHARD)
+    private void onDoItemUseHand(CallbackInfo ci, Hand[] var1, int var2, int var3, Hand hand, ItemStack itemStack) {
+        FastUse fastUse = Modules.get().get(FastUse.class);
+        if(fastUse.isActive()) {
+            itemUseCooldown = fastUse.getItemUseCooldown(itemStack);
+        }
     }
 
     @ModifyExpressionValue(method = "doItemUse", at = @At(value = "FIELD", target = "Lnet/minecraft/client/MinecraftClient;crosshairTarget:Lnet/minecraft/util/hit/HitResult;", ordinal = 1))

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/FastUse.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/FastUse.java
@@ -5,12 +5,9 @@
 
 package meteordevelopment.meteorclient.systems.modules.player;
 
-import meteordevelopment.meteorclient.events.world.TickEvent;
-import meteordevelopment.meteorclient.mixin.MinecraftClientAccessor;
 import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
-import meteordevelopment.orbit.EventHandler;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -60,15 +57,11 @@ public class FastUse extends Module {
         super(Categories.Player, "fast-use", "Allows you to use items at very high speeds.");
     }
 
-    @EventHandler
-    private void onTick(TickEvent.Post event) {
-        int cooldownTicks = Math.min(((MinecraftClientAccessor) mc).getItemUseCooldown(), cooldown.get());
-        if (mode.get() == Mode.All || shouldWorkSome()) ((MinecraftClientAccessor) mc).setItemUseCooldown(cooldownTicks);
-    }
-
-    private boolean shouldWorkSome() {
-        if (shouldWorkSome(mc.player.getMainHandStack())) return true;
-        return shouldWorkSome(mc.player.getOffHandStack());
+    public int getItemUseCooldown(ItemStack itemStack) {
+        if (mode.get() == Mode.All || shouldWorkSome(itemStack)) {
+            return cooldown.get();
+        }
+        return 4; //default cooldown
     }
 
     private boolean shouldWorkSome(ItemStack itemStack) {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Fastuse in the some mode previously applied to the main hand when the item was held in the offhand.

1. Select the "some" mode in FastUse
2. Add an Item like Snowballs to the whitelist
3. Turn on FastUse
4. Put snowballs in your offhand and something else in your main hand
5. FastUse is applied to the item in your mainhand

## Related issues

closes #3807 

# How Has This Been Tested?

Only in dev

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [ ] I have tested the code in both development and production environments.
