### PR TITLE
mark Quilt versions below 0.23.0 as incompatible

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -54,6 +54,7 @@
     "origins": "*",
     "wurst": "*",
     "sodium": "<0.5.6",
-    "morechathistory": "*"
+    "morechathistory": "*",
+    "quilt_loader": "<0.23.0"
   }
 }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

This pull request marks Quilt versions under 0.23.0 as incompatible with Meteor. Meteor crashes on startup when using Quilt 0.22.0 and below, with this change, Quilt users that haven't updated will know what's wrong.
# How Has This Been Tested?

Tested using quilt 0.20.2+ on 1.20.4

# Checklist:
- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
