### PR TITLE
Fix and improvement of the Scaffold module

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/PlayerEntityMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/PlayerEntityMixin.java
@@ -13,6 +13,7 @@ import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.movement.Anchor;
 import meteordevelopment.meteorclient.systems.modules.movement.Flight;
 import meteordevelopment.meteorclient.systems.modules.movement.NoSlow;
+import meteordevelopment.meteorclient.systems.modules.movement.Scaffold;
 import meteordevelopment.meteorclient.systems.modules.player.SpeedMine;
 import meteordevelopment.meteorclient.utils.world.BlockUtils;
 import net.minecraft.block.BlockState;
@@ -85,6 +86,7 @@ public abstract class PlayerEntityMixin extends LivingEntity {
 
         Anchor module = Modules.get().get(Anchor.class);
         if (module.isActive() && module.cancelJump) info.cancel();
+        else if (Modules.get().get(Scaffold.class).towering()) info.cancel();
     }
 
     @ModifyReturnValue(method = "getMovementSpeed", at = @At("RETURN"))

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Scaffold.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Scaffold.java
@@ -280,7 +280,8 @@ public class Scaffold extends Module {
 
     public boolean towering() {
         return isActive() && fastTower.get() && mc.options.jumpKey.isPressed() && !mc.options.sneakKey.isPressed() &&
-            (whileMoving.get() || (!mc.options.forwardKey.isPressed() && !mc.options.backKey.isPressed() && !mc.options.leftKey.isPressed() && !mc.options.rightKey.isPressed()));
+            (whileMoving.get() || (!mc.options.forwardKey.isPressed() && !mc.options.backKey.isPressed() && !mc.options.leftKey.isPressed() && !mc.options.rightKey.isPressed())) &&
+            (!onlyOnClick.get() || (onlyOnClick.get() && mc.options.useKey.isPressed()));
     }
 
     private boolean validItem(ItemStack itemStack, BlockPos pos) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Scaffold.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Scaffold.java
@@ -262,7 +262,7 @@ public class Scaffold extends Module {
             if (Streams.stream(mc.world.getBlockCollisions(mc.player, playerBox.offset(0, 1, 0))).toList().isEmpty() /*||
                 !Streams.stream(mc.world.getBlockCollisions(mc.player, playerBox.offset(0, -1, 0))).toList().isEmpty()*/) {
                 // If there is no block above the player: move the player up, so he can place another block
-                if (whileMoving.get() || (!mc.options.forwardKey.isPressed() && !mc.options.backKey.isPressed() && !mc.options.leftKey.isPressed() && !mc.options.rightKey.isPressed())) {
+                if (whileMoving.get() || !PlayerUtils.isMoving()) {
                     velocity = new Vec3d(velocity.x, 0.5, velocity.z);
                 }
                 mc.player.setVelocity(velocity);
@@ -280,7 +280,7 @@ public class Scaffold extends Module {
 
     public boolean towering() {
         return isActive() && fastTower.get() && mc.options.jumpKey.isPressed() && !mc.options.sneakKey.isPressed() &&
-            (whileMoving.get() || (!mc.options.forwardKey.isPressed() && !mc.options.backKey.isPressed() && !mc.options.leftKey.isPressed() && !mc.options.rightKey.isPressed())) &&
+            (whileMoving.get() || !PlayerUtils.isMoving()) &&
             (!onlyOnClick.get() || (onlyOnClick.get() && mc.options.useKey.isPressed()));
     }
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Scaffold.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Scaffold.java
@@ -259,8 +259,7 @@ public class Scaffold extends Module {
         if (fastTower.get() && mc.options.jumpKey.isPressed() && !mc.options.sneakKey.isPressed() && InvUtils.findInHotbar(itemStack -> validItem(itemStack, bp)).found()) {
             Vec3d velocity = mc.player.getVelocity();
             Box playerBox = mc.player.getBoundingBox();
-            if (Streams.stream(mc.world.getBlockCollisions(mc.player, playerBox.offset(0, 1, 0))).toList().isEmpty() /*||
-                !Streams.stream(mc.world.getBlockCollisions(mc.player, playerBox.offset(0, -1, 0))).toList().isEmpty()*/) {
+            if (Streams.stream(mc.world.getBlockCollisions(mc.player, playerBox.offset(0, 1, 0))).toList().isEmpty()) {
                 // If there is no block above the player: move the player up, so he can place another block
                 if (whileMoving.get() || !PlayerUtils.isMoving()) {
                     velocity = new Vec3d(velocity.x, 0.5, velocity.z);

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Scaffold.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Scaffold.java
@@ -266,7 +266,8 @@ public class Scaffold extends Module {
             place(bp);
         }
 
-        if (fastTower.get() && mc.options.jumpKey.isPressed() && !mc.options.sneakKey.isPressed() && InvUtils.findInHotbar(itemStack -> validItem(itemStack, bp)).found()) {
+        FindItemResult result = InvUtils.findInHotbar(itemStack -> validItem(itemStack, bp));
+        if (fastTower.get() && mc.options.jumpKey.isPressed() && !mc.options.sneakKey.isPressed() && result.found() && (autoSwitch.get() || result.getHand() != null)) {
             Vec3d velocity = mc.player.getVelocity();
             Box playerBox = mc.player.getBoundingBox();
             if (Streams.stream(mc.world.getBlockCollisions(mc.player, playerBox.offset(0, 1, 0))).toList().isEmpty()) {
@@ -288,8 +289,9 @@ public class Scaffold extends Module {
     }
 
     public boolean towering() {
+        FindItemResult result = InvUtils.findInHotbar(itemStack -> validItem(itemStack, bp));
         return scaffolding() && fastTower.get() && mc.options.jumpKey.isPressed() && !mc.options.sneakKey.isPressed() &&
-            (whileMoving.get() || !PlayerUtils.isMoving()) && InvUtils.findInHotbar(itemStack -> validItem(itemStack, bp)).found();
+            (whileMoving.get() || !PlayerUtils.isMoving()) && result.found() && (autoSwitch.get() || result.getHand() != null);
     }
 
     private boolean validItem(ItemStack itemStack, BlockPos pos) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Scaffold.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Scaffold.java
@@ -288,9 +288,8 @@ public class Scaffold extends Module {
     }
 
     public boolean towering() {
-        return isActive() && fastTower.get() && mc.options.jumpKey.isPressed() && !mc.options.sneakKey.isPressed() &&
-            (whileMoving.get() || !PlayerUtils.isMoving()) &&
-            (!onlyOnClick.get() || (onlyOnClick.get() && mc.options.useKey.isPressed()));
+        return scaffolding() && fastTower.get() && mc.options.jumpKey.isPressed() && !mc.options.sneakKey.isPressed() &&
+            (whileMoving.get() || !PlayerUtils.isMoving()) && InvUtils.findInHotbar(itemStack -> validItem(itemStack, bp)).found();
     }
 
     private boolean validItem(ItemStack itemStack, BlockPos pos) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Scaffold.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Scaffold.java
@@ -97,6 +97,16 @@ public class Scaffold extends Module {
         .build()
     );
 
+    private final Setting<Double> aheadDistance = sgGeneral.add(new DoubleSetting.Builder()
+        .name("ahead-distance")
+        .description("How far ahead to place blocks.")
+        .defaultValue(0)
+        .min(0)
+        .sliderMax(1)
+        .visible(() -> !airPlace.get())
+        .build()
+    );
+
     private final Setting<Double> placeRange = sgGeneral.add(new DoubleSetting.Builder()
         .name("closest-block-range")
         .description("How far can scaffold place blocks when you are in air.")
@@ -175,6 +185,13 @@ public class Scaffold extends Module {
             bp.set(vec.getX(), vec.getY(), vec.getZ());
         } else {
             Vec3d pos = mc.player.getPos();
+            if (aheadDistance.get() != 0 && !towering() && !mc.world.getBlockState(mc.player.getBlockPos().down()).getCollisionShape(mc.world, mc.player.getBlockPos()).isEmpty()) {
+                Vec3d dir = Vec3d.fromPolar(0, mc.player.getYaw()).multiply(aheadDistance.get(), 0, aheadDistance.get());
+                if (mc.options.forwardKey.isPressed()) pos = pos.add(dir.x, 0, dir.z);
+                if (mc.options.backKey.isPressed()) pos = pos.add(-dir.x, 0, -dir.z);
+                if (mc.options.leftKey.isPressed()) pos = pos.add(dir.z, 0, -dir.x);
+                if (mc.options.rightKey.isPressed()) pos = pos.add(-dir.z, 0, dir.x);
+            }
             bp.set(pos.x, vec.y, pos.z);
         }
         if (mc.options.sneakKey.isPressed() && !mc.options.jumpKey.isPressed() && mc.player.getY() + vec.y > -1) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Scaffold.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Scaffold.java
@@ -54,6 +54,16 @@ public class Scaffold extends Module {
         .build()
     );
 
+    private final Setting<Double> towerSpeed = sgGeneral.add(new DoubleSetting.Builder()
+        .name("tower-speed")
+        .description("The speed at which to tower.")
+        .defaultValue(0.5)
+        .min(0)
+        .sliderMax(1)
+        .visible(fastTower::get)
+        .build()
+    );
+
     private final Setting<Boolean> whileMoving = sgGeneral.add(new BoolSetting.Builder()
         .name("while-moving")
         .description("Allows you to tower while moving.")
@@ -262,7 +272,7 @@ public class Scaffold extends Module {
             if (Streams.stream(mc.world.getBlockCollisions(mc.player, playerBox.offset(0, 1, 0))).toList().isEmpty()) {
                 // If there is no block above the player: move the player up, so he can place another block
                 if (whileMoving.get() || !PlayerUtils.isMoving()) {
-                    velocity = new Vec3d(velocity.x, 0.5, velocity.z);
+                    velocity = new Vec3d(velocity.x, towerSpeed.get(), velocity.z);
                 }
                 mc.player.setVelocity(velocity);
             } else {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Scaffold.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Scaffold.java
@@ -256,7 +256,7 @@ public class Scaffold extends Module {
             place(bp);
         }
 
-        if (fastTower.get() && mc.options.jumpKey.isPressed() && !mc.options.sneakKey.isPressed()) {
+        if (fastTower.get() && mc.options.jumpKey.isPressed() && !mc.options.sneakKey.isPressed() && InvUtils.findInHotbar(itemStack -> validItem(itemStack, bp)).found()) {
             Vec3d velocity = mc.player.getVelocity();
             Box playerBox = mc.player.getBoundingBox();
             if (Streams.stream(mc.world.getBlockCollisions(mc.player, playerBox.offset(0, 1, 0))).toList().isEmpty() /*||

--- a/src/main/java/meteordevelopment/meteorclient/utils/world/BlockUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/world/BlockUtils.java
@@ -162,6 +162,33 @@ public class BlockUtils {
         return null;
     }
 
+    public static Direction getClosestPlaceSide(BlockPos blockPos) {
+        return getClosestPlaceSide(blockPos, mc.player.getEyePos());
+    }
+    public static Direction getClosestPlaceSide(BlockPos blockPos, Vec3d pos) {
+        Direction closestSide = null;
+        double closestDistance = Double.MAX_VALUE;
+
+        for (Direction side : Direction.values()) {
+            BlockPos neighbor = blockPos.offset(side);
+            BlockState state = mc.world.getBlockState(neighbor);
+
+            // Check if neighbour isn't empty
+            if (state.isAir() || isClickable(state.getBlock())) continue;
+
+            // Check if neighbour is a fluid
+            if (!state.getFluidState().isEmpty()) continue;
+
+            double distance = pos.squaredDistanceTo(neighbor.getX(), neighbor.getY(), neighbor.getZ());
+            if (distance < closestDistance) {
+                closestDistance = distance;
+                closestSide = side;
+            }
+        }
+
+        return closestSide;
+    }
+
     // Breaking
 
     @EventHandler(priority = EventPriority.HIGHEST + 100)


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [x] New feature

## Description

- Fixed an issue where the non-air-place mode would cause the player to fall when descending.
- Fixed a bug in the air-place mode.
- Improved the logic for placing blocks in the non-air-place mode.
- Enhanced the fast-tower functionality.
- Added the "ahead-distance" setting, which allows choosing the distance at which blocks are placed in front of the player (prevent falling in certain cases).

## Related issues
[[Bug] Scaffold does not work #3543](https://github.com/MeteorDevelopment/meteor-client/issues/3543)

# How Has This Been Tested?

:)
![2024-01-12_19 34 52](https://github.com/MeteorDevelopment/meteor-client/assets/63475640/16a95543-ce9f-4c5f-9254-935369868af7)

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
