### PR TITLE
Changed tag name from "Effects" to "effects"

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BetterTooltips.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BetterTooltips.java
@@ -229,7 +229,7 @@ public class BetterTooltips extends Module {
                 NbtCompound tag = event.itemStack.getNbt();
 
                 if (tag != null) {
-                    NbtList effects = tag.getList("Effects", 10);
+                    NbtList effects = tag.getList("effects", 10);
 
                     if (effects != null) {
                         for (int i = 0; i < effects.size(); i++) {


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

BetterTooltips will try to get a tag with the name "Effects" (capitalized), which in returns null. The correct name of the tag is "effects" (lowercase)


# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
