### PR TITLE
Add "Sign" setting to BookBot

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BookBot.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BookBot.java
@@ -165,7 +165,7 @@ public class BookBot extends Module {
     @EventHandler
     private void onTick(TickEvent.Post event) {
         Predicate<ItemStack> bookPredicate = i ->
-            i.getItem() == Items.WRITABLE_BOOK && (i.getNbt() == null || i.getNbt().get("pages").asString().isEmpty());
+            i.getItem() == Items.WRITABLE_BOOK && (i.getNbt() == null || i.getNbt().get("pages") == null || ((NbtList) i.getNbt().get("pages")).isEmpty());
 
         FindItemResult writableBook = InvUtils.find(bookPredicate);
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BookBot.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BookBot.java
@@ -19,7 +19,7 @@ import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.utils.player.FindItemResult;
 import meteordevelopment.meteorclient.utils.player.InvUtils;
 import meteordevelopment.orbit.EventHandler;
-import net.minecraft.item.Items;
+import net.minecraft.item.*;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtList;
 import net.minecraft.nbt.NbtString;
@@ -39,10 +39,8 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Optional;
-import java.util.PrimitiveIterator;
-import java.util.Random;
+import java.util.*;
+import java.util.function.Predicate;
 
 public class BookBot extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
@@ -54,10 +52,18 @@ public class BookBot extends Module {
         .build()
     );
 
+    private final Setting<Boolean> sign = sgGeneral.add(new BoolSetting.Builder()
+        .name("sign")
+        .description("Whether to sign the book.")
+        .defaultValue(true)
+        .build()
+    );
+
     private final Setting<String> name = sgGeneral.add(new StringSetting.Builder()
         .name("name")
         .description("The name you want to give your books.")
         .defaultValue("Meteor on Crack!")
+        .visible(sign::get)
         .build()
     );
 
@@ -83,6 +89,7 @@ public class BookBot extends Module {
         .name("append-count")
         .description("Whether to append the number of the book to the title.")
         .defaultValue(true)
+        .visible(sign::get)
         .build()
     );
 
@@ -157,7 +164,10 @@ public class BookBot extends Module {
 
     @EventHandler
     private void onTick(TickEvent.Post event) {
-        FindItemResult writableBook = InvUtils.find(Items.WRITABLE_BOOK);
+        Predicate<ItemStack> bookPredicate = i ->
+            i.getItem() == Items.WRITABLE_BOOK && (i.getNbt() == null || i.getNbt().get("pages").asString().isEmpty());
+
+        FindItemResult writableBook = InvUtils.find(bookPredicate);
 
         // Check if there is a book to write
         if (!writableBook.found()) {
@@ -166,7 +176,7 @@ public class BookBot extends Module {
         }
 
         // Move the book into hand
-        if (!InvUtils.testInMainHand(Items.WRITABLE_BOOK)) {
+        if (!InvUtils.testInMainHand(bookPredicate)) {
             InvUtils.move().from(writableBook.slot()).toHotbar(mc.player.getInventory().selectedSlot);
             return;
         }
@@ -291,7 +301,7 @@ public class BookBot extends Module {
         if (!pages.isEmpty()) mc.player.getMainHandStack().setSubNbt("pages", pageNbt);
 
         // Send book update to server
-        mc.player.networkHandler.sendPacket(new BookUpdateC2SPacket(mc.player.getInventory().selectedSlot, pages, Optional.of(title)));
+        mc.player.networkHandler.sendPacket(new BookUpdateC2SPacket(mc.player.getInventory().selectedSlot, pages, sign.get() ? Optional.of(title) : Optional.empty()));
 
         bookCount++;
     }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BookBot.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BookBot.java
@@ -52,21 +52,6 @@ public class BookBot extends Module {
         .build()
     );
 
-    private final Setting<Boolean> sign = sgGeneral.add(new BoolSetting.Builder()
-        .name("sign")
-        .description("Whether to sign the book.")
-        .defaultValue(true)
-        .build()
-    );
-
-    private final Setting<String> name = sgGeneral.add(new StringSetting.Builder()
-        .name("name")
-        .description("The name you want to give your books.")
-        .defaultValue("Meteor on Crack!")
-        .visible(sign::get)
-        .build()
-    );
-
     private final Setting<Integer> pages = sgGeneral.add(new IntSetting.Builder()
         .name("pages")
         .description("The number of pages to write per book.")
@@ -85,20 +70,35 @@ public class BookBot extends Module {
         .build()
     );
 
-    private final Setting<Boolean> count = sgGeneral.add(new BoolSetting.Builder()
-        .name("append-count")
-        .description("Whether to append the number of the book to the title.")
-        .defaultValue(true)
-        .visible(sign::get)
-        .build()
-    );
-
     private final Setting<Integer> delay = sgGeneral.add(new IntSetting.Builder()
         .name("delay")
         .description("The amount of delay between writing books.")
         .defaultValue(20)
         .min(1)
         .sliderRange(1, 200)
+        .build()
+    );
+
+    private final Setting<Boolean> sign = sgGeneral.add(new BoolSetting.Builder()
+        .name("sign")
+        .description("Whether to sign the book.")
+        .defaultValue(true)
+        .build()
+    );
+
+    private final Setting<String> name = sgGeneral.add(new StringSetting.Builder()
+        .name("name")
+        .description("The name you want to give your books.")
+        .defaultValue("Meteor on Crack!")
+        .visible(sign::get)
+        .build()
+    );
+
+    private final Setting<Boolean> count = sgGeneral.add(new BoolSetting.Builder()
+        .name("append-count")
+        .description("Whether to append the number of the book to the title.")
+        .defaultValue(true)
+        .visible(sign::get)
         .build()
     );
 


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Allow books to be left unsigned. Can be useful if player just wants to fill books with text without signing them.

# How Has This Been Tested?
Sign is enabled (default):
![image](https://github.com/MeteorDevelopment/meteor-client/assets/46041044/2092e534-d581-4540-a2ca-146e20ad70ed)
Sign is disabled:
![image](https://github.com/MeteorDevelopment/meteor-client/assets/46041044/dbe47f47-b836-45f5-9b9b-7875960cfd1c)

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
