### PR TITLE
Fix Meteor logo when using BetterChat with Player Heads and Timestamps

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterChat.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterChat.java
@@ -394,7 +394,8 @@ public class BetterChat extends Module {
         int startOffset = 0;
 
         try {
-            startOffset = TIMESTAMP_REGEX.matcher(text).end();
+            Matcher m = TIMESTAMP_REGEX.matcher(text);
+            if (m.find()) startOffset = m.end() + 1;
         }
         catch (IllegalStateException ignored) {}
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Fixes the meteor logo not showing when using Better Chat with Playerheads + Timestamps

## Related issues

None

# How Has This Been Tested?

Before
<img width="987" alt="image" src="https://github.com/MeteorDevelopment/meteor-client/assets/73178245/4b9d0bc5-951c-4afa-9193-5ca95a2931d2">

After
<img width="984" alt="image" src="https://github.com/MeteorDevelopment/meteor-client/assets/73178245/f83b2668-137e-4244-992b-8b05ff9a2b29">


# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
