### PR TITLE
Extend range of characters rendered by the custom font renderer

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/renderer/text/Font.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/text/Font.java
@@ -39,7 +39,8 @@ public class Font {
             STBTTPackedchar.create(96), // Latin 1 Supplement
             STBTTPackedchar.create(128), // Latin Extended-A
             STBTTPackedchar.create(144), // Greek and Coptic
-            STBTTPackedchar.create(256) // Cyrillic
+            STBTTPackedchar.create(256), // Cyrillic
+            STBTTPackedchar.create(1) // infinity symbol
         };
 
         // create and initialise packing context
@@ -47,12 +48,13 @@ public class Font {
         STBTruetype.stbtt_PackBegin(packContext, bitmap, size, size, 0 ,1);
 
         // create the pack range, populate with the specific packing ranges
-        STBTTPackRange.Buffer packRange = STBTTPackRange.create(5);
+        STBTTPackRange.Buffer packRange = STBTTPackRange.create(cdata.length);
         packRange.put(STBTTPackRange.create().set(height, 32, null, 95, cdata[0], (byte) 2, (byte) 2));
         packRange.put(STBTTPackRange.create().set(height, 160, null, 96, cdata[1], (byte) 2, (byte) 2));
         packRange.put(STBTTPackRange.create().set(height, 256, null, 128, cdata[2], (byte) 2, (byte) 2));
         packRange.put(STBTTPackRange.create().set(height, 880, null, 144, cdata[3], (byte) 2, (byte) 2));
         packRange.put(STBTTPackRange.create().set(height, 1024, null, 256, cdata[4], (byte) 2, (byte) 2));
+        packRange.put(STBTTPackRange.create().set(height, 8734, null, 1, cdata[5], (byte) 2, (byte) 2)); // lol
         packRange.flip();
 
         // write and finish

--- a/src/main/java/meteordevelopment/meteorclient/renderer/text/Font.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/text/Font.java
@@ -5,15 +5,13 @@
 
 package meteordevelopment.meteorclient.renderer.text;
 
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import meteordevelopment.meteorclient.renderer.Mesh;
 import meteordevelopment.meteorclient.utils.render.ByteTexture;
 import meteordevelopment.meteorclient.utils.render.color.Color;
 import net.minecraft.client.texture.AbstractTexture;
 import org.lwjgl.BufferUtils;
-import org.lwjgl.stb.STBTTFontinfo;
-import org.lwjgl.stb.STBTTPackContext;
-import org.lwjgl.stb.STBTTPackedchar;
-import org.lwjgl.stb.STBTruetype;
+import org.lwjgl.stb.*;
 import org.lwjgl.system.MemoryStack;
 
 import java.nio.ByteBuffer;
@@ -21,11 +19,11 @@ import java.nio.IntBuffer;
 
 public class Font {
     public AbstractTexture texture;
-
     private final int height;
     private final float scale;
     private final float ascent;
-    private final CharData[] charData;
+    private final Int2ObjectOpenHashMap<CharData> charMap = new Int2ObjectOpenHashMap<>();
+    private final static int size = 2048;
 
     public Font(ByteBuffer buffer, int height) {
         this.height = height;
@@ -34,20 +32,35 @@ public class Font {
         STBTTFontinfo fontInfo = STBTTFontinfo.create();
         STBTruetype.stbtt_InitFont(fontInfo, buffer);
 
-        // Allocate STBTTPackedchar buffer
-        charData = new CharData[128];
-        STBTTPackedchar.Buffer cdata = STBTTPackedchar.create(charData.length);
-        ByteBuffer bitmap = BufferUtils.createByteBuffer(2048 * 2048);
+        // Allocate buffers
+        ByteBuffer bitmap = BufferUtils.createByteBuffer(size * size);
+        STBTTPackedchar.Buffer[] cdata = {
+            STBTTPackedchar.create(95), // Basic Latin
+            STBTTPackedchar.create(96), // Latin 1 Supplement
+            STBTTPackedchar.create(128), // Latin Extended-A
+            STBTTPackedchar.create(144), // Greek and Coptic
+            STBTTPackedchar.create(256) // Cyrillic
+        };
 
-        // Create font texture
+        // create and initialise packing context
         STBTTPackContext packContext = STBTTPackContext.create();
-        STBTruetype.stbtt_PackBegin(packContext, bitmap, 2048, 2048, 0, 1);
-        STBTruetype.stbtt_PackSetOversampling(packContext, 2, 2);
-        STBTruetype.stbtt_PackFontRange(packContext, buffer, 0, height, 32, cdata);
+        STBTruetype.stbtt_PackBegin(packContext, bitmap, size, size, 0 ,1);
+
+        // create the pack range, populate with the specific packing ranges
+        STBTTPackRange.Buffer packRange = STBTTPackRange.create(5);
+        packRange.put(STBTTPackRange.create().set(height, 32, null, 95, cdata[0], (byte) 2, (byte) 2));
+        packRange.put(STBTTPackRange.create().set(height, 160, null, 96, cdata[1], (byte) 2, (byte) 2));
+        packRange.put(STBTTPackRange.create().set(height, 256, null, 128, cdata[2], (byte) 2, (byte) 2));
+        packRange.put(STBTTPackRange.create().set(height, 880, null, 144, cdata[3], (byte) 2, (byte) 2));
+        packRange.put(STBTTPackRange.create().set(height, 1024, null, 256, cdata[4], (byte) 2, (byte) 2));
+        packRange.flip();
+
+        // write and finish
+        STBTruetype.stbtt_PackFontRanges(packContext, buffer, 0, packRange);
         STBTruetype.stbtt_PackEnd(packContext);
 
         // Create texture object and get font scale
-        texture = new ByteTexture(2048, 2048, bitmap, ByteTexture.Format.A, ByteTexture.Filter.Linear, ByteTexture.Filter.Linear);
+        texture = new ByteTexture(size, size, bitmap, ByteTexture.Format.A, ByteTexture.Filter.Linear, ByteTexture.Filter.Linear);
         scale = STBTruetype.stbtt_ScaleForPixelHeight(fontInfo, height);
 
         // Get font vertical ascent
@@ -57,14 +70,17 @@ public class Font {
             this.ascent = ascent.get(0);
         }
 
-        // Populate charData array
-        for (int i = 0; i < charData.length; i++) {
-            STBTTPackedchar packedChar = cdata.get(i);
+        for (int i = 0; i < cdata.length; i++) {
+            STBTTPackedchar.Buffer cbuf = cdata[i];
+            int offset = packRange.get(i).first_unicode_codepoint_in_range();
 
-            float ipw = 1f / 2048;
-            float iph = 1f / 2048;
+            for (int j = 0; j < cbuf.capacity(); j++) {
+                STBTTPackedchar packedChar = cbuf.get(j);
 
-            charData[i] = new CharData(
+                float ipw = 1f / size; // pixel width and height
+                float iph = 1f / size;
+
+                charMap.put(j + offset, new CharData(
                     packedChar.xoff(),
                     packedChar.yoff(),
                     packedChar.xoff2(),
@@ -74,7 +90,8 @@ public class Font {
                     packedChar.x1() * ipw,
                     packedChar.y1() * iph,
                     packedChar.xadvance()
-            );
+                ));
+            }
         }
     }
 
@@ -83,8 +100,7 @@ public class Font {
 
         for (int i = 0; i < length; i++) {
             int cp = string.charAt(i);
-            if (cp < 32 || cp > 128) cp = 32;
-            CharData c = charData[cp - 32];
+            CharData c = (charMap.containsKey(cp) ? charMap.get(cp) : charMap.get(32));
 
             width += c.xAdvance;
         }
@@ -101,8 +117,7 @@ public class Font {
 
         for (int i = 0; i < string.length(); i++) {
             int cp = string.charAt(i);
-            if (cp < 32 || cp > 128) cp = 32;
-            CharData c = charData[cp - 32];
+            CharData c = (charMap.containsKey(cp) ? charMap.get(cp) : charMap.get(32));
 
             mesh.quad(
                 mesh.vec2(x + c.x0 * scale, y + c.y0 * scale).vec2(c.u0, c.v0).color(color).next(),

--- a/src/main/java/meteordevelopment/meteorclient/renderer/text/Font.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/text/Font.java
@@ -102,7 +102,8 @@ public class Font {
 
         for (int i = 0; i < length; i++) {
             int cp = string.charAt(i);
-            CharData c = (charMap.containsKey(cp) ? charMap.get(cp) : charMap.get(32));
+            CharData c = charMap.get(cp);
+            if (c == null) c = charMap.get(32);
 
             width += c.xAdvance;
         }
@@ -119,7 +120,8 @@ public class Font {
 
         for (int i = 0; i < string.length(); i++) {
             int cp = string.charAt(i);
-            CharData c = (charMap.containsKey(cp) ? charMap.get(cp) : charMap.get(32));
+            CharData c = charMap.get(cp);
+            if (c == null) c = charMap.get(32);
 
             mesh.quad(
                 mesh.vec2(x + c.x0 * scale, y + c.y0 * scale).vec2(c.u0, c.v0).color(color).next(),

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PotionTimersHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PotionTimersHud.java
@@ -14,7 +14,7 @@ import meteordevelopment.meteorclient.utils.render.color.Color;
 import meteordevelopment.meteorclient.utils.render.color.SettingColor;
 import net.minecraft.entity.effect.StatusEffect;
 import net.minecraft.entity.effect.StatusEffectInstance;
-import net.minecraft.util.StringHelper;
+import net.minecraft.entity.effect.StatusEffectUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -241,7 +241,7 @@ public class PotionTimersHud extends HudElement {
     }
 
     private String getString(StatusEffectInstance statusEffectInstance) {
-        return String.format("%s %d (%s)", Names.get(statusEffectInstance.getEffectType()), statusEffectInstance.getAmplifier() + 1, statusEffectInstance.isInfinite() ? "inf" : StringHelper.formatTicks(statusEffectInstance.getDuration(), mc.world.getTickManager().getTickRate())); //todo remove "inf" when font rendering can use symbols
+        return String.format("%s %d (%s)", Names.get(statusEffectInstance.getEffectType()), statusEffectInstance.getAmplifier() + 1, StatusEffectUtil.getDurationText(statusEffectInstance, 1, mc.world.getTickManager().getTickRate()).getString());
     }
 
     private double getScale() {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature 🤷 

## Description

Increases the amount of characters rasterized and able to be rendered by the custom font renderer. Previously solely included [Basic Latin](https://en.wikipedia.org/wiki/List_of_Unicode_characters#Basic_Latin); now extended to support almost all common Latin based characters, as well as Cyrillic and Greek.

This isn't a perfect fix, as there are still many characters unable to be rendered. The eventual goal would likely be to dynamically rasterize characters as we encounter them instead of spending time creating them at startup.

The size of the texture atlas doesn't need to be increased, as even at the font's largest, there is still more than enough room (2048 x 2048 is huge).
![meteor_79786267498400_0](https://github.com/MeteorDevelopment/meteor-client/assets/74723656/0f0a3b03-aaec-40cf-98d6-f03d224d32f7)


## Related issues

Closes #3835 
Closes #2572 

# How Has This Been Tested?

![java_eih8DiuosF](https://github.com/MeteorDevelopment/meteor-client/assets/74723656/3c4e2381-f813-4cbe-9b58-91ea1ae92a35)
![java_HzycZRdUR6](https://github.com/MeteorDevelopment/meteor-client/assets/74723656/4eda6c51-3b26-417e-8098-725ecb66c240)

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
