### PR TITLE
Custom text renderer shadow fix

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/renderer/text/CustomTextRenderer.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/text/CustomTextRenderer.java
@@ -81,13 +81,13 @@ public class CustomTextRenderer implements TextRenderer {
         if (text.isEmpty()) return 0;
 
         Font font = building ? this.font : fonts[0];
-        return (font.getWidth(text, length) + (shadow ? fontScale : 0)) * scale;
+        return (font.getWidth(text, length) + (shadow ? 1 : 0)) * scale;
     }
 
     @Override
     public double getHeight(boolean shadow) {
         Font font = building ? this.font : fonts[0];
-        return (font.getHeight() + 1 + (shadow ? fontScale : 0)) * scale;
+        return (font.getHeight() + 1 + (shadow ? 1 : 0)) * scale;
     }
 
     @Override

--- a/src/main/java/meteordevelopment/meteorclient/renderer/text/CustomTextRenderer.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/text/CustomTextRenderer.java
@@ -26,6 +26,7 @@ public class CustomTextRenderer implements TextRenderer {
 
     private boolean building;
     private boolean scaleOnly;
+    private double fontScale = 1;
     private double scale = 1;
 
     public CustomTextRenderer(FontFace fontFace) {
@@ -71,7 +72,7 @@ public class CustomTextRenderer implements TextRenderer {
         this.building = true;
         this.scaleOnly = scaleOnly;
 
-        double fontScale = font.getHeight() / 18.0;
+        this.fontScale = font.getHeight() / 18.0;
         this.scale = 1 + (scale - fontScale) / fontScale;
     }
 
@@ -80,13 +81,13 @@ public class CustomTextRenderer implements TextRenderer {
         if (text.isEmpty()) return 0;
 
         Font font = building ? this.font : fonts[0];
-        return (font.getWidth(text, length) + (shadow ? 1 : 0)) * scale + (shadow ? 1 : 0);
+        return (font.getWidth(text, length) + (shadow ? fontScale : 0)) * scale;
     }
 
     @Override
     public double getHeight(boolean shadow) {
         Font font = building ? this.font : fonts[0];
-        return (font.getHeight() + 1 + (shadow ? 1 : 0)) * scale;
+        return (font.getHeight() + 1 + (shadow ? fontScale : 0)) * scale;
     }
 
     @Override
@@ -99,7 +100,7 @@ public class CustomTextRenderer implements TextRenderer {
             int preShadowA = SHADOW_COLOR.a;
             SHADOW_COLOR.a = (int) (color.a / 255.0 * preShadowA);
 
-            width = font.render(mesh, text, x + 1, y + 1, SHADOW_COLOR, scale);
+            width = font.render(mesh, text, x + fontScale * scale, y + fontScale * scale, SHADOW_COLOR, scale);
             font.render(mesh, text, x, y, color, scale);
 
             SHADOW_COLOR.a = preShadowA;


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

This pull request fixes 2 issues:
1. Inconsistent shadow offset when scaling text
2. Overcompensating shadow text size (Compare background box left margin size & right margin size)

![image](https://github.com/MeteorDevelopment/meteor-client/assets/32882447/1037293d-440a-4dab-9730-672d1b8535fa)

# How Has This Been Tested?

![2023-09-20_17 52 12](https://github.com/MeteorDevelopment/meteor-client/assets/32882447/6a2d61e5-e8b6-4807-9230-587a97c13844)

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
