### PR TITLE
Shutdown command

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/commands/Commands.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/Commands.java
@@ -61,6 +61,7 @@ public class Commands {
         add(new RotationCommand());
         add(new WaypointCommand());
         add(new InputCommand());
+        add(new ShutDownCommand());
 
         COMMANDS.sort(Comparator.comparing(Command::getName));
     }

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/ShutDownCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/ShutDownCommand.java
@@ -7,7 +7,9 @@ package meteordevelopment.meteorclient.commands.commands;
 
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
+import net.minecraft.client.gui.screen.MessageScreen;
 import net.minecraft.command.CommandSource;
+import net.minecraft.text.Text;
 
 import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
 import static meteordevelopment.meteorclient.MeteorClient.mc;
@@ -21,9 +23,27 @@ public class ShutDownCommand extends Command {
     public void build(LiteralArgumentBuilder<CommandSource> builder) {
         builder.executes(context -> {
             info("Shutting down...");
+            this.disconnect();
+
             mc.stop();
 
             return SINGLE_SUCCESS;
         });
+    }
+
+    /**
+     * Repurposed from GameMenuScreen
+     */
+    private void disconnect() {
+        boolean isSp = mc.isInSingleplayer();
+
+        if (mc.world != null) mc.world.disconnect();
+
+        // Handle network
+        if (isSp) {
+            mc.disconnect(new MessageScreen(Text.translatable("menu.savingLevel")));
+        } else {
+            mc.disconnect();
+        }
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/ShutDownCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/ShutDownCommand.java
@@ -5,24 +5,16 @@
 
 package meteordevelopment.meteorclient.commands.commands;
 
-import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
-import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import meteordevelopment.meteorclient.commands.Command;
-import meteordevelopment.meteorclient.systems.modules.Modules;
-import meteordevelopment.meteorclient.systems.modules.movement.NoFall;
-import meteordevelopment.meteorclient.systems.modules.player.AntiHunger;
 import net.minecraft.command.CommandSource;
-import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket;
-import net.minecraft.text.Text;
-import net.minecraft.util.math.Vec3d;
 
 import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
 import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class ShutDownCommand extends Command {
     public ShutDownCommand() {
-        super("shutdown", "Closes the client", "shut");
+        super("shutdown", "Closes the client.", "shut");
     }
 
     @Override

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/ShutDownCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/ShutDownCommand.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.commands.commands;
+
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
+import meteordevelopment.meteorclient.commands.Command;
+import meteordevelopment.meteorclient.systems.modules.Modules;
+import meteordevelopment.meteorclient.systems.modules.movement.NoFall;
+import meteordevelopment.meteorclient.systems.modules.player.AntiHunger;
+import net.minecraft.command.CommandSource;
+import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket;
+import net.minecraft.text.Text;
+import net.minecraft.util.math.Vec3d;
+
+import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
+import static meteordevelopment.meteorclient.MeteorClient.mc;
+
+public class ShutDownCommand extends Command {
+    public ShutDownCommand() {
+        super("shutdown", "Closes the client", "shut");
+    }
+
+    @Override
+    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+        builder.executes(context -> {
+            info("Shutting down...");
+            mc.stop();
+
+            return SINGLE_SUCCESS;
+        });
+    }
+}


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

A simple command that shuts down the Minecraft client using vanilla's own function.

## Related issues

Works fine, only one tiny thing is that the info message doesn't get displayed on time but whatever.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
