### PR TITLE
Fix Issue #4040, mark PacketFixer as incompatible

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -55,6 +55,7 @@
     "feather": "*",
     "origins": "*",
     "wurst": "*",
-    "sodium": "<0.5.0"
+    "sodium": "<0.5.0",
+    "packetfixer": "*"
   }
 }


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description
This pull request marks [PacketFixer](https://github.com/TonimatasDEV/PacketFixer) as incompatible with Meteor, preventing client crashes due to mod conflicts when `AntiPacketKick` module is enabled.

## Related issues
#4040 - `Crash on 1.20.1 with Mod`

# How Has This Been Tested?
Building Meteor before this change and running alongside PacketFixer resulted in [this crash](https://mclo.gs/0Uinwy9) 

After applying this change and running alongside PacketFixer, the player is instead [warned about the mod conflict](https://mclo.gs/m4qIzKu) when the client starts.

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
