### PR TITLE
Reconfiguration phase disables modules.

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayNetworkHandlerMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayNetworkHandlerMixin.java
@@ -52,6 +52,7 @@ public abstract class ClientPlayNetworkHandlerMixin extends ClientCommonNetworkH
     @Unique
     private boolean ignoreChatMessage;
 
+    @Unique
     private boolean worldNotNull;
 
     protected ClientPlayNetworkHandlerMixin(MinecraftClient client, ClientConnection connection, ClientConnectionState connectionState) {
@@ -79,6 +80,12 @@ public abstract class ClientPlayNetworkHandlerMixin extends ClientCommonNetworkH
         }
 
         MeteorClient.EVENT_BUS.post(GameJoinedEvent.get());
+    }
+
+    // the server sends a GameJoin packet after the reconfiguration phase
+    @Inject(method = "onEnterReconfiguration", at = @At("HEAD"))
+    private void onEnterReconfiguration(EnterReconfigurationS2CPacket packet, CallbackInfo info) {
+        MeteorClient.EVENT_BUS.post(GameLeftEvent.get());
     }
 
     @Inject(method = "onPlaySound", at = @At("HEAD"))


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

The reconfiguration phase was added in 1.20.2 to let servers update stuff like registries without the client needing to reconnect.
The world and player are null during this phase which caused modules to crash.

## Related issues

closes #4135 
closes #4132 
possibly the crash in #4128 
closes #4127 

# How Has This Been Tested?

join og-network.net and switch worlds. The server sends the client to the configuration phase during this.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
