### PR TITLE
Freecam improvements

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Freecam.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Freecam.java
@@ -144,15 +144,20 @@ public class Freecam extends Module {
         Utils.set(pos, mc.gameRenderer.getCamera().getPos());
         Utils.set(prevPos, mc.gameRenderer.getCamera().getPos());
 
+        if (mc.options.getPerspective() == Perspective.THIRD_PERSON_FRONT) {
+            yaw += 180;
+            pitch *= -1;
+        }
+
         prevYaw = yaw;
         prevPitch = pitch;
 
-        forward = false;
-        backward = false;
-        right = false;
-        left = false;
-        up = false;
-        down = false;
+        forward = mc.options.forwardKey.isPressed();
+        backward = mc.options.backKey.isPressed();
+        right = mc.options.rightKey.isPressed();
+        left = mc.options.leftKey.isPressed();
+        up = mc.options.jumpKey.isPressed();
+        down = mc.options.sneakKey.isPressed();
 
         unpress();
         if (reloadChunks.get()) mc.worldRenderer.reload();


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

- Fix where the user cannot keep the directional keys pressed while activating Freecam.
- Fix where the camera direction is reversed when the player activates Freecam while being in third person front (double f5).

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
