### PR TITLE
catch corrupted files

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/System.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/System.java
@@ -10,9 +10,12 @@ import meteordevelopment.meteorclient.utils.files.StreamUtils;
 import meteordevelopment.meteorclient.utils.misc.ISerializable;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtIo;
+import net.minecraft.util.crash.CrashException;
+import org.apache.commons.io.FilenameUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.LocalDate;
 
 public abstract class System<T> implements ISerializable<T> {
     private final String name;
@@ -64,7 +67,16 @@ public abstract class System<T> implements ISerializable<T> {
             if (folder != null) file = new File(folder, file.getName());
 
             if (file.exists()) {
-                fromTag(NbtIo.read(file));
+                try {
+                    fromTag(NbtIo.read(file));
+                } catch (CrashException e) {
+                    String backupName = FilenameUtils.removeExtension(file.getName()) + "-" + LocalDate.now() + ".backup.nbt";
+                    File backup = new File(file.getParentFile(), backupName);
+                    StreamUtils.copy(file, backup);
+                    MeteorClient.LOG.error("Error loading " + this.name + ". Possibly corrupted?");
+                    MeteorClient.LOG.info("Saved settings backup to '" + backup + "'.");
+                    e.printStackTrace();
+                }
             }
         } catch (IOException e) {
             e.printStackTrace();


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

Here's a fun fact! Did you know the `NbtIo.read()` javadoc is wrong?
![image](https://github.com/MeteorDevelopment/meteor-client/assets/32882447/3be009a9-b9b4-4367-aaa7-42431b661f7e)
Yep! They actually catch `IOException`'s and rethrow them as `CrashException`'s, which are *not* a subclass of `IOException` and *not* stated in the javadoc.
Anyways this PR catches those and prevents it from crashing the game, as well as creating a backup before overwriting the erroring settings.
Note: I kept the `IOException` catch and explicitly didn't make it create a backup, as that would indicate something might be wrong with the backup process, or IO operations. It will still allow the game to run, it will just overwrite the settings.

# How Has This Been Tested?

![image](https://github.com/MeteorDevelopment/meteor-client/assets/32882447/80fc3200-5a34-4ea5-9bfc-f753622cee95)

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
