### PR TITLE
Fix PlayerHeadTexture memory leaks

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/utils/render/PlayerHeadTexture.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/PlayerHeadTexture.java
@@ -78,7 +78,7 @@ public class PlayerHeadTexture extends Texture {
 
                 ByteBuffer image = STBImage.stbi_load_from_memory(data, width, height, comp, 3);
                 upload(image);
-                RenderSystem.recordRenderCall(() -> STBImage.stbi_image_free(image));
+                STBImage.stbi_image_free(image);
             }
             MemoryUtil.memFree(data);
         }

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/PlayerHeadTexture.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/PlayerHeadTexture.java
@@ -77,12 +77,8 @@ public class PlayerHeadTexture extends Texture {
                 IntBuffer comp = stack.mallocInt(1);
 
                 ByteBuffer image = STBImage.stbi_load_from_memory(data, width, height, comp, 3);
-                Runnable action = () -> {
-                    upload(8, 8, image, Texture.Format.RGB, Texture.Filter.Nearest, Texture.Filter.Nearest, false);
-                    STBImage.stbi_image_free(image);
-                };
-                if (RenderSystem.isOnRenderThread()) action.run();
-                else RenderSystem.recordRenderCall(action::run);
+                upload(image);
+                RenderSystem.recordRenderCall(() -> STBImage.stbi_image_free(image));
             }
             MemoryUtil.memFree(data);
         }


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

1. Close `InputStream`
2. Release `ByteBuffer` (`TextureUtil` uses jemalloc via lwjgl which is native memory, not jvm heap, it has to be released manually)
3. Ensure image `ByteBuffer` is released *after* it is used (not a memory leak, but thread safety)

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
