### PR TITLE
fix .server info command

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/ServerCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/ServerCommand.java
@@ -194,7 +194,7 @@ public class ServerCommand extends Command {
 
         info("Port: %d", ServerAddress.parse(server.address).getPort());
 
-        info("Type: %s", mc.player.getServer().getSaveProperties().getServerBrands() != null ? mc.player.getServer().getSaveProperties().getServerBrands() : "unknown");
+        info("Type: %s", mc.getNetworkHandler().getBrand() != null ? mc.getNetworkHandler().getBrand() : "unknown");
 
         info("Motd: %s", server.label != null ? server.label.getString() : "unknown");
 


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

`mc.player.getServer()` now always returns `null` since 1.20.2

## Related issues

#4130 

# How Has This Been Tested?

yeap

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
