### PR TITLE
improve command api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,6 @@ dependencies {
     mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
     modInclude fabricApi.module("fabric-resource-loader-v0", project.fapi_version)
-    modInclude fabricApi.module("fabric-command-api-v2", project.fapi_version)
 
     // Compat fixes
     modCompileOnly fabricApi.module("fabric-renderer-indigo", project.fapi_version)

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
     modInclude fabricApi.module("fabric-resource-loader-v0", project.fapi_version)
+    modInclude fabricApi.module("fabric-command-api-v2", project.fapi_version)
 
     // Compat fixes
     modCompileOnly fabricApi.module("fabric-renderer-indigo", project.fapi_version)

--- a/src/main/java/meteordevelopment/meteorclient/commands/Command.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/Command.java
@@ -12,8 +12,8 @@ import com.mojang.brigadier.builder.RequiredArgumentBuilder;
 import meteordevelopment.meteorclient.systems.config.Config;
 import meteordevelopment.meteorclient.utils.Utils;
 import meteordevelopment.meteorclient.utils.player.ChatUtils;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.command.CommandRegistryAccess;
 import net.minecraft.registry.BuiltinRegistries;
 import net.minecraft.server.command.CommandManager;
@@ -41,26 +41,26 @@ public abstract class Command {
     }
 
     // Helper methods to painlessly infer the CommandSource generic type argument
-    protected static <T> RequiredArgumentBuilder<FabricClientCommandSource, T> argument(final String name, final ArgumentType<T> type) {
+    protected static <T> RequiredArgumentBuilder<ClientCommandSource, T> argument(final String name, final ArgumentType<T> type) {
         return RequiredArgumentBuilder.argument(name, type);
     }
 
-    protected static LiteralArgumentBuilder<FabricClientCommandSource> literal(final String name) {
+    protected static LiteralArgumentBuilder<ClientCommandSource> literal(final String name) {
         return LiteralArgumentBuilder.literal(name);
     }
 
-    public final void registerTo(CommandDispatcher<FabricClientCommandSource> dispatcher) {
+    public final void registerTo(CommandDispatcher<ClientCommandSource> dispatcher) {
         register(dispatcher, name);
         for (String alias : aliases) register(dispatcher, alias);
     }
 
-    public void register(CommandDispatcher<FabricClientCommandSource> dispatcher, String name) {
-        LiteralArgumentBuilder<FabricClientCommandSource> builder = LiteralArgumentBuilder.literal(name);
+    public void register(CommandDispatcher<ClientCommandSource> dispatcher, String name) {
+        LiteralArgumentBuilder<ClientCommandSource> builder = LiteralArgumentBuilder.literal(name);
         build(builder);
         dispatcher.register(builder);
     }
 
-    public abstract void build(LiteralArgumentBuilder<FabricClientCommandSource> builder);
+    public abstract void build(LiteralArgumentBuilder<ClientCommandSource> builder);
 
     public String getName() {
         return name;

--- a/src/main/java/meteordevelopment/meteorclient/commands/Command.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/Command.java
@@ -12,8 +12,9 @@ import com.mojang.brigadier.builder.RequiredArgumentBuilder;
 import meteordevelopment.meteorclient.systems.config.Config;
 import meteordevelopment.meteorclient.utils.Utils;
 import meteordevelopment.meteorclient.utils.player.ChatUtils;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.command.CommandRegistryAccess;
-import net.minecraft.command.CommandSource;
 import net.minecraft.registry.BuiltinRegistries;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.text.Text;
@@ -24,6 +25,8 @@ import java.util.List;
 
 public abstract class Command {
     protected static final CommandRegistryAccess REGISTRY_ACCESS = CommandManager.createRegistryAccess(BuiltinRegistries.createWrapperLookup());
+    protected static final MinecraftClient mc = MinecraftClient.getInstance();
+    protected static final int SINGLE_SUCCESS = 1;
 
     private final String name;
     private final String title;
@@ -38,26 +41,26 @@ public abstract class Command {
     }
 
     // Helper methods to painlessly infer the CommandSource generic type argument
-    protected static <T> RequiredArgumentBuilder<CommandSource, T> argument(final String name, final ArgumentType<T> type) {
+    protected static <T> RequiredArgumentBuilder<FabricClientCommandSource, T> argument(final String name, final ArgumentType<T> type) {
         return RequiredArgumentBuilder.argument(name, type);
     }
 
-    protected static LiteralArgumentBuilder<CommandSource> literal(final String name) {
+    protected static LiteralArgumentBuilder<FabricClientCommandSource> literal(final String name) {
         return LiteralArgumentBuilder.literal(name);
     }
 
-    public final void registerTo(CommandDispatcher<CommandSource> dispatcher) {
+    public final void registerTo(CommandDispatcher<FabricClientCommandSource> dispatcher) {
         register(dispatcher, name);
         for (String alias : aliases) register(dispatcher, alias);
     }
 
-    public void register(CommandDispatcher<CommandSource> dispatcher, String name) {
-        LiteralArgumentBuilder<CommandSource> builder = LiteralArgumentBuilder.literal(name);
+    public void register(CommandDispatcher<FabricClientCommandSource> dispatcher, String name) {
+        LiteralArgumentBuilder<FabricClientCommandSource> builder = LiteralArgumentBuilder.literal(name);
         build(builder);
         dispatcher.register(builder);
     }
 
-    public abstract void build(LiteralArgumentBuilder<CommandSource> builder);
+    public abstract void build(LiteralArgumentBuilder<FabricClientCommandSource> builder);
 
     public String getName() {
         return name;

--- a/src/main/java/meteordevelopment/meteorclient/commands/Commands.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/Commands.java
@@ -10,6 +10,7 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import meteordevelopment.meteorclient.commands.commands.*;
 import meteordevelopment.meteorclient.pathing.PathManagers;
 import meteordevelopment.meteorclient.utils.PostInit;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.command.CommandSource;
 
@@ -20,8 +21,7 @@ import java.util.List;
 import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class Commands {
-    public static final CommandDispatcher<CommandSource> DISPATCHER = new CommandDispatcher<>();
-    public static final CommandSource COMMAND_SOURCE = new ClientCommandSource(null, mc);
+    public static final CommandDispatcher<FabricClientCommandSource> DISPATCHER = new CommandDispatcher<>();
     public static final List<Command> COMMANDS = new ArrayList<>();
 
     @PostInit(dependencies = PathManagers.class)
@@ -66,6 +66,10 @@ public class Commands {
         COMMANDS.sort(Comparator.comparing(Command::getName));
     }
 
+    public static FabricClientCommandSource getCommandSource() {
+        return mc.getNetworkHandler() == null ? null : (FabricClientCommandSource) mc.getNetworkHandler().getCommandSource();
+    }
+
     public static void add(Command command) {
         COMMANDS.removeIf(existing -> existing.getName().equals(command.getName()));
         command.registerTo(DISPATCHER);
@@ -73,7 +77,7 @@ public class Commands {
     }
 
     public static void dispatch(String message) throws CommandSyntaxException {
-        DISPATCHER.execute(message, COMMAND_SOURCE);
+        DISPATCHER.execute(message, getCommandSource());
     }
 
     public static Command get(String name) {

--- a/src/main/java/meteordevelopment/meteorclient/commands/Commands.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/Commands.java
@@ -24,7 +24,7 @@ public class Commands {
     public static final CommandDispatcher<FabricClientCommandSource> DISPATCHER = new CommandDispatcher<>();
     public static final List<Command> COMMANDS = new ArrayList<>();
 
-    @PostInit(dependencies = PathManagers.class)
+    @PostInit
     public static void init() {
         add(new VClipCommand());
         add(new HClipCommand());

--- a/src/main/java/meteordevelopment/meteorclient/commands/Commands.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/Commands.java
@@ -8,11 +8,8 @@ package meteordevelopment.meteorclient.commands;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import meteordevelopment.meteorclient.commands.commands.*;
-import meteordevelopment.meteorclient.pathing.PathManagers;
 import meteordevelopment.meteorclient.utils.PostInit;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.client.network.ClientCommandSource;
-import net.minecraft.command.CommandSource;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -21,7 +18,7 @@ import java.util.List;
 import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class Commands {
-    public static final CommandDispatcher<FabricClientCommandSource> DISPATCHER = new CommandDispatcher<>();
+    public static final CommandDispatcher<ClientCommandSource> DISPATCHER = new CommandDispatcher<>();
     public static final List<Command> COMMANDS = new ArrayList<>();
 
     @PostInit
@@ -66,8 +63,8 @@ public class Commands {
         COMMANDS.sort(Comparator.comparing(Command::getName));
     }
 
-    public static FabricClientCommandSource getCommandSource() {
-        return mc.getNetworkHandler() == null ? null : (FabricClientCommandSource) mc.getNetworkHandler().getCommandSource();
+    public static ClientCommandSource getCommandSource() {
+        return mc.getNetworkHandler() == null ? null : mc.getNetworkHandler().getCommandSource();
     }
 
     public static void add(Command command) {

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/BindCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/BindCommand.java
@@ -10,9 +10,7 @@ import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.commands.arguments.ModuleArgumentType;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.systems.modules.Modules;
-import net.minecraft.command.CommandSource;
-
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 
 public class BindCommand extends Command {
     public BindCommand() {
@@ -20,7 +18,7 @@ public class BindCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder.then(argument("module", ModuleArgumentType.create()).executes(context -> {
             Module module = context.getArgument("module", Module.class);
             Modules.get().setModuleToBind(module);

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/BindCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/BindCommand.java
@@ -10,7 +10,7 @@ import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.commands.arguments.ModuleArgumentType;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.systems.modules.Modules;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 
 public class BindCommand extends Command {
     public BindCommand() {
@@ -18,7 +18,7 @@ public class BindCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder.then(argument("module", ModuleArgumentType.create()).executes(context -> {
             Module module = context.getArgument("module", Module.class);
             Modules.get().setModuleToBind(module);

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/BindsCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/BindsCommand.java
@@ -11,7 +11,7 @@ import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.utils.Utils;
 import meteordevelopment.meteorclient.utils.player.ChatUtils;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.text.HoverEvent;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
@@ -25,7 +25,7 @@ public class BindsCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder.executes(context -> {
             // Modules
             List<Module> modules = Modules.get().getAll().stream()

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/BindsCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/BindsCommand.java
@@ -11,7 +11,7 @@ import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.utils.Utils;
 import meteordevelopment.meteorclient.utils.player.ChatUtils;
-import net.minecraft.command.CommandSource;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.text.HoverEvent;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
@@ -19,15 +19,13 @@ import net.minecraft.util.Formatting;
 
 import java.util.List;
 
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
-
 public class BindsCommand extends Command {
     public BindsCommand() {
         super("binds", "List of all bound modules.");
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder.executes(context -> {
             // Modules
             List<Module> modules = Modules.get().getAll().stream()

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/CommandsCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/CommandsCommand.java
@@ -11,14 +11,12 @@ import meteordevelopment.meteorclient.commands.Commands;
 import meteordevelopment.meteorclient.systems.config.Config;
 import meteordevelopment.meteorclient.utils.Utils;
 import meteordevelopment.meteorclient.utils.player.ChatUtils;
-import net.minecraft.command.CommandSource;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.text.ClickEvent;
 import net.minecraft.text.HoverEvent;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
-
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
 
 public class CommandsCommand extends Command {
     public CommandsCommand() {
@@ -26,7 +24,7 @@ public class CommandsCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder.executes(context -> {
             ChatUtils.info("--- Commands ((highlight)%d(default)) ---", Commands.COMMANDS.size());
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/CommandsCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/CommandsCommand.java
@@ -11,7 +11,7 @@ import meteordevelopment.meteorclient.commands.Commands;
 import meteordevelopment.meteorclient.systems.config.Config;
 import meteordevelopment.meteorclient.utils.Utils;
 import meteordevelopment.meteorclient.utils.player.ChatUtils;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.text.ClickEvent;
 import net.minecraft.text.HoverEvent;
 import net.minecraft.text.MutableText;
@@ -24,7 +24,7 @@ public class CommandsCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder.executes(context -> {
             ChatUtils.info("--- Commands ((highlight)%d(default)) ---", Commands.COMMANDS.size());
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/DamageCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/DamageCommand.java
@@ -12,7 +12,7 @@ import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.movement.NoFall;
 import meteordevelopment.meteorclient.systems.modules.player.AntiHunger;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket;
 import net.minecraft.text.Text;
 import net.minecraft.util.math.Vec3d;
@@ -25,7 +25,7 @@ public class DamageCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder.then(argument("damage", IntegerArgumentType.integer(1, 7)).executes(context -> {
             int amount = IntegerArgumentType.getInteger(context, "damage");
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/DamageCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/DamageCommand.java
@@ -12,13 +12,10 @@ import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.movement.NoFall;
 import meteordevelopment.meteorclient.systems.modules.player.AntiHunger;
-import net.minecraft.command.CommandSource;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket;
 import net.minecraft.text.Text;
 import net.minecraft.util.math.Vec3d;
-
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
-import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class DamageCommand extends Command {
     private final static SimpleCommandExceptionType INVULNERABLE = new SimpleCommandExceptionType(Text.literal("You are invulnerable."));
@@ -28,7 +25,7 @@ public class DamageCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder.then(argument("damage", IntegerArgumentType.integer(1, 7)).executes(context -> {
             int amount = IntegerArgumentType.getInteger(context, "damage");
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/DismountCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/DismountCommand.java
@@ -7,11 +7,8 @@ package meteordevelopment.meteorclient.commands.commands;
 
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
-import net.minecraft.command.CommandSource;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.network.packet.c2s.play.PlayerInputC2SPacket;
-
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
-import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class DismountCommand extends Command {
     public DismountCommand() {
@@ -19,7 +16,7 @@ public class DismountCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder.executes(context -> {
             mc.getNetworkHandler().sendPacket(new PlayerInputC2SPacket(0, 0, false, true));
             return SINGLE_SUCCESS;

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/DismountCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/DismountCommand.java
@@ -7,7 +7,7 @@ package meteordevelopment.meteorclient.commands.commands;
 
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.network.packet.c2s.play.PlayerInputC2SPacket;
 
 public class DismountCommand extends Command {
@@ -16,7 +16,7 @@ public class DismountCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder.executes(context -> {
             mc.getNetworkHandler().sendPacket(new PlayerInputC2SPacket(0, 0, false, true));
             return SINGLE_SUCCESS;

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/DropCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/DropCommand.java
@@ -10,7 +10,7 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.utils.player.InvUtils;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.command.argument.ItemStackArgumentType;
 import net.minecraft.item.ItemStack;
@@ -26,7 +26,7 @@ public class DropCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         // Main Hand
         builder.then(literal("hand").executes(context -> drop(player -> player.dropSelectedItem(true))));
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/DropCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/DropCommand.java
@@ -10,15 +10,12 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.utils.player.InvUtils;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.client.network.ClientPlayerEntity;
-import net.minecraft.command.CommandSource;
 import net.minecraft.command.argument.ItemStackArgumentType;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.text.Text;
-
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
-import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class DropCommand extends Command {
     private static final SimpleCommandExceptionType NOT_SPECTATOR = new SimpleCommandExceptionType(Text.literal("Can't drop items while in spectator."));
@@ -29,7 +26,7 @@ public class DropCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         // Main Hand
         builder.then(literal("hand").executes(context -> drop(player -> player.dropSelectedItem(true))));
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/EnchantCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/EnchantCommand.java
@@ -12,8 +12,8 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.utils.Utils;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.client.gui.screen.ingame.InventoryScreen;
-import net.minecraft.command.CommandSource;
 import net.minecraft.command.argument.RegistryEntryArgumentType;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.item.ItemStack;
@@ -24,9 +24,6 @@ import net.minecraft.text.Text;
 
 import java.util.function.Function;
 
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
-import static meteordevelopment.meteorclient.MeteorClient.mc;
-
 public class EnchantCommand extends Command {
     private final static SimpleCommandExceptionType NOT_IN_CREATIVE = new SimpleCommandExceptionType(Text.literal("You must be in creative mode to use this."));
     private final static SimpleCommandExceptionType NOT_HOLDING_ITEM = new SimpleCommandExceptionType(Text.literal("You need to hold some item to enchant."));
@@ -36,7 +33,7 @@ public class EnchantCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder.then(literal("one").then(argument("enchantment", RegistryEntryArgumentType.registryEntry(REGISTRY_ACCESS, RegistryKeys.ENCHANTMENT))
             .then(literal("level").then(argument("level", IntegerArgumentType.integer()).executes(context -> {
                 one(context, enchantment -> context.getArgument("level", Integer.class));
@@ -88,7 +85,7 @@ public class EnchantCommand extends Command {
         })));
     }
 
-    private void one(CommandContext<CommandSource> context, Function<Enchantment, Integer> level) throws CommandSyntaxException {
+    private void one(CommandContext<FabricClientCommandSource> context, Function<Enchantment, Integer> level) throws CommandSyntaxException {
         ItemStack itemStack = tryGetItemStack();
 
         RegistryEntry.Reference<Enchantment> enchantment = context.getArgument("enchantment", RegistryEntry.Reference.class);

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/EnchantCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/EnchantCommand.java
@@ -12,8 +12,8 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.utils.Utils;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.client.gui.screen.ingame.InventoryScreen;
+import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.command.argument.RegistryEntryArgumentType;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.item.ItemStack;
@@ -33,7 +33,7 @@ public class EnchantCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder.then(literal("one").then(argument("enchantment", RegistryEntryArgumentType.registryEntry(REGISTRY_ACCESS, RegistryKeys.ENCHANTMENT))
             .then(literal("level").then(argument("level", IntegerArgumentType.integer()).executes(context -> {
                 one(context, enchantment -> context.getArgument("level", Integer.class));
@@ -85,7 +85,7 @@ public class EnchantCommand extends Command {
         })));
     }
 
-    private void one(CommandContext<FabricClientCommandSource> context, Function<Enchantment, Integer> level) throws CommandSyntaxException {
+    private void one(CommandContext<ClientCommandSource> context, Function<Enchantment, Integer> level) throws CommandSyntaxException {
         ItemStack itemStack = tryGetItemStack();
 
         RegistryEntry.Reference<Enchantment> enchantment = context.getArgument("enchantment", RegistryEntry.Reference.class);

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/EnderChestCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/EnderChestCommand.java
@@ -8,11 +8,9 @@ package meteordevelopment.meteorclient.commands.commands;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.utils.Utils;
-import net.minecraft.command.CommandSource;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
-
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
 
 public class EnderChestCommand extends Command {
     public EnderChestCommand() {
@@ -20,7 +18,7 @@ public class EnderChestCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder.executes(context -> {
             Utils.openContainer(Items.ENDER_CHEST.getDefaultStack(), new ItemStack[27], true);
             return SINGLE_SUCCESS;

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/EnderChestCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/EnderChestCommand.java
@@ -8,7 +8,7 @@ package meteordevelopment.meteorclient.commands.commands;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.utils.Utils;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 
@@ -18,7 +18,7 @@ public class EnderChestCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder.executes(context -> {
             Utils.openContainer(Items.ENDER_CHEST.getDefaultStack(), new ItemStack[27], true);
             return SINGLE_SUCCESS;

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/FakePlayerCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/FakePlayerCommand.java
@@ -14,9 +14,7 @@ import meteordevelopment.meteorclient.systems.modules.player.FakePlayer;
 import meteordevelopment.meteorclient.utils.entity.fakeplayer.FakePlayerEntity;
 import meteordevelopment.meteorclient.utils.entity.fakeplayer.FakePlayerManager;
 import meteordevelopment.meteorclient.utils.player.ChatUtils;
-import net.minecraft.command.CommandSource;
-
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 
 public class FakePlayerCommand extends Command {
     public FakePlayerCommand() {
@@ -24,7 +22,7 @@ public class FakePlayerCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder.then(literal("add")
             .executes(context -> {
                 FakePlayer fakePlayer = Modules.get().get(FakePlayer.class);

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/FakePlayerCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/FakePlayerCommand.java
@@ -14,7 +14,7 @@ import meteordevelopment.meteorclient.systems.modules.player.FakePlayer;
 import meteordevelopment.meteorclient.utils.entity.fakeplayer.FakePlayerEntity;
 import meteordevelopment.meteorclient.utils.entity.fakeplayer.FakePlayerManager;
 import meteordevelopment.meteorclient.utils.player.ChatUtils;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 
 public class FakePlayerCommand extends Command {
     public FakePlayerCommand() {
@@ -22,7 +22,7 @@ public class FakePlayerCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder.then(literal("add")
             .executes(context -> {
                 FakePlayer fakePlayer = Modules.get().get(FakePlayer.class);

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/FovCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/FovCommand.java
@@ -9,7 +9,7 @@ import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.mixininterface.ISimpleOption;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 
 public class FovCommand extends Command {
     public FovCommand() {
@@ -17,7 +17,7 @@ public class FovCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder.then(argument("fov", IntegerArgumentType.integer(0, 180)).executes(context -> {
             ((ISimpleOption) (Object) mc.options.getFov()).set(context.getArgument("fov", Integer.class));
             return SINGLE_SUCCESS;

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/FovCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/FovCommand.java
@@ -9,10 +9,7 @@ import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.mixininterface.ISimpleOption;
-import net.minecraft.command.CommandSource;
-
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
-import static meteordevelopment.meteorclient.MeteorClient.mc;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 
 public class FovCommand extends Command {
     public FovCommand() {
@@ -20,7 +17,7 @@ public class FovCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder.then(argument("fov", IntegerArgumentType.integer(0, 180)).executes(context -> {
             ((ISimpleOption) (Object) mc.options.getFov()).set(context.getArgument("fov", Integer.class));
             return SINGLE_SUCCESS;

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/FriendsCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/FriendsCommand.java
@@ -13,7 +13,7 @@ import meteordevelopment.meteorclient.commands.arguments.PlayerListEntryArgument
 import meteordevelopment.meteorclient.systems.friends.Friend;
 import meteordevelopment.meteorclient.systems.friends.Friends;
 import meteordevelopment.meteorclient.utils.player.ChatUtils;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.util.Formatting;
 
 public class FriendsCommand extends Command {
@@ -22,7 +22,7 @@ public class FriendsCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder.then(literal("add")
             .then(argument("player", PlayerListEntryArgumentType.create())
                 .executes(context -> {

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/FriendsCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/FriendsCommand.java
@@ -13,10 +13,8 @@ import meteordevelopment.meteorclient.commands.arguments.PlayerListEntryArgument
 import meteordevelopment.meteorclient.systems.friends.Friend;
 import meteordevelopment.meteorclient.systems.friends.Friends;
 import meteordevelopment.meteorclient.utils.player.ChatUtils;
-import net.minecraft.command.CommandSource;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.util.Formatting;
-
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
 
 public class FriendsCommand extends Command {
     public FriendsCommand() {
@@ -24,7 +22,7 @@ public class FriendsCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder.then(literal("add")
             .then(argument("player", PlayerListEntryArgumentType.create())
                 .executes(context -> {

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/GamemodeCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/GamemodeCommand.java
@@ -7,11 +7,8 @@ package meteordevelopment.meteorclient.commands.commands;
 
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
-import net.minecraft.command.CommandSource;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.world.GameMode;
-
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
-import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class GamemodeCommand extends Command {
     public GamemodeCommand() {
@@ -19,7 +16,7 @@ public class GamemodeCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         for (GameMode gameMode : GameMode.values()) {
             builder.then(literal(gameMode.getName()).executes(context -> {
                 mc.interactionManager.setGameMode(gameMode);

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/GamemodeCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/GamemodeCommand.java
@@ -7,7 +7,7 @@ package meteordevelopment.meteorclient.commands.commands;
 
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.world.GameMode;
 
 public class GamemodeCommand extends Command {
@@ -16,7 +16,7 @@ public class GamemodeCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         for (GameMode gameMode : GameMode.values()) {
             builder.then(literal(gameMode.getName()).executes(context -> {
                 mc.interactionManager.setGameMode(gameMode);

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/GiveCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/GiveCommand.java
@@ -11,14 +11,11 @@ import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.utils.player.FindItemResult;
 import meteordevelopment.meteorclient.utils.player.InvUtils;
-import net.minecraft.command.CommandSource;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.command.argument.ItemStackArgumentType;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.packet.c2s.play.CreativeInventoryActionC2SPacket;
 import net.minecraft.text.Text;
-
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
-import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class GiveCommand extends Command {
     private final static SimpleCommandExceptionType NOT_IN_CREATIVE = new SimpleCommandExceptionType(Text.literal("You must be in creative mode to use this."));
@@ -29,7 +26,7 @@ public class GiveCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder.then(argument("item", ItemStackArgumentType.itemStack(REGISTRY_ACCESS)).executes(context -> {
             if (!mc.player.getAbilities().creativeMode) throw NOT_IN_CREATIVE.create();
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/GiveCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/GiveCommand.java
@@ -11,7 +11,7 @@ import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.utils.player.FindItemResult;
 import meteordevelopment.meteorclient.utils.player.InvUtils;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.command.argument.ItemStackArgumentType;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.packet.c2s.play.CreativeInventoryActionC2SPacket;
@@ -26,7 +26,7 @@ public class GiveCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder.then(argument("item", ItemStackArgumentType.itemStack(REGISTRY_ACCESS)).executes(context -> {
             if (!mc.player.getAbilities().creativeMode) throw NOT_IN_CREATIVE.create();
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/HClipCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/HClipCommand.java
@@ -8,12 +8,9 @@ package meteordevelopment.meteorclient.commands.commands;
 import com.mojang.brigadier.arguments.DoubleArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
-import net.minecraft.command.CommandSource;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.math.Vec3d;
-
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
-import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class HClipCommand extends Command {
     public HClipCommand() {
@@ -21,7 +18,7 @@ public class HClipCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder.then(argument("blocks", DoubleArgumentType.doubleArg()).executes(context -> {
             double blocks = context.getArgument("blocks", Double.class);
             Vec3d forward = Vec3d.fromPolar(0, mc.player.getYaw()).normalize();

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/HClipCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/HClipCommand.java
@@ -8,7 +8,7 @@ package meteordevelopment.meteorclient.commands.commands;
 import com.mojang.brigadier.arguments.DoubleArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.math.Vec3d;
 
@@ -18,7 +18,7 @@ public class HClipCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder.then(argument("blocks", DoubleArgumentType.doubleArg()).executes(context -> {
             double blocks = context.getArgument("blocks", Double.class);
             Vec3d forward = Vec3d.fromPolar(0, mc.player.getYaw()).normalize();

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/InputCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/InputCommand.java
@@ -11,7 +11,7 @@ import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.orbit.EventHandler;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.client.option.KeyBinding;
 
 import java.util.ArrayList;
@@ -37,7 +37,7 @@ public class InputCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         for (Map.Entry<KeyBinding, String> keyBinding : keys.entrySet()) {
             builder.then(literal(keyBinding.getValue())
                 .then(argument("ticks", IntegerArgumentType.integer(1))

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/InputCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/InputCommand.java
@@ -11,15 +11,12 @@ import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.orbit.EventHandler;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.client.option.KeyBinding;
-import net.minecraft.command.CommandSource;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
-import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class InputCommand extends Command {
     private static final List<KeypressHandler> activeHandlers = new ArrayList<>();
@@ -40,7 +37,7 @@ public class InputCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         for (Map.Entry<KeyBinding, String> keyBinding : keys.entrySet()) {
             builder.then(literal(keyBinding.getValue())
                 .then(argument("ticks", IntegerArgumentType.integer(1))

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/InventoryCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/InventoryCommand.java
@@ -9,8 +9,8 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.commands.arguments.PlayerArgumentType;
 import meteordevelopment.meteorclient.utils.Utils;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.client.gui.screen.ingame.InventoryScreen;
+import net.minecraft.client.network.ClientCommandSource;
 
 public class InventoryCommand extends Command {
     public InventoryCommand() {
@@ -18,7 +18,7 @@ public class InventoryCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder.then(argument("player", PlayerArgumentType.create()).executes(context -> {
             Utils.screenToOpen = new InventoryScreen(PlayerArgumentType.get(context));
             return SINGLE_SUCCESS;

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/InventoryCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/InventoryCommand.java
@@ -9,10 +9,8 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.commands.arguments.PlayerArgumentType;
 import meteordevelopment.meteorclient.utils.Utils;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.client.gui.screen.ingame.InventoryScreen;
-import net.minecraft.command.CommandSource;
-
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
 
 public class InventoryCommand extends Command {
     public InventoryCommand() {
@@ -20,7 +18,7 @@ public class InventoryCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder.then(argument("player", PlayerArgumentType.create()).executes(context -> {
             Utils.screenToOpen = new InventoryScreen(PlayerArgumentType.get(context));
             return SINGLE_SUCCESS;

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/LocateCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/LocateCommand.java
@@ -15,9 +15,9 @@ import meteordevelopment.meteorclient.pathing.PathManagers;
 import meteordevelopment.meteorclient.utils.player.ChatUtils;
 import meteordevelopment.meteorclient.utils.player.InvUtils;
 import meteordevelopment.orbit.EventHandler;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
-import net.minecraft.command.CommandSource;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.EyeOfEnderEntity;
 import net.minecraft.item.ItemStack;
@@ -34,9 +34,6 @@ import net.minecraft.util.math.Vec3d;
 
 import java.util.Arrays;
 import java.util.List;
-
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
-import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class LocateCommand extends Command {
     private Vec3d firstStart;
@@ -65,7 +62,7 @@ public class LocateCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder.then(literal("buried_treasure").executes(s -> {
             ItemStack stack = mc.player.getInventory().getMainHandStack();
             if (stack.getItem() != Items.FILLED_MAP) {

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/LocateCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/LocateCommand.java
@@ -15,9 +15,9 @@ import meteordevelopment.meteorclient.pathing.PathManagers;
 import meteordevelopment.meteorclient.utils.player.ChatUtils;
 import meteordevelopment.meteorclient.utils.player.InvUtils;
 import meteordevelopment.orbit.EventHandler;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
+import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.EyeOfEnderEntity;
 import net.minecraft.item.ItemStack;
@@ -62,7 +62,7 @@ public class LocateCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder.then(literal("buried_treasure").executes(s -> {
             ItemStack stack = mc.player.getInventory().getMainHandStack();
             if (stack.getItem() != Items.FILLED_MAP) {

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/MacroCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/MacroCommand.java
@@ -9,9 +9,7 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.commands.arguments.MacroArgumentType;
 import meteordevelopment.meteorclient.systems.macros.Macro;
-import net.minecraft.command.CommandSource;
-
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 
 public class MacroCommand extends Command {
     public MacroCommand() {
@@ -19,7 +17,7 @@ public class MacroCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder.then(argument("macro", MacroArgumentType.create()).executes(context -> {
             Macro macro = MacroArgumentType.get(context);
             macro.onAction();

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/MacroCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/MacroCommand.java
@@ -9,7 +9,7 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.commands.arguments.MacroArgumentType;
 import meteordevelopment.meteorclient.systems.macros.Macro;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 
 public class MacroCommand extends Command {
     public MacroCommand() {
@@ -17,7 +17,7 @@ public class MacroCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder.then(argument("macro", MacroArgumentType.create()).executes(context -> {
             Macro macro = MacroArgumentType.get(context);
             macro.onAction();

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/ModulesCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/ModulesCommand.java
@@ -10,13 +10,11 @@ import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.utils.player.ChatUtils;
-import net.minecraft.command.CommandSource;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.text.HoverEvent;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
-
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
 
 public class ModulesCommand extends Command {
     public ModulesCommand() {
@@ -24,7 +22,7 @@ public class ModulesCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder.executes(context -> {
             ChatUtils.info("--- Modules ((highlight)%d(default)) ---", Modules.get().getCount());
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/ModulesCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/ModulesCommand.java
@@ -10,7 +10,7 @@ import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.utils.player.ChatUtils;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.text.HoverEvent;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
@@ -22,7 +22,7 @@ public class ModulesCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder.executes(context -> {
             ChatUtils.info("--- Modules ((highlight)%d(default)) ---", Modules.get().getCount());
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/NameHistoryCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/NameHistoryCommand.java
@@ -14,8 +14,8 @@ import meteordevelopment.meteorclient.utils.network.MeteorExecutor;
 import meteordevelopment.meteorclient.utils.player.ChatUtils;
 import meteordevelopment.meteorclient.utils.player.PlayerUtils;
 import meteordevelopment.meteorclient.utils.render.color.Color;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.client.network.PlayerListEntry;
-import net.minecraft.command.CommandSource;
 import net.minecraft.text.*;
 import net.minecraft.util.Formatting;
 
@@ -24,16 +24,13 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.UUID;
 
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
-import static meteordevelopment.meteorclient.MeteorClient.mc;
-
 public class NameHistoryCommand extends Command {
     public NameHistoryCommand() {
         super("name-history", "Provides a list of a players previous names from the laby.net api.", "history", "names");
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder.then(argument("player", PlayerListEntryArgumentType.create()).executes(context -> {
             MeteorExecutor.execute(() -> {
                 PlayerListEntry lookUpTarget = PlayerListEntryArgumentType.get(context);

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/NameHistoryCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/NameHistoryCommand.java
@@ -14,7 +14,7 @@ import meteordevelopment.meteorclient.utils.network.MeteorExecutor;
 import meteordevelopment.meteorclient.utils.player.ChatUtils;
 import meteordevelopment.meteorclient.utils.player.PlayerUtils;
 import meteordevelopment.meteorclient.utils.render.color.Color;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.client.network.PlayerListEntry;
 import net.minecraft.text.*;
 import net.minecraft.util.Formatting;
@@ -30,7 +30,7 @@ public class NameHistoryCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder.then(argument("player", PlayerListEntryArgumentType.create()).executes(context -> {
             MeteorExecutor.execute(() -> {
                 PlayerListEntry lookUpTarget = PlayerListEntryArgumentType.get(context);

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/NbtCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/NbtCommand.java
@@ -11,7 +11,7 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.commands.arguments.CompoundNbtTagArgumentType;
 import meteordevelopment.meteorclient.systems.config.Config;
-import net.minecraft.command.CommandSource;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.command.argument.NbtPathArgumentType;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
@@ -23,16 +23,13 @@ import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
-import static meteordevelopment.meteorclient.MeteorClient.mc;
-
 public class NbtCommand extends Command {
     public NbtCommand() {
         super("nbt", "Modifies NBT data for an item, example: .nbt add {display:{Name:'{\"text\":\"$cRed Name\"}'}}");
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder.then(literal("add").then(argument("nbt", CompoundNbtTagArgumentType.create()).executes(s -> {
             ItemStack stack = mc.player.getInventory().getMainHandStack();
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/NbtCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/NbtCommand.java
@@ -11,7 +11,7 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.commands.arguments.CompoundNbtTagArgumentType;
 import meteordevelopment.meteorclient.systems.config.Config;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.command.argument.NbtPathArgumentType;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
@@ -29,7 +29,7 @@ public class NbtCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder.then(literal("add").then(argument("nbt", CompoundNbtTagArgumentType.create()).executes(s -> {
             ItemStack stack = mc.player.getInventory().getMainHandStack();
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/NotebotCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/NotebotCommand.java
@@ -17,8 +17,8 @@ import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.misc.Notebot;
 import meteordevelopment.meteorclient.utils.notebot.song.Note;
 import meteordevelopment.orbit.EventHandler;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.block.enums.Instrument;
+import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.network.packet.s2c.play.PlaySoundS2CPacket;
 import net.minecraft.sound.SoundEvent;
 import net.minecraft.text.Text;
@@ -43,7 +43,7 @@ public class NotebotCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder.then(literal("help").executes(ctx -> {
             Util.getOperatingSystem().open("https://github.com/MeteorDevelopment/meteor-client/wiki/Notebot-Guide");
             return SINGLE_SUCCESS;

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/NotebotCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/NotebotCommand.java
@@ -17,8 +17,8 @@ import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.misc.Notebot;
 import meteordevelopment.meteorclient.utils.notebot.song.Note;
 import meteordevelopment.orbit.EventHandler;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.block.enums.Instrument;
-import net.minecraft.command.CommandSource;
 import net.minecraft.network.packet.s2c.play.PlaySoundS2CPacket;
 import net.minecraft.sound.SoundEvent;
 import net.minecraft.text.Text;
@@ -32,8 +32,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
-
 public class NotebotCommand extends Command {
     private final static SimpleCommandExceptionType INVALID_SONG = new SimpleCommandExceptionType(Text.literal("Invalid song."));
 
@@ -45,7 +43,7 @@ public class NotebotCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder.then(literal("help").executes(ctx -> {
             Util.getOperatingSystem().open("https://github.com/MeteorDevelopment/meteor-client/wiki/Notebot-Guide");
             return SINGLE_SUCCESS;

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/PeekCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/PeekCommand.java
@@ -9,7 +9,7 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.utils.Utils;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.item.ItemStack;
 import net.minecraft.text.Text;
 
@@ -22,7 +22,7 @@ public class PeekCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder.executes(context -> {
             if (Utils.openContainer(mc.player.getMainHandStack(), ITEMS, true)) return SINGLE_SUCCESS;
             else if (Utils.openContainer(mc.player.getOffHandStack(), ITEMS, true)) return SINGLE_SUCCESS;

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/PeekCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/PeekCommand.java
@@ -9,12 +9,9 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.utils.Utils;
-import net.minecraft.command.CommandSource;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.item.ItemStack;
 import net.minecraft.text.Text;
-
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
-import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class PeekCommand extends Command {
     private static final ItemStack[] ITEMS = new ItemStack[27];
@@ -25,7 +22,7 @@ public class PeekCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder.executes(context -> {
             if (Utils.openContainer(mc.player.getMainHandStack(), ITEMS, true)) return SINGLE_SUCCESS;
             else if (Utils.openContainer(mc.player.getOffHandStack(), ITEMS, true)) return SINGLE_SUCCESS;

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/ProfilesCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/ProfilesCommand.java
@@ -10,7 +10,7 @@ import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.commands.arguments.ProfileArgumentType;
 import meteordevelopment.meteorclient.systems.profiles.Profile;
 import meteordevelopment.meteorclient.systems.profiles.Profiles;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 
 public class ProfilesCommand extends Command {
 
@@ -19,7 +19,7 @@ public class ProfilesCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder.then(literal("load").then(argument("profile", ProfileArgumentType.create()).executes(context -> {
             Profile profile = ProfileArgumentType.get(context);
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/ProfilesCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/ProfilesCommand.java
@@ -10,9 +10,7 @@ import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.commands.arguments.ProfileArgumentType;
 import meteordevelopment.meteorclient.systems.profiles.Profile;
 import meteordevelopment.meteorclient.systems.profiles.Profiles;
-import net.minecraft.command.CommandSource;
-
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 
 public class ProfilesCommand extends Command {
 
@@ -21,7 +19,7 @@ public class ProfilesCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder.then(literal("load").then(argument("profile", ProfileArgumentType.create()).executes(context -> {
             Profile profile = ProfileArgumentType.get(context);
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/ReloadCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/ReloadCommand.java
@@ -13,9 +13,7 @@ import meteordevelopment.meteorclient.systems.friends.Friend;
 import meteordevelopment.meteorclient.systems.friends.Friends;
 import meteordevelopment.meteorclient.utils.network.Capes;
 import meteordevelopment.meteorclient.utils.network.MeteorExecutor;
-import net.minecraft.command.CommandSource;
-
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 
 public class ReloadCommand extends Command {
     public ReloadCommand() {
@@ -23,7 +21,7 @@ public class ReloadCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder.executes(context -> {
             warning("Reloading systems, this may take a while.");
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/ReloadCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/ReloadCommand.java
@@ -13,7 +13,7 @@ import meteordevelopment.meteorclient.systems.friends.Friend;
 import meteordevelopment.meteorclient.systems.friends.Friends;
 import meteordevelopment.meteorclient.utils.network.Capes;
 import meteordevelopment.meteorclient.utils.network.MeteorExecutor;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 
 public class ReloadCommand extends Command {
     public ReloadCommand() {
@@ -21,7 +21,7 @@ public class ReloadCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder.executes(context -> {
             warning("Reloading systems, this may take a while.");
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/ResetCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/ResetCommand.java
@@ -15,7 +15,7 @@ import meteordevelopment.meteorclient.systems.hud.Hud;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.utils.player.ChatUtils;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 
 public class ResetCommand extends Command {
 
@@ -24,7 +24,7 @@ public class ResetCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder.then(literal("settings")
                 .then(argument("module", ModuleArgumentType.create()).executes(context -> {
                     Module module = context.getArgument("module", Module.class);

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/ResetCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/ResetCommand.java
@@ -15,9 +15,7 @@ import meteordevelopment.meteorclient.systems.hud.Hud;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.utils.player.ChatUtils;
-import net.minecraft.command.CommandSource;
-
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 
 public class ResetCommand extends Command {
 
@@ -26,7 +24,7 @@ public class ResetCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder.then(literal("settings")
                 .then(argument("module", ModuleArgumentType.create()).executes(context -> {
                     Module module = context.getArgument("module", Module.class);

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/RotationCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/RotationCommand.java
@@ -9,7 +9,7 @@ import com.mojang.brigadier.arguments.FloatArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.commands.arguments.DirectionArgumentType;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.MathHelper;
 
@@ -19,7 +19,7 @@ public class RotationCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder
             .then(literal("set")
                 .then(argument("direction", DirectionArgumentType.create())

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/RotationCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/RotationCommand.java
@@ -9,12 +9,9 @@ import com.mojang.brigadier.arguments.FloatArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.commands.arguments.DirectionArgumentType;
-import net.minecraft.command.CommandSource;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.MathHelper;
-
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
-import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class RotationCommand extends Command {
     public RotationCommand() {
@@ -22,7 +19,7 @@ public class RotationCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder
             .then(literal("set")
                 .then(argument("direction", DirectionArgumentType.create())

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/SaveMapCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/SaveMapCommand.java
@@ -10,8 +10,8 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.mixin.MapRendererAccessor;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.client.render.MapRenderer;
-import net.minecraft.command.CommandSource;
 import net.minecraft.item.FilledMapItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
@@ -28,9 +28,6 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
-import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class SaveMapCommand extends Command {
     private static final SimpleCommandExceptionType MAP_NOT_FOUND = new SimpleCommandExceptionType(Text.literal("You must be holding a filled map."));
@@ -50,7 +47,7 @@ public class SaveMapCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder.executes(context -> {
 
             MapState state = getMapState();

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/SaveMapCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/SaveMapCommand.java
@@ -10,7 +10,7 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.mixin.MapRendererAccessor;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.client.render.MapRenderer;
 import net.minecraft.item.FilledMapItem;
 import net.minecraft.item.ItemStack;
@@ -47,7 +47,7 @@ public class SaveMapCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder.executes(context -> {
 
             MapState state = getMapState();

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/SayCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/SayCommand.java
@@ -11,8 +11,8 @@ import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.mixin.ClientPlayNetworkHandlerAccessor;
 import meteordevelopment.meteorclient.utils.misc.MeteorStarscript;
 import meteordevelopment.starscript.Script;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
-import net.minecraft.command.CommandSource;
 import net.minecraft.network.encryption.NetworkEncryptionUtils;
 import net.minecraft.network.message.LastSeenMessagesCollector;
 import net.minecraft.network.message.MessageBody;
@@ -21,16 +21,13 @@ import net.minecraft.network.packet.c2s.play.ChatMessageC2SPacket;
 
 import java.time.Instant;
 
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
-import static meteordevelopment.meteorclient.MeteorClient.mc;
-
 public class SayCommand extends Command {
     public SayCommand() {
         super("say", "Sends messages in chat.");
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder.then(argument("message", StringArgumentType.greedyString()).executes(context -> {
             String msg = context.getArgument("message", String.class);
             Script script = MeteorStarscript.compile(msg);

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/SayCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/SayCommand.java
@@ -11,7 +11,7 @@ import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.mixin.ClientPlayNetworkHandlerAccessor;
 import meteordevelopment.meteorclient.utils.misc.MeteorStarscript;
 import meteordevelopment.starscript.Script;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.network.encryption.NetworkEncryptionUtils;
 import net.minecraft.network.message.LastSeenMessagesCollector;
@@ -27,7 +27,7 @@ public class SayCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder.then(argument("message", StringArgumentType.greedyString()).executes(context -> {
             String msg = context.getArgument("message", String.class);
             Script script = MeteorStarscript.compile(msg);

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/ServerCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/ServerCommand.java
@@ -15,7 +15,7 @@ import meteordevelopment.meteorclient.events.packets.PacketEvent;
 import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.utils.world.TickRate;
 import meteordevelopment.orbit.EventHandler;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.client.network.ServerAddress;
 import net.minecraft.client.network.ServerInfo;
 import net.minecraft.network.packet.c2s.play.RequestCommandCompletionsC2SPacket;
@@ -45,7 +45,7 @@ public class ServerCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder.executes(context -> {
             basicInfo();
             return SINGLE_SUCCESS;

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/ServerCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/ServerCommand.java
@@ -15,9 +15,9 @@ import meteordevelopment.meteorclient.events.packets.PacketEvent;
 import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.utils.world.TickRate;
 import meteordevelopment.orbit.EventHandler;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.client.network.ServerAddress;
 import net.minecraft.client.network.ServerInfo;
-import net.minecraft.command.CommandSource;
 import net.minecraft.network.packet.c2s.play.RequestCommandCompletionsC2SPacket;
 import net.minecraft.network.packet.s2c.play.CommandSuggestionsS2CPacket;
 import net.minecraft.server.integrated.IntegratedServer;
@@ -32,9 +32,6 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.*;
 
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
-import static meteordevelopment.meteorclient.MeteorClient.mc;
-
 public class ServerCommand extends Command {
     private static final List<String> ANTICHEAT_LIST = Arrays.asList("nocheatplus", "negativity", "warden", "horizon", "illegalstack", "coreprotect", "exploitsx", "vulcan", "abc", "spartan", "kauri", "anticheatreloaded", "witherac", "godseye", "matrix", "wraith", "antixrayheuristics", "grimac");
     private static final String completionStarts = "/:abcdefghijklmnopqrstuvwxyz0123456789-";
@@ -48,7 +45,7 @@ public class ServerCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder.executes(context -> {
             basicInfo();
             return SINGLE_SUCCESS;

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/SettingCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/SettingCommand.java
@@ -17,7 +17,7 @@ import meteordevelopment.meteorclient.gui.tabs.Tabs;
 import meteordevelopment.meteorclient.settings.Setting;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.utils.Utils;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 
 public class SettingCommand extends Command {
     public SettingCommand() {
@@ -25,7 +25,7 @@ public class SettingCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder.then(
             literal("hud")
                 .executes(context -> {

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/SettingCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/SettingCommand.java
@@ -17,9 +17,7 @@ import meteordevelopment.meteorclient.gui.tabs.Tabs;
 import meteordevelopment.meteorclient.settings.Setting;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.utils.Utils;
-import net.minecraft.command.CommandSource;
-
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 
 public class SettingCommand extends Command {
     public SettingCommand() {
@@ -27,7 +25,7 @@ public class SettingCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder.then(
             literal("hud")
                 .executes(context -> {

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/SpectateCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/SpectateCommand.java
@@ -11,11 +11,8 @@ import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.commands.arguments.PlayerArgumentType;
 import meteordevelopment.meteorclient.events.meteor.KeyEvent;
 import meteordevelopment.orbit.EventHandler;
-import net.minecraft.command.CommandSource;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.text.Text;
-
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
-import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class SpectateCommand extends Command {
 
@@ -26,7 +23,7 @@ public class SpectateCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder.then(literal("reset").executes(context -> {
             mc.setCameraEntity(mc.player);
             return SINGLE_SUCCESS;

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/SpectateCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/SpectateCommand.java
@@ -11,7 +11,7 @@ import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.commands.arguments.PlayerArgumentType;
 import meteordevelopment.meteorclient.events.meteor.KeyEvent;
 import meteordevelopment.orbit.EventHandler;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.text.Text;
 
 public class SpectateCommand extends Command {
@@ -23,7 +23,7 @@ public class SpectateCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder.then(literal("reset").executes(context -> {
             mc.setCameraEntity(mc.player);
             return SINGLE_SUCCESS;

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/SwarmCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/SwarmCommand.java
@@ -21,7 +21,7 @@ import meteordevelopment.meteorclient.systems.modules.misc.swarm.SwarmConnection
 import meteordevelopment.meteorclient.systems.modules.misc.swarm.SwarmWorker;
 import meteordevelopment.meteorclient.systems.modules.world.InfinityMiner;
 import meteordevelopment.meteorclient.utils.player.ChatUtils;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.command.argument.BlockStateArgument;
 import net.minecraft.command.argument.BlockStateArgumentType;
 import net.minecraft.entity.player.PlayerEntity;
@@ -40,7 +40,7 @@ public class SwarmCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder.then(literal("disconnect").executes(context -> {
             Swarm swarm = Modules.get().get(Swarm.class);
             if (swarm.isActive()) {

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/SwarmCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/SwarmCommand.java
@@ -21,7 +21,7 @@ import meteordevelopment.meteorclient.systems.modules.misc.swarm.SwarmConnection
 import meteordevelopment.meteorclient.systems.modules.misc.swarm.SwarmWorker;
 import meteordevelopment.meteorclient.systems.modules.world.InfinityMiner;
 import meteordevelopment.meteorclient.utils.player.ChatUtils;
-import net.minecraft.command.CommandSource;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.command.argument.BlockStateArgument;
 import net.minecraft.command.argument.BlockStateArgumentType;
 import net.minecraft.entity.player.PlayerEntity;
@@ -30,9 +30,6 @@ import net.minecraft.util.math.BlockPos;
 
 import java.util.List;
 import java.util.Random;
-
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
-import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class SwarmCommand extends Command {
 
@@ -43,7 +40,7 @@ public class SwarmCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder.then(literal("disconnect").executes(context -> {
             Swarm swarm = Modules.get().get(Swarm.class);
             if (swarm.isActive()) {

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/ToggleCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/ToggleCommand.java
@@ -11,7 +11,7 @@ import meteordevelopment.meteorclient.commands.arguments.ModuleArgumentType;
 import meteordevelopment.meteorclient.systems.hud.Hud;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.systems.modules.Modules;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 
 import java.util.ArrayList;
 
@@ -21,7 +21,7 @@ public class ToggleCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder
             .then(literal("all")
                 .then(literal("on")

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/ToggleCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/ToggleCommand.java
@@ -11,11 +11,9 @@ import meteordevelopment.meteorclient.commands.arguments.ModuleArgumentType;
 import meteordevelopment.meteorclient.systems.hud.Hud;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.systems.modules.Modules;
-import net.minecraft.command.CommandSource;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 
 import java.util.ArrayList;
-
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
 
 public class ToggleCommand extends Command {
     public ToggleCommand() {
@@ -23,7 +21,7 @@ public class ToggleCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder
             .then(literal("all")
                 .then(literal("on")

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/VClipCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/VClipCommand.java
@@ -8,12 +8,9 @@ package meteordevelopment.meteorclient.commands.commands;
 import com.mojang.brigadier.arguments.DoubleArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
-import net.minecraft.command.CommandSource;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket;
 import net.minecraft.network.packet.c2s.play.VehicleMoveC2SPacket;
-
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
-import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class VClipCommand extends Command {
     public VClipCommand() {
@@ -21,7 +18,7 @@ public class VClipCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder.then(argument("blocks", DoubleArgumentType.doubleArg()).executes(context -> {
 
             double blocks = context.getArgument("blocks", Double.class);

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/VClipCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/VClipCommand.java
@@ -8,7 +8,7 @@ package meteordevelopment.meteorclient.commands.commands;
 import com.mojang.brigadier.arguments.DoubleArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket;
 import net.minecraft.network.packet.c2s.play.VehicleMoveC2SPacket;
 
@@ -18,7 +18,7 @@ public class VClipCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder.then(argument("blocks", DoubleArgumentType.doubleArg()).executes(context -> {
 
             double blocks = context.getArgument("blocks", Double.class);

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/WaypointCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/WaypointCommand.java
@@ -13,7 +13,7 @@ import meteordevelopment.meteorclient.commands.arguments.WaypointArgumentType;
 import meteordevelopment.meteorclient.systems.waypoints.Waypoint;
 import meteordevelopment.meteorclient.systems.waypoints.Waypoints;
 import meteordevelopment.meteorclient.utils.player.PlayerUtils;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.command.argument.PosArgument;
 import net.minecraft.command.argument.Vec3ArgumentType;
 import net.minecraft.util.Formatting;
@@ -25,7 +25,7 @@ public class WaypointCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
+    public void build(LiteralArgumentBuilder<ClientCommandSource> builder) {
         builder.then(literal("list").executes(context -> {
             if (Waypoints.get().waypoints.isEmpty()) error("No created waypoints.");
             else {
@@ -81,7 +81,7 @@ public class WaypointCommand extends Command {
         return "X: " + waypoint.pos.get().getX() + ", Y: " + waypoint.pos.get().getY() + ", Z: " + waypoint.pos.get().getZ();
     }
 
-    private int addWaypoint(CommandContext<FabricClientCommandSource> context, boolean withCoords) {
+    private int addWaypoint(CommandContext<ClientCommandSource> context, boolean withCoords) {
         if (mc.player == null) return -1;
 
         BlockPos pos = withCoords ? context.getArgument("pos", PosArgument.class).toAbsoluteBlockPos(mc.player.getCommandSource()) : mc.player.getBlockPos().up(2);

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/WaypointCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/WaypointCommand.java
@@ -13,14 +13,11 @@ import meteordevelopment.meteorclient.commands.arguments.WaypointArgumentType;
 import meteordevelopment.meteorclient.systems.waypoints.Waypoint;
 import meteordevelopment.meteorclient.systems.waypoints.Waypoints;
 import meteordevelopment.meteorclient.utils.player.PlayerUtils;
-import net.minecraft.command.CommandSource;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.command.argument.PosArgument;
 import net.minecraft.command.argument.Vec3ArgumentType;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.math.BlockPos;
-
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
-import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class WaypointCommand extends Command {
     public WaypointCommand() {
@@ -28,7 +25,7 @@ public class WaypointCommand extends Command {
     }
 
     @Override
-    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+    public void build(LiteralArgumentBuilder<FabricClientCommandSource> builder) {
         builder.then(literal("list").executes(context -> {
             if (Waypoints.get().waypoints.isEmpty()) error("No created waypoints.");
             else {
@@ -84,7 +81,7 @@ public class WaypointCommand extends Command {
         return "X: " + waypoint.pos.get().getX() + ", Y: " + waypoint.pos.get().getY() + ", Z: " + waypoint.pos.get().getZ();
     }
 
-    private int addWaypoint(CommandContext<CommandSource> context, boolean withCoords) {
+    private int addWaypoint(CommandContext<FabricClientCommandSource> context, boolean withCoords) {
         if (mc.player == null) return -1;
 
         BlockPos pos = withCoords ? context.getArgument("pos", PosArgument.class).toAbsoluteBlockPos(mc.player.getCommandSource()) : mc.player.getBlockPos().up(2);

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ChatInputSuggestorMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ChatInputSuggestorMixin.java
@@ -10,9 +10,9 @@ import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.suggestion.Suggestions;
 import meteordevelopment.meteorclient.commands.Commands;
 import meteordevelopment.meteorclient.systems.config.Config;
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.client.gui.screen.ChatInputSuggestor;
 import net.minecraft.client.gui.widget.TextFieldWidget;
+import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.command.CommandSource;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -22,7 +22,6 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 @Mixin(ChatInputSuggestor.class)
@@ -54,7 +53,7 @@ public abstract class ChatInputSuggestorMixin {
 
             int cursor = textField.getCursor();
             if (cursor >= 1 && (this.window == null || !this.completingSuggestions)) {
-                this.pendingSuggestions = Commands.DISPATCHER.getCompletionSuggestions((ParseResults<FabricClientCommandSource>) (Object) this.parse, cursor);
+                this.pendingSuggestions = Commands.DISPATCHER.getCompletionSuggestions((ParseResults<ClientCommandSource>) (Object) this.parse, cursor);
                 this.pendingSuggestions.thenRun(() -> {
                     if (this.pendingSuggestions.isDone()) {
                         this.showCommandSuggestions();

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ChatInputSuggestorMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ChatInputSuggestorMixin.java
@@ -10,6 +10,7 @@ import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.suggestion.Suggestions;
 import meteordevelopment.meteorclient.commands.Commands;
 import meteordevelopment.meteorclient.systems.config.Config;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.client.gui.screen.ChatInputSuggestor;
 import net.minecraft.client.gui.widget.TextFieldWidget;
 import net.minecraft.command.CommandSource;
@@ -21,6 +22,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 @Mixin(ChatInputSuggestor.class)
@@ -34,6 +36,7 @@ public abstract class ChatInputSuggestorMixin {
     @Shadow
     protected abstract void showCommandSuggestions();
 
+    @SuppressWarnings("unchecked")
     @Inject(method = "refresh",
         at = @At(value = "INVOKE", target = "Lcom/mojang/brigadier/StringReader;canRead()Z", remap = false),
         cancellable = true,
@@ -46,12 +49,12 @@ public abstract class ChatInputSuggestorMixin {
             reader.setCursor(reader.getCursor() + length);
 
             if (this.parse == null) {
-                this.parse = Commands.DISPATCHER.parse(reader, Commands.COMMAND_SOURCE);
+                this.parse = (ParseResults<CommandSource>) (Object) Commands.DISPATCHER.parse(reader, Commands.getCommandSource());
             }
 
             int cursor = textField.getCursor();
             if (cursor >= 1 && (this.window == null || !this.completingSuggestions)) {
-                this.pendingSuggestions = Commands.DISPATCHER.getCompletionSuggestions(this.parse, cursor);
+                this.pendingSuggestions = Commands.DISPATCHER.getCompletionSuggestions((ParseResults<FabricClientCommandSource>) (Object) this.parse, cursor);
                 this.pendingSuggestions.thenRun(() -> {
                     if (this.pendingSuggestions.isDone()) {
                         this.showCommandSuggestions();


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

- Removes the static imports for `SINGLE_SUCCESS` and `mc`
- Allows using `CommandSource` methods without running into `NullPointerException`
- Expose `ClientCommandSource` instead of `CommandSource` to make it easier to use the command api with established command libs such as clientarguments

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
