### PR TITLE
Add null check to runObject

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/screens/AddHudElementScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/screens/AddHudElementScreen.java
@@ -104,6 +104,7 @@ public class AddHudElementScreen extends WindowScreen {
     }
 
     private void runObject(Object object) {
+        if (object == null) return;
         if (object instanceof HudElementInfo.Preset preset) {
             Hud.get().add(preset, x, y);
             close();


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Fixes Minecraft crashing when pressing ENTER in the search box of HUD elements when there are no results

## Related issues

#4073 

# How Has This Been Tested?

No

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
