### PR TITLE
fixed autoeat not working when using shield/offhand items

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoEat.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoEat.java
@@ -117,6 +117,8 @@ public class AutoEat extends Module {
         // Skip if Auto Gap is already eating
         if (Modules.get().get(AutoGap.class).isEating()) return;
 
+        if (mc.options.useKey.isPressed()) return;
+
         if (eating) {
             // If we are eating check if we should still be still eating
             if (shouldEat()) {
@@ -188,6 +190,7 @@ public class AutoEat extends Module {
     private void eat() {
         changeSlot(slot);
         setPressed(true);
+        if(eating == false) setPressed(false);
         if (!mc.player.isUsingItem()) Utils.rightClick();
 
         eating = true;


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

made it so if you are holding up shield, autoeat triggers after you drop it. fixed the bug that made your shield stay up instead of eating

## Related issues

#4203 

# How Has This Been Tested?

request video if needed

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
