### PR TITLE
GuiMove improvements

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/ScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ScreenMixin.java
@@ -9,6 +9,7 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import meteordevelopment.meteorclient.commands.Commands;
 import meteordevelopment.meteorclient.systems.config.Config;
 import meteordevelopment.meteorclient.systems.modules.Modules;
+import meteordevelopment.meteorclient.systems.modules.movement.GUIMove;
 import meteordevelopment.meteorclient.systems.modules.render.NoRender;
 import meteordevelopment.meteorclient.utils.Utils;
 import net.minecraft.client.gui.screen.Screen;
@@ -18,6 +19,10 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.List;
+
+import static net.minecraft.client.util.InputUtil.*;
 
 @Mixin(value = Screen.class, priority = 500) // needs to be before baritone
 public abstract class ScreenMixin {
@@ -36,6 +41,15 @@ public abstract class ScreenMixin {
             } catch (CommandSyntaxException e) {
                 e.printStackTrace();
             }
+        }
+    }
+
+    @Inject(method = "keyPressed", at = @At("HEAD"), cancellable = true)
+    private void onKeyPressed(int keyCode, int scanCode, int modifiers, CallbackInfoReturnable<Boolean> info) {
+        GUIMove guiMove = Modules.get().get(GUIMove.class);
+        List<Integer> arrows = List.of(GLFW_KEY_RIGHT, GLFW_KEY_LEFT, GLFW_KEY_DOWN,  GLFW_KEY_UP);
+        if ((guiMove.disableArrows() && arrows.contains(keyCode)) || (guiMove.disableSpace() && keyCode == GLFW_KEY_SPACE)) {
+            info.cancel();
         }
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ScreenMixin.java
@@ -12,6 +12,7 @@ import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.movement.GUIMove;
 import meteordevelopment.meteorclient.systems.modules.render.NoRender;
 import meteordevelopment.meteorclient.utils.Utils;
+import net.minecraft.client.gui.screen.ChatScreen;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.text.Style;
 import org.spongepowered.asm.mixin.Mixin;
@@ -46,6 +47,7 @@ public abstract class ScreenMixin {
 
     @Inject(method = "keyPressed", at = @At("HEAD"), cancellable = true)
     private void onKeyPressed(int keyCode, int scanCode, int modifiers, CallbackInfoReturnable<Boolean> info) {
+        if ((Object) (this) instanceof ChatScreen) return;
         GUIMove guiMove = Modules.get().get(GUIMove.class);
         List<Integer> arrows = List.of(GLFW_KEY_RIGHT, GLFW_KEY_LEFT, GLFW_KEY_DOWN,  GLFW_KEY_UP);
         if ((guiMove.disableArrows() && arrows.contains(keyCode)) || (guiMove.disableSpace() && keyCode == GLFW_KEY_SPACE)) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/GUIMove.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/GUIMove.java
@@ -87,9 +87,7 @@ public class GUIMove extends Module {
         .min(0)
         .build()
     );
-
-    long lastRotateTime = System.currentTimeMillis();
-
+    
     public GUIMove() {
         super(Categories.Movement, "gui-move", "Allows you to perform various actions while in GUIs.");
     }
@@ -136,12 +134,7 @@ public class GUIMove extends Module {
         if (screens.get() == Screens.GUI && !(mc.currentScreen instanceof WidgetScreen)) return;
         if (screens.get() == Screens.Inventory && mc.currentScreen instanceof WidgetScreen) return;
 
-        // Intervals between calls of Render3DEvent are not constant, so it is necessary to calculate the time difference between the last tick and the current tick
-        long time = System.currentTimeMillis();
-        long timeDelta = time - lastRotateTime;
-        lastRotateTime = time;
-
-        float rotationDelta = Math.min((float) (rotateSpeed.get() * timeDelta / 50f), 100);
+        float rotationDelta = Math.min((float) (rotateSpeed.get() * event.frameTime * 20f), 100);
 
         if (arrowsRotate.get()) {
             float yaw = mc.player.getYaw();

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/GUIMove.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/GUIMove.java
@@ -106,6 +106,13 @@ public class GUIMove extends Module {
         if (sprint.get()) set(mc.options.sprintKey, false);
     }
 
+    public boolean disableSpace() {
+        return isActive() && jump.get() && mc.options.jumpKey.isDefault();
+    }
+    public boolean disableArrows() {
+        return isActive() && arrowsRotate.get();
+    }
+
     @EventHandler
     private void onTick(TickEvent.Pre event) {
         if (skip()) return;


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Rotations inside GUIs (from GuiMove) are only done every tick, which produces a jerky effect.

https://github.com/MeteorDevelopment/meteor-client/assets/63475640/6ba15029-19a0-4048-942a-c69e9d3e41e1

This PR passes this functionality to Render3DEvent, resulting in a much smoother rendering.

https://github.com/MeteorDevelopment/meteor-client/assets/63475640/3c8c2264-f90f-4498-8bfb-b675e596da88

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
