### PR TITLE
optimize player head texture upload

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/FriendsTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/FriendsTab.java
@@ -86,7 +86,7 @@ public class FriendsTab extends Tab {
             );
 
             for (Friend friend : Friends.get()) {
-                table.add(theme.texture(32, 32, friend.getHead().needsRotate() ? 90 : 0, friend.getHead()));
+                table.add(theme.texture(32, 32, 0, friend.getHead()));
                 table.add(theme.label(friend.getName()));
 
                 WMinus remove = table.add(theme.minus()).expandCellX().right().widget();

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/WAccount.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/WAccount.java
@@ -33,7 +33,7 @@ public abstract class WAccount extends WHorizontalList {
     @Override
     public void init() {
         // Head
-        add(theme.texture(32, 32, account.getCache().getHeadTexture().needsRotate() ? 90 : 0, account.getCache().getHeadTexture()));
+        add(theme.texture(32, 32, 0, account.getCache().getHeadTexture()));
 
         // Name
         WLabel name = add(theme.label(account.getUsername())).widget();

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/PlayerHeadTexture.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/PlayerHeadTexture.java
@@ -20,8 +20,6 @@ import java.nio.IntBuffer;
 import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class PlayerHeadTexture extends Texture {
-    private boolean needsRotate;
-
     public PlayerHeadTexture(String url) {
         BufferedImage skin;
         try {
@@ -32,38 +30,33 @@ public class PlayerHeadTexture extends Texture {
         }
 
         byte[] head = new byte[8 * 8 * 3];
-        int[] pixel = new int[4];
+        int[] pixels = new int[8 * 8 * 4];
 
-        int i = 0;
-        for (int x = 8; x < 16; x++) {
-            for (int y = 8; y < 16; y++) {
-                skin.getData().getPixel(x, y, pixel);
+        skin.getData().getPixels(8, 8, 8, 8, pixels);
 
-                for (int j = 0; j < 3; j++) {
-                    head[i] = (byte) pixel[j];
-                    i++;
-                }
-            }
+        for (int i = 0; i < 8 * 8; i++) {
+            int inputIndex = i * 4;
+            int outputIndex = i * 3;
+
+            head[outputIndex] = (byte) pixels[inputIndex];
+            head[outputIndex + 1] = (byte) pixels[inputIndex + 1];
+            head[outputIndex + 2] = (byte) pixels[inputIndex + 2];
         }
 
-        i = 0;
-        for (int x = 40; x < 48; x++) {
-            for (int y = 8; y < 16; y++) {
-                skin.getData().getPixel(x, y, pixel);
+        skin.getData().getPixels(40, 8, 8, 8, pixels);
 
-                if (pixel[3] != 0) {
-                    for (int j = 0; j < 3; j++) {
-                        head[i] = (byte) pixel[j];
-                        i++;
-                    }
-                }
-                else i += 3;
+        for (int i = 0; i < 8 * 8; i++) {
+            int inputIndex = i * 4;
+            int outputIndex = i * 3;
+
+            if (pixels[inputIndex + 3] != 0) {
+                head[outputIndex] = (byte) pixels[inputIndex];
+                head[outputIndex + 1] = (byte) pixels[inputIndex + 1];
+                head[outputIndex + 2] = (byte) pixels[inputIndex + 2];
             }
         }
 
         upload(BufferUtils.createByteBuffer(head.length).put(head));
-
-        needsRotate = true;
     }
 
     public PlayerHeadTexture() {
@@ -91,9 +84,5 @@ public class PlayerHeadTexture extends Texture {
         Runnable action = () -> upload(8, 8, data, Texture.Format.RGB, Texture.Filter.Nearest, Texture.Filter.Nearest, false);
         if (RenderSystem.isOnRenderThread()) action.run();
         else RenderSystem.recordRenderCall(action::run);
-    }
-
-    public boolean needsRotate() {
-        return needsRotate;
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/postprocess/ChamsShader.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/postprocess/ChamsShader.java
@@ -18,6 +18,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.resource.Resource;
 import org.lwjgl.stb.STBImage;
 import org.lwjgl.system.MemoryStack;
+import org.lwjgl.system.MemoryUtil;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -67,6 +68,8 @@ public class ChamsShader extends EntityShader {
                 STBImage.stbi_image_free(image);
                 STBImage.stbi_set_flip_vertically_on_load(false);
             }
+
+            MemoryUtil.memFree(data);
         }
         catch (IOException e) {
             e.printStackTrace();


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

- make player head texture upload faster
- remove `needsUpdate` field by making the rotation correct
- free chams shader image from memory after upload (lol free 0.5 MB of memory)

# How Has This Been Tested?

Videos or screenshots of the changes if applicable.

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
