### PR TITLE
Allow any characters in cracked names

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/accounts/AddCrackedAccountScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/accounts/AddCrackedAccountScreen.java
@@ -32,7 +32,7 @@ public class AddCrackedAccountScreen extends AddAccountScreen {
         // Add
         add = t.add(theme.button("Add")).expandX().widget();
         add.action = () -> {
-            if (!name.get().isEmpty() && (name.get().length() < 17) && name.get().matches("^[a-zA-Z0-9_]+$")) {
+            if (!name.get().isEmpty() && name.get().length() < 17) {
                 CrackedAccount account = new CrackedAccount(name.get());
                 if (!(Accounts.get().exists(account))) {
                     AccountsScreen.addAccount(this, parent, account);


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [X] New feature

## Description
Cracked account names only allow upper-case, lower-case and underscores. 
While real Minecraft accounts follow this pattern, you can actually have any characters in the name and a vanilla server doesn't care. 
The only software that I'm aware of that checks player names would be Paper (and they even allow dots).
There is no reason to block all other names.

## Related issues
[#12733](https://github.com/meteor/meteor/issues/12733) (posted in the wrong repo)
