### PR TITLE
Add no-sneak setting to Flight

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayerEntityMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayerEntityMixin.java
@@ -12,10 +12,7 @@ import meteordevelopment.meteorclient.events.entity.DamageEvent;
 import meteordevelopment.meteorclient.events.entity.DropItemsEvent;
 import meteordevelopment.meteorclient.events.entity.player.SendMovementPacketsEvent;
 import meteordevelopment.meteorclient.systems.modules.Modules;
-import meteordevelopment.meteorclient.systems.modules.movement.NoSlow;
-import meteordevelopment.meteorclient.systems.modules.movement.Scaffold;
-import meteordevelopment.meteorclient.systems.modules.movement.Sneak;
-import meteordevelopment.meteorclient.systems.modules.movement.Velocity;
+import meteordevelopment.meteorclient.systems.modules.movement.*;
 import meteordevelopment.meteorclient.systems.modules.player.Portals;
 import meteordevelopment.meteorclient.utils.Utils;
 import net.minecraft.client.MinecraftClient;
@@ -55,6 +52,7 @@ public abstract class ClientPlayerEntityMixin extends AbstractClientPlayerEntity
     @Inject(method = "isSneaking", at = @At("HEAD"), cancellable = true)
     private void onIsSneaking(CallbackInfoReturnable<Boolean> info) {
         if (Modules.get().get(Scaffold.class).scaffolding()) info.setReturnValue(false);
+        if (Modules.get().get(Flight.class).noSneak()) info.setReturnValue(false);
     }
 
     @Inject(method = "shouldSlowDown", at = @At("HEAD"), cancellable = true)


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [x] New feature

## Description

Adds a 'no-sneak' setting to the Flight module, preventing the player from entering sneak mode while flying.
This notably helps prevent 'Player moved wrongly!' messages from appearing in the console when the player approaches the ground while in flight.


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
