### PR TITLE
faster map usage in `Systems` & `Modules`

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/Systems.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/Systems.java
@@ -5,6 +5,7 @@
 
 package meteordevelopment.meteorclient.systems;
 
+import it.unimi.dsi.fastutil.objects.Reference2ReferenceOpenHashMap;
 import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.events.game.GameLeftEvent;
 import meteordevelopment.meteorclient.systems.accounts.Accounts;
@@ -20,13 +21,12 @@ import meteordevelopment.orbit.EventHandler;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class Systems {
     @SuppressWarnings("rawtypes")
-    private static final Map<Class<? extends System>, System<?>> systems = new HashMap<>();
+    private static final Map<Class<? extends System>, System<?>> systems = new Reference2ReferenceOpenHashMap<>();
     private static final List<Runnable> preLoadTasks = new ArrayList<>(1);
 
     public static void addPreLoadTask(Runnable task) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
@@ -8,6 +8,7 @@ package meteordevelopment.meteorclient.systems.modules;
 import com.google.common.collect.Ordering;
 import com.mojang.datafixers.util.Pair;
 import com.mojang.serialization.Lifecycle;
+import it.unimi.dsi.fastutil.objects.Reference2ReferenceOpenHashMap;
 import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.events.game.GameJoinedEvent;
 import meteordevelopment.meteorclient.events.game.GameLeftEvent;
@@ -68,8 +69,8 @@ public class Modules extends System<Modules> {
     private static final List<Category> CATEGORIES = new ArrayList<>();
 
     private final List<Module> modules = new ArrayList<>();
-    private final Map<Class<? extends Module>, Module> moduleInstances = new HashMap<>();
-    private final Map<Category, List<Module>> groups = new HashMap<>();
+    private final Map<Class<? extends Module>, Module> moduleInstances = new Reference2ReferenceOpenHashMap<>();
+    private final Map<Category, List<Module>> groups = new Reference2ReferenceOpenHashMap<>();
 
     private final List<Module> active = new ArrayList<>();
     private Module moduleToBind;

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/Names.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/Names.java
@@ -5,6 +5,7 @@
 
 package meteordevelopment.meteorclient.utils.misc;
 
+import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
 import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.events.game.ResourcePacksReloadedEvent;
 import meteordevelopment.meteorclient.utils.PreInit;
@@ -28,12 +29,12 @@ import java.util.Map;
 import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class Names {
-    private static final Map<StatusEffect, String> statusEffectNames = new HashMap<>(16);
-    private static final Map<Item, String> itemNames = new HashMap<>(128);
-    private static final Map<Block, String> blockNames = new HashMap<>(128);
-    private static final Map<Enchantment, String> enchantmentNames = new HashMap<>(16);
-    private static final Map<EntityType<?>, String> entityTypeNames = new HashMap<>(64);
-    private static final Map<ParticleType<?>, String> particleTypesNames = new HashMap<>(64);
+    private static final Map<StatusEffect, String> statusEffectNames = new Reference2ObjectOpenHashMap<>(16);
+    private static final Map<Item, String> itemNames = new Reference2ObjectOpenHashMap<>(128);
+    private static final Map<Block, String> blockNames = new Reference2ObjectOpenHashMap<>(128);
+    private static final Map<Enchantment, String> enchantmentNames = new Reference2ObjectOpenHashMap<>(16);
+    private static final Map<EntityType<?>, String> entityTypeNames = new Reference2ObjectOpenHashMap<>(64);
+    private static final Map<ParticleType<?>, String> particleTypesNames = new Reference2ObjectOpenHashMap<>(64);
     private static final Map<Identifier, String> soundNames = new HashMap<>(64);
 
     @PreInit


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

`Module`, `System`, & `Category` should all never have multiple instances created of their respective classes, therefore we can safely use referential equality in order to speed up `Modules.get().get(Module.class)` invocations commonly used in many locations.

# How Has This Been Tested?

work grate 👍 

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
