### PR TITLE
Added Tab Height adjustment

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/PlayerListHudMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/PlayerListHudMixin.java
@@ -42,6 +42,12 @@ public class PlayerListHudMixin {
         return module.isActive() && module.accurateLatency.get() ? width + 30 : width;
     }
 
+    @ModifyConstant(constant = {@Constant(intValue = 20)},method = {"render"})
+    private int modifyHeight(int height) {
+        BetterTab module = (BetterTab)Modules.get().get(BetterTab.class);
+        return module.isActive() ? (Integer)module.tabHeight.get() : height;
+    }
+
     @Inject(method = "renderLatencyIcon", at = @At("HEAD"), cancellable = true)
     private void onRenderLatencyIcon(DrawContext context, int width, int x, int y, PlayerListEntry entry, CallbackInfo ci) {
         BetterTab betterTab = Modules.get().get(BetterTab.class);

--- a/src/main/java/meteordevelopment/meteorclient/mixin/PlayerListHudMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/PlayerListHudMixin.java
@@ -42,10 +42,10 @@ public class PlayerListHudMixin {
         return module.isActive() && module.accurateLatency.get() ? width + 30 : width;
     }
 
-    @ModifyConstant(constant = {@Constant(intValue = 20)},method = {"render"})
+    @ModifyConstant(constant = @Constant(intValue = 20), method = "render")
     private int modifyHeight(int height) {
-        BetterTab module = (BetterTab)Modules.get().get(BetterTab.class);
-        return module.isActive() ? (Integer)module.tabHeight.get() : height;
+        BetterTab module = Modules.get().get(BetterTab.class);
+        return module.isActive() ? module.tabHeight.get() : height;
     }
 
     @Inject(method = "renderLatencyIcon", at = @At("HEAD"), cancellable = true)

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterTab.java
@@ -26,7 +26,7 @@ public class BetterTab extends Module {
 
     public final Setting<Integer> tabSize = sgGeneral.add(new IntSetting.Builder()
         .name("tablist-size")
-        .description("How many players to display in the tablist.")
+        .description("How many players in total to display in the tablist.")
         .defaultValue(100)
         .min(1)
         .sliderRange(1, 1000)
@@ -34,9 +34,9 @@ public class BetterTab extends Module {
     );
 
     public final Setting<Integer> tabHeight = sgGeneral.add(new IntSetting.Builder()
-        .name("tablist-height")
-        .description("How many players to display vertically.")
-        .defaultValue(45)
+        .name("column-height")
+        .description("How many players to display in each column.")
+        .defaultValue(20)
         .min(1)
         .sliderRange(1, 1000)
         .build()

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterTab.java
@@ -33,6 +33,15 @@ public class BetterTab extends Module {
         .build()
     );
 
+    public final Setting<Integer> tabHeight = sgGeneral.add(new IntSetting.Builder()
+        .name("tablist-height")
+        .description("How many players to display vertically.")
+        .defaultValue(45)
+        .min(1)
+        .sliderRange(1, 1000)
+        .build()
+    );
+
     private final Setting<Boolean> self = sgGeneral.add(new BoolSetting.Builder()
         .name("highlight-self")
         .description("Highlights yourself in the tablist.")


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature

## Description

Added height adjustment for the TabList for servers with a lot of players since it just stretches to the sides

## Related issues

If player count is too high the current implementation just extends off screen if the player count is too high and this allows for more adjustment.

# How Has This Been Tested?

[My solution.](https://imgur.com/RRzWHcu)
[Current solution](https://imgur.com/nYj2GNE)

# Checklist:

- [X] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.

Comments aren't really applicable in this case since the change is relatively minor.
