### PR TITLE
Add speed limit to auto-jump in Elytra recast mode

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFly.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFly.java
@@ -202,6 +202,16 @@ public class ElytraFly extends Module {
         .build()
     );
 
+    public final Setting<Double> autoJumpSpeedLimit = sgGeneral.add(new DoubleSetting.Builder()
+        .name("auto-jump-speed-limit")
+        .description("Only automatically jumps when below a certain speed.")
+        .defaultValue(27)
+        .min(0)
+        .sliderMax(50)
+        .visible(() -> flightMode.get() == ElytraFlightModes.Recast && autoJump.get())
+        .build()
+    );
+
     public final Setting<Double> pitch = sgGeneral.add(new DoubleSetting.Builder()
         .name("pitch")
         .description("The pitch angle to look at when using the recast mode.")

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/modes/Recast.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/modes/Recast.java
@@ -13,6 +13,7 @@ import meteordevelopment.meteorclient.events.packets.PacketEvent;
 import meteordevelopment.meteorclient.systems.modules.movement.elytrafly.ElytraFlightMode;
 import meteordevelopment.meteorclient.systems.modules.movement.elytrafly.ElytraFlightModes;
 import meteordevelopment.meteorclient.systems.modules.movement.elytrafly.ElytraFly;
+import meteordevelopment.meteorclient.utils.Utils;
 import meteordevelopment.meteorclient.utils.misc.input.Input;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.option.KeyBinding;
@@ -43,7 +44,15 @@ public class Recast extends ElytraFlightMode {
 
             mc.player.setSprinting(true);
             setPressed(mc.options.forwardKey, true);
-            if (elytraFly.autoJump.get()) setPressed(mc.options.jumpKey, true);
+            if (elytraFly.autoJump.get()) {
+                // If we're constantly jumping, we're also constantly accelerating
+                // and too high of a speed is a problem
+                if (Utils.getPlayerSpeed().horizontalLength() < elytraFly.autoJumpSpeedLimit.get()) {
+                    setPressed(mc.options.jumpKey, true);
+                } else {
+                    setPressed(mc.options.jumpKey, false);
+                }
+            }
             mc.player.setYaw(getSmartYawDirection());
             mc.player.setPitch(elytraFly.pitch.get().floatValue());
 


### PR DESCRIPTION
## Type of change

- [x] New feature

## Description

Adds a limit in ElytraFly recast to only auto-jump when below this limit. This allows the user to limit the maximum speed they travel using ElytraFly recast mode. Traveling at too high of speeds can cause the player to stop and lose all momentum, greatly slowing travel.

## Related issues

I do not believe there are any issues relating to this currently.

# How Has This Been Tested?

https://cdn.discordapp.com/attachments/1117615804238798978/1146876163776594021/javaw_1693506900.mp4
(Uploaded to external source due to large video size)

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
