### PR TITLE
prevent crash on book copy

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/BookScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/BookScreenMixin.java
@@ -8,6 +8,7 @@ package meteordevelopment.meteorclient.mixin;
 import it.unimi.dsi.fastutil.io.FastByteArrayOutputStream;
 import meteordevelopment.meteorclient.gui.GuiThemes;
 import meteordevelopment.meteorclient.gui.screens.EditBookTitleAndAuthorScreen;
+import meteordevelopment.meteorclient.utils.player.ChatUtils;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ingame.BookScreen;
 import net.minecraft.client.gui.widget.ButtonWidget;
@@ -20,6 +21,8 @@ import net.minecraft.nbt.NbtString;
 import net.minecraft.text.Text;
 import net.minecraft.util.Hand;
 import org.lwjgl.glfw.GLFW;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.system.MemoryUtil;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -63,7 +66,17 @@ public class BookScreenMixin extends Screen {
                         e.printStackTrace();
                     }
 
-                    GLFW.glfwSetClipboardString(mc.getWindow().getHandle(), Base64.getEncoder().encodeToString(bytes.array));
+                    String encoded = Base64.getEncoder().encodeToString(bytes.array);
+                    
+                    @SuppressWarnings("resource")
+                    long available = MemoryStack.stackGet().getPointer();
+                    long size = MemoryUtil.memLengthUTF8(encoded, true);
+
+                    if (size > available) {
+                        ChatUtils.error("Could not copy to clipboard: Out of memory.");
+                    } else {
+                        GLFW.glfwSetClipboardString(mc.getWindow().getHandle(), encoded);
+                    }
                 })
                 .position(4, 4)
                 .size(120, 20)


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

If the encoded text size is bigger than the LWJGL buffer, output an error in chat instead of crashing.

## Related issues

closes #1715 

# How Has This Been Tested?

![2023-11-28_22 47 54](https://github.com/MeteorDevelopment/meteor-client/assets/32882447/29984acd-8f26-462a-9013-c97636d2a8d3)

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
