### PR TITLE
fix small hud details

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CombatHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CombatHud.java
@@ -57,6 +57,7 @@ public class CombatHud extends HudElement {
         .defaultValue(2)
         .min(1)
         .sliderRange(1, 5)
+        .onChanged(this::onResize)
         .build()
     );
 
@@ -179,9 +180,8 @@ public class CombatHud extends HudElement {
         super(INFO);
     }
 
-    @Override
-    public void tick(HudRenderer renderer) {
-        setSize(175 * scale.get(), 95 * scale.get());
+    private void onResize(double newScale) {
+        setSize(175 * newScale, 95 * newScale);
     }
 
     @Override

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CombatHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CombatHud.java
@@ -202,15 +202,16 @@ public class CombatHud extends HudElement {
             // Background
             Renderer2D.COLOR.begin();
             Renderer2D.COLOR.quad(x, y, getWidth(), getHeight(), backgroundColor.get());
-            Renderer2D.COLOR.render(null);
 
             if (playerEntity == null) {
                 if (isInEditor()) {
                     renderer.line(x, y, x + getWidth(), y + getHeight(), Color.GRAY);
                     renderer.line(x + getWidth(), y, x, y + getHeight(), Color.GRAY);
+                    Renderer2D.COLOR.render(null); // i know, ill fix it soon
                 }
                 return;
             }
+            Renderer2D.COLOR.render(null);
 
             // Player Model
             InventoryScreen.drawEntity(

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CombatHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CombatHud.java
@@ -57,7 +57,7 @@ public class CombatHud extends HudElement {
         .defaultValue(2)
         .min(1)
         .sliderRange(1, 5)
-        .onChanged(this::onResize)
+        .onChanged(aDouble -> calculateSize())
         .build()
     );
 
@@ -178,10 +178,12 @@ public class CombatHud extends HudElement {
 
     public CombatHud() {
         super(INFO);
+
+        calculateSize();
     }
 
-    private void onResize(double newScale) {
-        setSize(175 * newScale, 95 * newScale);
+    private void calculateSize() {
+        setSize(175 * scale.get(), 95 * scale.get());
     }
 
     @Override

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CombatHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CombatHud.java
@@ -204,7 +204,13 @@ public class CombatHud extends HudElement {
             Renderer2D.COLOR.quad(x, y, getWidth(), getHeight(), backgroundColor.get());
             Renderer2D.COLOR.render(null);
 
-            if (playerEntity == null) return;
+            if (playerEntity == null) {
+                if (isInEditor()) {
+                    renderer.line(x, y, x + getWidth(), y + getHeight(), Color.GRAY);
+                    renderer.line(x + getWidth(), y, x, y + getHeight(), Color.GRAY);
+                }
+                return;
+            }
 
             // Player Model
             InventoryScreen.drawEntity(

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/InventoryHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/InventoryHud.java
@@ -42,6 +42,7 @@ public class InventoryHud extends HudElement {
         .defaultValue(2)
         .min(1)
         .sliderRange(1, 5)
+        .onChanged(aDouble -> calculateSize())
         .build()
     );
 
@@ -49,6 +50,7 @@ public class InventoryHud extends HudElement {
         .name("background")
         .description("Background of inventory viewer.")
         .defaultValue(Background.Texture)
+            .onChanged(bg -> calculateSize())
         .build()
     );
 
@@ -64,12 +66,12 @@ public class InventoryHud extends HudElement {
 
     private InventoryHud() {
         super(INFO);
+
+        calculateSize();
     }
 
     @Override
     public void render(HudRenderer renderer) {
-        setSize(background.get().width * scale.get(), background.get().height * scale.get());
-
         double x = this.x, y = this.y;
 
         ItemStack container = getContainer();
@@ -97,6 +99,10 @@ public class InventoryHud extends HudElement {
                 }
             }
         });
+    }
+
+    private void calculateSize() {
+        setSize(background.get().width * scale.get(), background.get().height * scale.get());
     }
 
     private void drawBackground(HudRenderer renderer, int x, int y, Color color) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/InventoryHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/InventoryHud.java
@@ -50,7 +50,7 @@ public class InventoryHud extends HudElement {
         .name("background")
         .description("Background of inventory viewer.")
         .defaultValue(Background.Texture)
-            .onChanged(bg -> calculateSize())
+        .onChanged(bg -> calculateSize())
         .build()
     );
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PlayerModelHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PlayerModelHud.java
@@ -10,6 +10,7 @@ import meteordevelopment.meteorclient.systems.hud.Hud;
 import meteordevelopment.meteorclient.systems.hud.HudElement;
 import meteordevelopment.meteorclient.systems.hud.HudElementInfo;
 import meteordevelopment.meteorclient.systems.hud.HudRenderer;
+import meteordevelopment.meteorclient.utils.render.color.Color;
 import meteordevelopment.meteorclient.utils.render.color.SettingColor;
 import net.minecraft.client.gui.screen.ingame.InventoryScreen;
 import net.minecraft.entity.player.PlayerEntity;
@@ -101,8 +102,12 @@ public class PlayerModelHud extends HudElement {
             InventoryScreen.drawEntity(renderer.drawContext, x, y, (int) (x + (25 * scale.get())), (int) (y + (66 * scale.get())), (int) (30 * scale.get()), 0, -yaw, -pitch, player);
         });
 
-        if (background.get() || mc.player == null) {
+        if (background.get()) {
             renderer.quad(x, y, getWidth(), getHeight(), backgroundColor.get());
+        } else if (mc.player == null) {
+            renderer.quad(x, y, getWidth(), getHeight(), backgroundColor.get());
+            renderer.line(x, y, x + getWidth(), y + getHeight(), Color.GRAY);
+            renderer.line(x + getWidth(), y, x, y + getHeight(), Color.GRAY);
         }
     }
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PlayerModelHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PlayerModelHud.java
@@ -30,6 +30,7 @@ public class PlayerModelHud extends HudElement {
         .defaultValue(2)
         .min(1)
         .sliderRange(1, 5)
+        .onChanged(this::onResize)
         .build()
     );
 
@@ -90,8 +91,6 @@ public class PlayerModelHud extends HudElement {
 
     @Override
     public void render(HudRenderer renderer) {
-        setSize(50 * scale.get(), 75 * scale.get());
-
         renderer.post(() -> {
             PlayerEntity player = mc.player;
             if (player == null) return;
@@ -102,8 +101,12 @@ public class PlayerModelHud extends HudElement {
             InventoryScreen.drawEntity(renderer.drawContext, x, y, (int) (x + (25 * scale.get())), (int) (y + (66 * scale.get())), (int) (30 * scale.get()), 0, -yaw, -pitch, player);
         });
 
-        if (background.get()) {
+        if (background.get() || mc.player == null) {
             renderer.quad(x, y, getWidth(), getHeight(), backgroundColor.get());
         }
+    }
+
+    private void onResize(double newScale) {
+        setSize(50 * newScale, 75 * newScale);
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PlayerModelHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PlayerModelHud.java
@@ -31,7 +31,7 @@ public class PlayerModelHud extends HudElement {
         .defaultValue(2)
         .min(1)
         .sliderRange(1, 5)
-        .onChanged(this::onResize)
+        .onChanged(aDouble -> calculateSize())
         .build()
     );
 
@@ -88,6 +88,8 @@ public class PlayerModelHud extends HudElement {
 
     public PlayerModelHud() {
         super(INFO);
+
+        calculateSize();
     }
 
     @Override
@@ -111,7 +113,7 @@ public class PlayerModelHud extends HudElement {
         }
     }
 
-    private void onResize(double newScale) {
-        setSize(50 * newScale, 75 * newScale);
+    private void calculateSize() {
+        setSize(50 * scale.get(), 75 * scale.get());
     }
 }


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

- Display crosses on Player Model Hud and Combat Hud when in editor and there is no content displayed, as they may have a transparent background.
- Move tasks from `render()` and `tick()` to setting `onChanged()` listeners

# How Has This Been Tested?

![image](https://github.com/MeteorDevelopment/meteor-client/assets/32882447/23e9f6ca-6fbd-4c61-97c3-8ac98898fa24)
(Combat Hud player model is an unrelated issue)
![image](https://github.com/MeteorDevelopment/meteor-client/assets/32882447/31acd072-3bc6-4f2c-ad94-54565241920e)

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
