### PR TITLE
fix bookbot text wrapping

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BookBot.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BookBot.java
@@ -275,6 +275,8 @@ public class BookBot extends Module {
                     lineIndex++;
                     // Wrap to next line, unless wrapping to next page
                     if (lineIndex != 14) page.appendCodePoint(c);
+                } else if (lineWidth == 0f && c == ' ') {
+                    continue; // Prevent leading space from text wrapping
                 } else {
                     lineWidth += charWidth;
                     page.appendCodePoint(c);


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

Old behaviour would consume a character when changing lines.
This fix also has the side effect of allowing bookbot to write on the last line of the pages, which was not allowed beforehand.

Example taken from Discord with test input `1 The book of the lineage of Jesus Christ, the son of David, the son of Abraham`
![image](https://github.com/MeteorDevelopment/meteor-client/assets/32882447/1bb05de3-89e3-4e5f-9a81-ed0d94f37cca)

# How Has This Been Tested?

![2023-11-28_22 21 06](https://github.com/MeteorDevelopment/meteor-client/assets/32882447/ebd079e9-9860-4c72-b863-2411deebfef7)

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
