### PR TITLE
Make chest swap close inventory because anticheats

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/ChestSwap.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/ChestSwap.java
@@ -17,6 +17,7 @@ import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.item.ArmorItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.Items;
+import net.minecraft.network.packet.c2s.play.CloseHandledScreenC2SPacket;
 
 public class ChestSwap extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
@@ -31,6 +32,13 @@ public class ChestSwap extends Module {
     private final Setting<Boolean> stayOn = sgGeneral.add(new BoolSetting.Builder()
         .name("stay-on")
         .description("Stays on and activates when you turn it off.")
+        .defaultValue(false)
+        .build()
+    );
+
+    private final Setting<Boolean> closeInventory = sgGeneral.add(new BoolSetting.Builder()
+        .name("close-inventory")
+        .description("Sends inventory close after swap.")
         .defaultValue(false)
         .build()
     );
@@ -120,6 +128,10 @@ public class ChestSwap extends Module {
 
     private void equip(int slot) {
         InvUtils.move().from(slot).toArmor(2);
+        if (closeInventory.get()) {
+            // Notchian clients send a Close Window packet with Window ID 0 to close their inventory even though there is never an Open Screen packet for the inventory.
+            mc.getNetworkHandler().sendPacket(new CloseHandledScreenC2SPacket(0));
+        }
     }
 
     @Override


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

On some servers anticheat does not allow attacking entities if you moved inventory without closing inventory first.

# How Has This Been Tested?

On latest meteor dev and then with build from unstaged changes, seems like with option enabled anticheat does not block attacks anymore.
Tested on constantiam.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.