### PR TITLE
Fix ChatUtils formatting in log files

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/utils/player/ChatUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/ChatUtils.java
@@ -122,14 +122,12 @@ public class ChatUtils {
     }
 
     public static void sendMsg(int id, @Nullable String prefixTitle, @Nullable Formatting prefixColor, Formatting messageColor, String messageContent, Object... args) {
-        MutableText message = formatMsg(messageContent, messageColor, args);
-        message.formatted(messageColor);
+        MutableText message = formatMsg(String.format(messageContent, args), messageColor);
         sendMsg(id, prefixTitle, prefixColor, message);
     }
 
     public static void sendMsg(int id, @Nullable String prefixTitle, @Nullable Formatting prefixColor, String messageContent, Formatting messageColor) {
-        MutableText message = Text.literal(messageContent);
-        message.formatted(messageColor);
+        MutableText message = formatMsg(messageContent, messageColor);
         sendMsg(id, prefixTitle, prefixColor, message);
     }
 
@@ -199,8 +197,8 @@ public class ChatUtils {
         return PREFIX;
     }
 
-    private static MutableText formatMsg(String format, Formatting defaultColor, Object... args) {
-        StringReader reader = new StringReader(String.format(format, args));
+    private static MutableText formatMsg(String message, Formatting defaultColor) {
+        StringReader reader = new StringReader(message);
         MutableText text = Text.empty();
         Style style = Style.EMPTY.withFormatting(defaultColor);
         StringBuilder result = new StringBuilder();

--- a/src/main/java/meteordevelopment/meteorclient/utils/player/ChatUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/ChatUtils.java
@@ -31,7 +31,7 @@ public class ChatUtils {
 
     @PostInit
     public static void init() {
-        PREFIX = Text.literal("")
+        PREFIX = Text.empty()
             .setStyle(Style.EMPTY.withFormatting(Formatting.GRAY))
             .append("[")
             .append(Text.literal("Meteor").setStyle(Style.EMPTY.withColor(TextColor.fromRgb(MeteorClient.ADDON.color.getPacked()))))
@@ -134,7 +134,7 @@ public class ChatUtils {
     public static void sendMsg(int id, @Nullable String prefixTitle, @Nullable Formatting prefixColor, Text msg) {
         if (mc.world == null) return;
 
-        MutableText message = Text.literal("");
+        MutableText message = Text.empty();
         message.append(getPrefix());
         if (prefixTitle != null) message.append(getCustomPrefix(prefixTitle, prefixColor));
         message.append(msg);
@@ -145,7 +145,7 @@ public class ChatUtils {
     }
 
     private static MutableText getCustomPrefix(String prefixTitle, Formatting prefixColor) {
-        MutableText prefix = Text.literal("");
+        MutableText prefix = Text.empty();
         prefix.setStyle(prefix.getStyle().withFormatting(Formatting.GRAY));
 
         prefix.append("[");


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

Format `ChatUtils` messages into `Text` instead of using formatting codes.

With test input `.server plugins BukkitVer`:
Before
![image](https://github.com/MeteorDevelopment/meteor-client/assets/32882447/2e6219f7-4184-424b-b11e-3c18d3eb16a8)
After
![image](https://github.com/MeteorDevelopment/meteor-client/assets/32882447/e22d295c-431c-4290-897d-3fa4ed716191)

# How Has This Been Tested?

![image](https://github.com/MeteorDevelopment/meteor-client/assets/32882447/466d5207-c25d-4316-8756-4993f3f00cb3)

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
