### PR TITLE
Added item type filters to tracers & nametags

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Tracers.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Tracers.java
@@ -5,6 +5,8 @@
 
 package meteordevelopment.meteorclient.systems.modules.render;
 
+import java.util.HashSet;
+import java.util.List;
 import meteordevelopment.meteorclient.events.render.Render2DEvent;
 import meteordevelopment.meteorclient.events.render.Render3DEvent;
 import meteordevelopment.meteorclient.renderer.Renderer2D;
@@ -24,7 +26,10 @@ import meteordevelopment.meteorclient.utils.render.color.SettingColor;
 import meteordevelopment.orbit.EventHandler;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
+import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.Vec2f;
 import org.joml.Vector2f;
 import org.joml.Vector3d;
@@ -35,6 +40,7 @@ import java.util.Set;
 
 public class Tracers extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
+    private final SettingGroup sgItems = settings.createGroup("Items");
     private final SettingGroup sgAppearance = settings.createGroup("Appearance");
     private final SettingGroup sgColors = settings.createGroup("Colors");
 
@@ -70,6 +76,33 @@ public class Tracers extends Module {
         .name("show-invisible")
         .description("Shows invisible entities.")
         .defaultValue(true)
+        .build()
+    );
+
+    // items
+
+    private final Setting<ListMode> shownItemFilterType = sgItems.add(new EnumSetting.Builder<ListMode>()
+        .name("Shown mode")
+        .description("Shown item filter mode")
+        .defaultValue(ListMode.All)
+        .build()
+    );
+
+    private final Set<Integer> shownItemIds = new HashSet<>();
+    private final Setting<List<Item>> shownItems = sgItems.add(new ItemListSetting.Builder()
+        .name("shown-item-filter")
+        .description("Select items to draw tracers for.")
+        .defaultValue()
+        .onChanged(items -> {
+             shownItemIds.clear();
+             shownItemIds.addAll(items.stream().map(Item::getRawId).toList());
+        }).build()
+    );
+
+    private final Setting<Boolean> alwaysShowNamed = sgItems.add(new BoolSetting.Builder()
+        .name("show-named")
+        .description("Display for named items regardless of being included in list.")
+        .defaultValue(false)
         .build()
     );
 
@@ -217,8 +250,25 @@ public class Tracers extends Module {
         super(Categories.Render, "tracers", "Displays tracer lines to specified entities.");
     }
 
+    private boolean shouldBeIgnored(ItemStack stack) {
+        boolean showCustomNamed = stack.hasCustomName() && alwaysShowNamed.get();
+
+        boolean showInList = shownItemFilterType.get() == ListMode.All
+            || (shownItemFilterType.get() == ListMode.Whitelist && shownItemIds.contains(Item.getRawId(stack.getItem())))
+            || (shownItemFilterType.get() == ListMode.Blacklist && !shownItemIds.contains(Item.getRawId(stack.getItem())));
+
+        return !showCustomNamed && !showInList;
+    }
+
     private boolean shouldBeIgnored(Entity entity) {
-        return !PlayerUtils.isWithin(entity, maxDist.get()) || (!Modules.get().isActive(Freecam.class) && entity == mc.player) || !entities.get().contains(entity.getType()) || (ignoreSelf.get() && entity == mc.player) || (ignoreFriends.get() && entity instanceof PlayerEntity && Friends.get().isFriend((PlayerEntity) entity)) || (!showInvis.get() && entity.isInvisible()) | !EntityUtils.isInRenderDistance(entity);
+        return !PlayerUtils.isWithin(entity, maxDist.get())
+            || (!Modules.get().isActive(Freecam.class) && entity == mc.player)
+            || !entities.get().contains(entity.getType())
+            || (ignoreSelf.get() && entity == mc.player)
+            || (ignoreFriends.get() && entity instanceof PlayerEntity && Friends.get().isFriend((PlayerEntity) entity))
+            || (!showInvis.get() && entity.isInvisible())
+            || !EntityUtils.isInRenderDistance(entity)
+            || (entity instanceof ItemEntity && shouldBeIgnored(((ItemEntity) entity).getStack()));
     }
 
     private Color getEntityColor(Entity entity) {
@@ -371,5 +421,12 @@ public class Tracers extends Module {
     @Override
     public String getInfoString() {
         return Integer.toString(count);
+    }
+
+    public enum ListMode {
+        Whitelist,
+        Blacklist,
+        None,
+        All
     }
 }


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description
Added options to filter specific items when the Item entity is included in Nametags/Tracers modules. Useful if you want item nametags without cluttering the screen with useless items (e.g. netherrack), or if you're looking for specific dropped items. Additional option to always highlight named items.

Code is nearly the same between the two modules, not sure if thats an issue

## Related issues

None as far as I know

# How Has This Been Tested?

![image](https://github.com/MeteorDevelopment/meteor-client/assets/120606980/5adf1851-561a-46a6-9dd8-db142ed5cb56)
![image](https://github.com/MeteorDevelopment/meteor-client/assets/120606980/4c57d3a8-8801-466c-872b-fc32b070b0e8)
![image](https://github.com/MeteorDevelopment/meteor-client/assets/120606980/9f19bd6c-2246-4dbf-b36d-b83a27d0cc61)


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
