### PR TITLE
PotionSpoof crash fix

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/StatusEffectAmplifierMapSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/StatusEffectAmplifierMapSettingScreen.java
@@ -14,6 +14,8 @@ import meteordevelopment.meteorclient.gui.widgets.input.WTextBox;
 import meteordevelopment.meteorclient.settings.Setting;
 import meteordevelopment.meteorclient.utils.misc.Names;
 import net.minecraft.entity.effect.StatusEffect;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
@@ -25,7 +27,6 @@ public class StatusEffectAmplifierMapSettingScreen extends WindowScreen {
 
     private WTable table;
 
-    private WTextBox filter;
     private String filterText = "";
 
     public StatusEffectAmplifierMapSettingScreen(GuiTheme theme, Setting<Object2IntMap<StatusEffect>> setting) {
@@ -36,7 +37,7 @@ public class StatusEffectAmplifierMapSettingScreen extends WindowScreen {
 
     @Override
     public void initWidgets() {
-        filter = add(theme.textBox("")).minWidth(400).expandX().widget();
+        WTextBox filter = add(theme.textBox("")).minWidth(400).expandX().widget();
         filter.setFocused(true);
         filter.action = () -> {
             filterText = filter.get().trim();
@@ -46,6 +47,7 @@ public class StatusEffectAmplifierMapSettingScreen extends WindowScreen {
         };
 
         table = add(theme.table()).expandX().widget();
+
         initTable();
     }
 
@@ -57,7 +59,7 @@ public class StatusEffectAmplifierMapSettingScreen extends WindowScreen {
             String name = Names.get(statusEffect);
             if (!StringUtils.containsIgnoreCase(name, filterText)) continue;
 
-            table.add(theme.label(name)).expandCellX();
+            table.add(theme.itemWithLabel(getPotionStack(statusEffect), name)).expandCellX();
 
             WIntEdit level = theme.intEdit(setting.get().getInt(statusEffect), 0, Integer.MAX_VALUE, true);
             level.action = () -> {
@@ -68,5 +70,11 @@ public class StatusEffectAmplifierMapSettingScreen extends WindowScreen {
             table.add(level).minWidth(50);
             table.row();
         }
+    }
+
+    private ItemStack getPotionStack(StatusEffect effect) {
+        ItemStack potion = Items.POTION.getDefaultStack();
+        potion.getOrCreateNbt().putInt("CustomPotionColor", effect.getColor());
+        return potion;
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/StatusEffectListSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/StatusEffectListSettingScreen.java
@@ -10,11 +10,8 @@ import meteordevelopment.meteorclient.gui.widgets.WWidget;
 import meteordevelopment.meteorclient.settings.Setting;
 import meteordevelopment.meteorclient.utils.misc.Names;
 import net.minecraft.entity.effect.StatusEffect;
-import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
-import net.minecraft.potion.Potion;
-import net.minecraft.potion.PotionUtil;
 import net.minecraft.registry.Registries;
 
 import java.util.List;
@@ -36,7 +33,7 @@ public class StatusEffectListSettingScreen extends LeftRightListSettingScreen<St
 
     private ItemStack getPotionStack(StatusEffect effect) {
         ItemStack potion = Items.POTION.getDefaultStack();
-        potion.getOrCreateNbt().putInt("CustomPotionColor", PotionUtil.getColor(new Potion(new StatusEffectInstance(effect))));
+        potion.getOrCreateNbt().putInt("CustomPotionColor", effect.getColor());
         return potion;
     }
 }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Fix crash, add icons to spoofed potions screen.

## Related issues

Closes [#4126](https://github.com/MeteorDevelopment/meteor-client/issues/4126)

# How Has This Been Tested?

Tested in game.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
