### PR TITLE
Jesus improvements

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/EntityMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/EntityMixin.java
@@ -13,10 +13,7 @@ import meteordevelopment.meteorclient.events.entity.player.JumpVelocityMultiplie
 import meteordevelopment.meteorclient.events.entity.player.PlayerMoveEvent;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.combat.Hitboxes;
-import meteordevelopment.meteorclient.systems.modules.movement.Flight;
-import meteordevelopment.meteorclient.systems.modules.movement.NoFall;
-import meteordevelopment.meteorclient.systems.modules.movement.NoSlow;
-import meteordevelopment.meteorclient.systems.modules.movement.Velocity;
+import meteordevelopment.meteorclient.systems.modules.movement.*;
 import meteordevelopment.meteorclient.systems.modules.movement.elytrafly.ElytraFly;
 import meteordevelopment.meteorclient.systems.modules.render.ESP;
 import meteordevelopment.meteorclient.systems.modules.render.NoRender;
@@ -67,6 +64,22 @@ public abstract class EntityMixin {
     private void isInLava(CallbackInfoReturnable<Boolean> info) {
         if ((Object) this == mc.player && Modules.get().get(Flight.class).isActive()) info.setReturnValue(false);
         if ((Object) this == mc.player && Modules.get().get(NoSlow.class).fluidDrag()) info.setReturnValue(false);
+    }
+
+    @Inject(method = "onBubbleColumnSurfaceCollision", at = @At("HEAD"))
+    private void onBubbleColumnSurfaceCollision(CallbackInfo info) {
+        Jesus jesus = Modules.get().get(Jesus.class);
+        if ((Object) this == mc.player && jesus.isActive()) {
+            jesus.isInBubbleColumn = true;
+        }
+    }
+
+    @Inject(method = "onBubbleColumnCollision", at = @At("HEAD"))
+    private void onBubbleColumnCollision(CallbackInfo info) {
+        Jesus jesus = Modules.get().get(Jesus.class);
+        if ((Object) this == mc.player && jesus.isActive()) {
+            jesus.isInBubbleColumn = true;
+        }
     }
 
     @ModifyExpressionValue(method = "updateSwimming", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;isSubmergedInWater()Z"))

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Jesus.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Jesus.java
@@ -150,6 +150,8 @@ public class Jesus extends Module {
     private boolean prePathManagerWalkOnWater;
     private boolean prePathManagerWalkOnLava;
 
+    public boolean isInBubbleColumn = false;
+
     public Jesus() {
         super(Categories.Movement, "jesus", "Walk on liquids and powder snow like Jesus.");
     }
@@ -171,6 +173,9 @@ public class Jesus extends Module {
 
     @EventHandler
     private void onTick(TickEvent.Post event) {
+        boolean bubbleColumn = isInBubbleColumn;
+        isInBubbleColumn = false;
+
         if ((waterMode.get() == Mode.Bob && mc.player.isTouchingWater()) || (lavaMode.get() == Mode.Bob && mc.player.isInLava())) {
             double fluidHeight;
             if (mc.player.isInLava()) fluidHeight = mc.player.getFluidHeight(FluidTags.LAVA);
@@ -193,7 +198,7 @@ public class Jesus extends Module {
         if (mc.player.isInLava() && !lavaShouldBeSolid()) return;
 
         // Move up in bubble columns
-        if (isTouchingBubbleColumn()) {
+        if (bubbleColumn) {
             if (mc.options.jumpKey.isPressed() && mc.player.getVelocity().getY() < 0.11) ((IVec3d) mc.player.getVelocity()).setY(0.11);
             return;
         }
@@ -341,31 +346,6 @@ public class Jesus extends Module {
         }
 
         return foundLiquid && !foundSolid;
-    }
-
-
-    private boolean isTouchingBubbleColumn() {
-        // Get the bounding box of the player, it's necessary to slightly to avoid false positives
-        Box box = mc.player.getBoundingBox().contract(0.001);
-
-        double xStep = (box.maxX - box.minX) / 2;
-        double yStep = (box.maxY - box.minY) / 2;
-        double zStep = (box.maxZ - box.minZ) / 2;
-
-        // Scans all corners and in mid-edges positions and checks whether the block is a bubble column or not
-        for (int x = 0; x < 3; x++) {
-            for (int y = 0; y < 3; y++) {
-                for (int z = 0; z < 3; z++) {
-                    BlockPos blockPos = new BlockPos((int) Math.floor(box.minX + xStep * x), (int) Math.floor(box.minY + yStep * y), (int) Math.floor(box.minZ + zStep * z));
-                    BlockState blockState = mc.world.getBlockState(blockPos);
-                    if (blockState.getBlock() == Blocks.BUBBLE_COLUMN) {
-                        return true;
-                    }
-                }
-            }
-        }
-
-        return false;
     }
 
     public enum Mode {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

This pull request brings the following modifications to the Jesus module:

- Disables the behavior where a player surfaces while swimming
- Fixes the issue where the player wasn't being pulled by bubble columns (but still allows upward swimming in magma block bubble columns)
- Resolves the problem where the player couldn't jump out of water while in a current
- Addresses the issue where the player couldn't enter water from the side

# How Has This Been Tested?
In water, lava, snow powder, bubble columns and waterlogged blocks with both solid and bob mode

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
