### PR TITLE
singleton command arguments

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/CompoundNbtTagArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/CompoundNbtTagArgumentType.java
@@ -18,15 +18,18 @@ import java.util.Collection;
 import static net.minecraft.nbt.StringNbtReader.EXPECTED_VALUE;
 
 public class CompoundNbtTagArgumentType implements ArgumentType<NbtCompound> {
+    private static final CompoundNbtTagArgumentType INSTANCE = new CompoundNbtTagArgumentType();
     private static final Collection<String> EXAMPLES = Arrays.asList("{foo:bar}", "{foo:[aa, bb],bar:15}");
 
     public static CompoundNbtTagArgumentType create() {
-        return new CompoundNbtTagArgumentType();
+        return INSTANCE;
     }
 
     public static NbtCompound get(CommandContext<?> context) {
         return context.getArgument("nbt", NbtCompound.class);
     }
+
+    private CompoundNbtTagArgumentType() {}
 
     @Override
     public NbtCompound parse(StringReader reader) throws CommandSyntaxException {

--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/DirectionArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/DirectionArgumentType.java
@@ -9,11 +9,13 @@ import net.minecraft.command.argument.EnumArgumentType;
 import net.minecraft.util.math.Direction;
 
 public class DirectionArgumentType extends EnumArgumentType<Direction> {
+    private static final DirectionArgumentType INSTANCE = new DirectionArgumentType();
+
     private DirectionArgumentType() {
         super(Direction.CODEC, Direction::values);
     }
 
     public static DirectionArgumentType create() {
-        return new DirectionArgumentType();
+        return INSTANCE;
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/FakePlayerArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/FakePlayerArgumentType.java
@@ -21,15 +21,18 @@ import java.util.concurrent.CompletableFuture;
 import static net.minecraft.command.CommandSource.suggestMatching;
 
 public class FakePlayerArgumentType implements ArgumentType<String> {
+    private static final FakePlayerArgumentType INSTANCE = new FakePlayerArgumentType();
     private static final Collection<String> EXAMPLES = List.of("seasnail8169", "MineGame159");
 
     public static FakePlayerArgumentType create() {
-        return new FakePlayerArgumentType();
+        return INSTANCE;
     }
 
     public static FakePlayerEntity get(CommandContext<?> context) {
         return FakePlayerManager.get(context.getArgument("fp", String.class));
     }
+
+    private FakePlayerArgumentType() {}
 
     @Override
     public String parse(StringReader reader) throws CommandSyntaxException {

--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/FriendArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/FriendArgumentType.java
@@ -22,15 +22,18 @@ import java.util.concurrent.CompletableFuture;
 import static net.minecraft.command.CommandSource.suggestMatching;
 
 public class FriendArgumentType implements ArgumentType<String> {
+    private static final FriendArgumentType INSTANCE = new FriendArgumentType();
     private static final Collection<String> EXAMPLES = List.of("seasnail8169", "MineGame159");
 
     public static FriendArgumentType create() {
-        return new FriendArgumentType();
+        return INSTANCE;
     }
 
     public static Friend get(CommandContext<?> context) {
         return Friends.get().get(context.getArgument("friend", String.class));
     }
+
+    private FriendArgumentType() {}
 
     @Override
     public String parse(StringReader reader) throws CommandSyntaxException {

--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/MacroArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/MacroArgumentType.java
@@ -22,15 +22,18 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 public class MacroArgumentType implements ArgumentType<Macro> {
+    private static final MacroArgumentType INSTANCE = new MacroArgumentType();
     private static final DynamicCommandExceptionType NO_SUCH_MACRO = new DynamicCommandExceptionType(name -> Text.literal("Macro with name " + name + " doesn't exist."));
 
     public static MacroArgumentType create() {
-        return new MacroArgumentType();
+        return INSTANCE;
     }
 
     public static Macro get(CommandContext<?> context) {
         return context.getArgument("macro", Macro.class);
     }
+
+    private MacroArgumentType() {}
 
     @Override
     public Macro parse(StringReader reader) throws CommandSyntaxException {

--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/ModuleArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/ModuleArgumentType.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 public class ModuleArgumentType implements ArgumentType<Module> {
+    private static final ModuleArgumentType INSTANCE = new ModuleArgumentType();
     private static final DynamicCommandExceptionType NO_SUCH_MODULE = new DynamicCommandExceptionType(name -> Text.literal("Module with name " + name + " doesn't exist."));
 
     private static final Collection<String> EXAMPLES = Modules.get().getAll()
@@ -31,12 +32,14 @@ public class ModuleArgumentType implements ArgumentType<Module> {
             .collect(Collectors.toList());
 
     public static ModuleArgumentType create() {
-        return new ModuleArgumentType();
+        return INSTANCE;
     }
 
     public static Module get(CommandContext<?> context) {
         return context.getArgument("module", Module.class);
     }
+
+    private ModuleArgumentType() {}
 
     @Override
     public Module parse(StringReader reader) throws CommandSyntaxException {

--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/NotebotSongArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/NotebotSongArgumentType.java
@@ -21,9 +21,13 @@ import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
 
 public class NotebotSongArgumentType implements ArgumentType<Path> {
+    private static final NotebotSongArgumentType INSTANCE = new NotebotSongArgumentType();
+
     public static NotebotSongArgumentType create() {
-        return new NotebotSongArgumentType();
+        return INSTANCE;
     }
+
+    private NotebotSongArgumentType() {}
 
     @Override
     public Path parse(StringReader reader) throws CommandSyntaxException {

--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/PlayerArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/PlayerArgumentType.java
@@ -23,17 +23,20 @@ import java.util.concurrent.CompletableFuture;
 import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class PlayerArgumentType implements ArgumentType<PlayerEntity> {
+    private static final PlayerArgumentType INSTANCE = new PlayerArgumentType();
     private static final DynamicCommandExceptionType NO_SUCH_PLAYER = new DynamicCommandExceptionType(name -> Text.literal("Player with name " + name + " doesn't exist."));
 
     private static final Collection<String> EXAMPLES = List.of("seasnail8169", "MineGame159");
 
     public static PlayerArgumentType create() {
-        return new PlayerArgumentType();
+        return INSTANCE;
     }
 
     public static PlayerEntity get(CommandContext<?> context) {
         return context.getArgument("player", PlayerEntity.class);
     }
+
+    private PlayerArgumentType() {}
 
     @Override
     public PlayerEntity parse(StringReader reader) throws CommandSyntaxException {

--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/PlayerListEntryArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/PlayerListEntryArgumentType.java
@@ -23,17 +23,20 @@ import java.util.concurrent.CompletableFuture;
 import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class PlayerListEntryArgumentType implements ArgumentType<PlayerListEntry> {
+    private static final PlayerListEntryArgumentType INSTANCE = new PlayerListEntryArgumentType();
     private static final DynamicCommandExceptionType NO_SUCH_PLAYER = new DynamicCommandExceptionType(name -> Text.literal("Player list entry with name " + name + " doesn't exist."));
 
     private static final Collection<String> EXAMPLES = List.of("seasnail8169", "MineGame159");
 
     public static PlayerListEntryArgumentType create() {
-        return new PlayerListEntryArgumentType();
+        return INSTANCE;
     }
 
     public static PlayerListEntry get(CommandContext<?> context) {
         return context.getArgument("player", PlayerListEntry.class);
     }
+
+    private PlayerListEntryArgumentType() {}
 
     @Override
     public PlayerListEntry parse(StringReader reader) throws CommandSyntaxException {

--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/ProfileArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/ProfileArgumentType.java
@@ -24,17 +24,20 @@ import java.util.concurrent.CompletableFuture;
 import static net.minecraft.command.CommandSource.suggestMatching;
 
 public class ProfileArgumentType implements ArgumentType<String> {
+    private static final ProfileArgumentType INSTANCE = new ProfileArgumentType();
     private static final DynamicCommandExceptionType NO_SUCH_PROFILE = new DynamicCommandExceptionType(name -> Text.literal("Profile with name " + name + " doesn't exist."));
 
     private static final Collection<String> EXAMPLES = List.of("pvp.meteorclient.com", "anarchy");
 
     public static ProfileArgumentType create() {
-        return new ProfileArgumentType();
+        return INSTANCE;
     }
 
     public static Profile get(CommandContext<?> context) {
         return Profiles.get().get(context.getArgument("profile", String.class));
     }
+
+    private ProfileArgumentType() {}
 
     @Override
     public String parse(StringReader reader) throws CommandSyntaxException {

--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/SettingArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/SettingArgumentType.java
@@ -22,10 +22,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
 public class SettingArgumentType implements ArgumentType<String> {
+    private static final SettingArgumentType INSTANCE = new SettingArgumentType();
     private static final DynamicCommandExceptionType NO_SUCH_SETTING = new DynamicCommandExceptionType(name -> Text.literal("No such setting '" + name + "'."));
 
     public static SettingArgumentType create() {
-        return new SettingArgumentType();
+        return INSTANCE;
     }
 
     public static Setting<?> get(CommandContext<?> context) throws CommandSyntaxException {
@@ -37,6 +38,8 @@ public class SettingArgumentType implements ArgumentType<String> {
 
         return setting;
     }
+
+    private SettingArgumentType() {}
 
     @Override
     public String parse(StringReader reader) throws CommandSyntaxException {

--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/SettingValueArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/SettingValueArgumentType.java
@@ -18,13 +18,17 @@ import net.minecraft.util.Identifier;
 import java.util.concurrent.CompletableFuture;
 
 public class SettingValueArgumentType implements ArgumentType<String> {
+    private static final SettingValueArgumentType INSTANCE = new SettingValueArgumentType();
+
     public static SettingValueArgumentType create() {
-        return new SettingValueArgumentType();
+        return INSTANCE;
     }
 
     public static String get(CommandContext<?> context) {
         return context.getArgument("value", String.class);
     }
+
+    private SettingValueArgumentType() {}
 
     @Override
     public String parse(StringReader reader) throws CommandSyntaxException {

--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/WaypointArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/WaypointArgumentType.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 public class WaypointArgumentType implements ArgumentType<String> {
+    private static final WaypointArgumentType GREEDY = new WaypointArgumentType(true);
+    private static final WaypointArgumentType QUOTED = new WaypointArgumentType(false);
     private static final DynamicCommandExceptionType NO_SUCH_WAYPOINT = new DynamicCommandExceptionType(name -> Text.literal("Waypoint with name '" + name + "' doesn't exist."));
     private final boolean greedyString;
 
@@ -31,11 +33,11 @@ public class WaypointArgumentType implements ArgumentType<String> {
     }
 
     public static WaypointArgumentType create() {
-        return new WaypointArgumentType(true);
+        return GREEDY;
     }
 
     public static WaypointArgumentType create(boolean greedy) {
-        return new WaypointArgumentType(greedy);
+        return greedy ? GREEDY : QUOTED;
     }
 
     public static Waypoint get(CommandContext<?> context) {

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/NbtCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/NbtCommand.java
@@ -135,7 +135,7 @@ public class NbtCommand extends Command {
             ItemStack stack = mc.player.getInventory().getMainHandStack();
 
             if (validBasic(stack)) {
-                stack.setNbt(new CompoundNbtTagArgumentType().parse(new StringReader(mc.keyboard.getClipboard())));
+                stack.setNbt(CompoundNbtTagArgumentType.create().parse(new StringReader(mc.keyboard.getClipboard())));
                 setStack(stack);
             }
 


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

Since the command argument types are stateless, we can re-use singleton instances to lower memory usage a tiny bit.
(760 bytes to 376 bytes, profiled with regular meteor)

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
