### PR TITLE
Add Disconnect command

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/commands/Commands.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/Commands.java
@@ -29,6 +29,7 @@ public class Commands {
         add(new VClipCommand());
         add(new HClipCommand());
         add(new DismountCommand());
+        add(new DisconnectCommand());
         add(new DamageCommand());
         add(new DropCommand());
         add(new EnchantCommand());

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/DisconnectCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/DisconnectCommand.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.commands.commands;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import meteordevelopment.meteorclient.commands.Command;
+import net.minecraft.client.gui.screen.DisconnectedScreen;
+import net.minecraft.command.CommandSource;
+import net.minecraft.network.packet.s2c.common.DisconnectS2CPacket;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+
+import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
+import static meteordevelopment.meteorclient.MeteorClient.mc;
+
+public class DisconnectCommand extends Command {
+    public DisconnectCommand() {
+        super("disconnect", "Disconnect from the server", "dc");
+    }
+
+    @Override
+    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+        builder.executes(context -> {
+            mc.player.networkHandler.onDisconnect(new DisconnectS2CPacket(Text.literal("%s[%sDisconnectCommand%s] Disconnected by user.".formatted(Formatting.GRAY, Formatting.BLUE, Formatting.GRAY))));
+            return SINGLE_SUCCESS;
+        });
+
+        builder.then(argument("reason", StringArgumentType.greedyString()).executes(context -> {
+            mc.player.networkHandler.onDisconnect(new DisconnectS2CPacket(Text.literal(StringArgumentType.getString(context, "reason"))));
+            return SINGLE_SUCCESS;
+        }));
+    }
+}


### PR DESCRIPTION
Allows users to disconnect from a server, and specify a `reason` message too.

## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Allows users to disconnect from a server, and specify a `reason` message too.

## Related issues

None.

# How Has This Been Tested?

Singple player and server testing.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
