### PR TITLE
Sort favorites

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/ModulesScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/ModulesScreen.java
@@ -164,16 +164,21 @@ public class ModulesScreen extends TabScreen {
     }
 
     protected boolean createFavoritesW(WWindow w) {
-        boolean hasFavorites = false;
+        List<Module> modules = new ArrayList<>();
 
         for (Module module : Modules.get().getAll()) {
             if (module.favorite) {
-                w.add(theme.module(module)).expandX();
-                hasFavorites = true;
+                modules.add(module);
             }
         }
 
-        return hasFavorites;
+        modules.sort((o1, o2) -> String.CASE_INSENSITIVE_ORDER.compare(o1.name, o2.name));
+
+        for (Module module : modules) {
+            w.add(theme.module(module)).expandX();
+        }
+
+        return !modules.isEmpty();
     }
 
     @Override


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

All categories have modules sorted by name but favorites were not sorted at all (resulting in arbitrary order).

## Related issues

No one reported it but it bothers me a lot.

# How Has This Been Tested?

Looks pretty sorted to me 
![image](https://github.com/MeteorDevelopment/meteor-client/assets/20772987/269c33ae-71d7-42f1-a9d9-8cc29f0f271a)

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
