### PR TITLE
Chat fix

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterChat.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterChat.java
@@ -147,8 +147,8 @@ public class BetterChat extends Module {
         .name("extra-lines")
         .description("The amount of extra chat lines.")
         .defaultValue(1000)
-        .min(100)
-        .sliderRange(100, 1000)
+        .min(0)
+        .sliderRange(0, 1000)
         .visible(longerChatHistory::get)
         .build()
     );
@@ -541,7 +541,7 @@ public class BetterChat extends Module {
 
     public boolean keepHistory() { return isActive() && keepHistory.get(); }
 
-    public int getChatLength() {
+    public int getExtraChatLines() {
         return longerChatLines.get();
     }
 }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Made code more concise by using modify constant.
Fixed a bug in longer-chat-history that deleted lines in the middle of the history instead of the oldest messages

## Related issues

maybe #4179 but that would require further investigation

# How Has This Been Tested?

enable better chat and minimize the longer chat history slider.
enable spam to fill the chat.
messages in the middle of the history will be deleted

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
