### PR TITLE
Fix #4272

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Freecam.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Freecam.java
@@ -335,7 +335,7 @@ public class Freecam extends Module {
 
     @EventHandler(priority = EventPriority.LOW)
     private void onMouseScroll(MouseScrollEvent event) {
-        if (speedScrollSensitivity.get() > 0) {
+        if (speedScrollSensitivity.get() > 0 && mc.currentScreen == null) {
             speedValue += event.value * 0.25 * (speedScrollSensitivity.get() * speedValue);
             if (speedValue < 0.1) speedValue = 0.1;
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Freecam.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Freecam.java
@@ -5,7 +5,6 @@
 
 package meteordevelopment.meteorclient.systems.modules.render;
 
-import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.events.entity.DamageEvent;
 import meteordevelopment.meteorclient.events.game.GameLeftEvent;
 import meteordevelopment.meteorclient.events.game.OpenScreenEvent;
@@ -336,7 +335,7 @@ public class Freecam extends Module {
 
     @EventHandler(priority = EventPriority.LOW)
     private void onMouseScroll(MouseScrollEvent event) {
-        if (speedScrollSensitivity.get() > 0 && mc.currentScreen == null) {
+        if (speedScrollSensitivity.get() > 0) {
             speedValue += event.value * 0.25 * (speedScrollSensitivity.get() * speedValue);
             if (speedValue < 0.1) speedValue = 0.1;
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Freecam.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Freecam.java
@@ -5,6 +5,7 @@
 
 package meteordevelopment.meteorclient.systems.modules.render;
 
+import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.events.entity.DamageEvent;
 import meteordevelopment.meteorclient.events.game.GameLeftEvent;
 import meteordevelopment.meteorclient.events.game.OpenScreenEvent;
@@ -335,7 +336,7 @@ public class Freecam extends Module {
 
     @EventHandler(priority = EventPriority.LOW)
     private void onMouseScroll(MouseScrollEvent event) {
-        if (speedScrollSensitivity.get() > 0) {
+        if (speedScrollSensitivity.get() > 0 && mc.currentScreen == null) {
             speedValue += event.value * 0.25 * (speedScrollSensitivity.get() * speedValue);
             if (speedValue < 0.1) speedValue = 0.1;
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

A summary of the changes along with the reasoning behind the changes.
Adds in a simple check in freecam to only stop scrolling if your screen is in game.

## Related issues
#4272

Mention any issues that this pr relates to.

# How Has This Been Tested?
Works perfectly, I am now able to scroll in GUIs no problem, and in Freecam, I can still scroll speed normally.

Videos or screenshots of the changes if applicable.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
