### PR TITLE
Fix Notebot align center on a slab

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notebot.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notebot.java
@@ -571,7 +571,8 @@ public class Notebot extends Module {
         WButton alignCenter = table.add(theme.button("Align Center")).expandX().minWidth(100).widget();
         alignCenter.action = () -> {
             if (mc.player == null) return;
-            mc.player.setPosition(Vec3d.ofBottomCenter(mc.player.getBlockPos()));
+            Vec3d pos = Vec3d.ofBottomCenter(mc.player.getBlockPos());
+            mc.player.setPosition(pos.x, mc.player.getY(), pos.z);
         };
 
         table.row();


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Fix that the notebot's Align Center function doesn't work when the player is on a slab.