### PR TITLE
Fix multiple key crash in StatusEffectBruteForce

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/utils/entity/effects/StatusEffectBruteForce.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/entity/effects/StatusEffectBruteForce.java
@@ -88,8 +88,8 @@ public class StatusEffectBruteForce {
         ALL_ENTRIES.add(StatusEffectEntry.of(StatusEffects.POISON, 2));
         ALL_ENTRIES.add(StatusEffectEntry.of(StatusEffects.WITHER, 1));
         ALL_ENTRIES.add(StatusEffectEntry.of(StatusEffects.HEALTH_BOOST, 1));
-        ALL_ENTRIES.add(StatusEffectEntry.of(StatusEffects.ABSORPTION, 1));
-        ALL_ENTRIES.add(StatusEffectEntry.of(StatusEffects.ABSORPTION, 4));
+        // ALL_ENTRIES.add(StatusEffectEntry.of(StatusEffects.ABSORPTION, 1));
+        // ALL_ENTRIES.add(StatusEffectEntry.of(StatusEffects.ABSORPTION, 4));
         ALL_ENTRIES.add(StatusEffectEntry.of(StatusEffects.GLOWING, 1));
         ALL_ENTRIES.add(StatusEffectEntry.of(StatusEffects.LEVITATION, 1));
         ALL_ENTRIES.add(StatusEffectEntry.of(StatusEffects.LUCK, 1));
@@ -151,8 +151,11 @@ public class StatusEffectBruteForce {
             int absorptionLevel = Math.round(entity.getAbsorptionAmount() / 4f);
             if (absorptionLevel <= 4) {
                 possibleEntries = new ReferenceOpenHashSet<>(ALL_ENTRIES);
-                possibleEntries.add(ABSORPTION_STRONG);
-                if (absorptionLevel <= 1) possibleEntries.add(ABSORPTION);
+                if (absorptionLevel <= 1) {
+                    possibleEntries.add(ABSORPTION);
+                } else {
+                    possibleEntries.add(ABSORPTION_STRONG);
+                }
             } else {
                 possibleEntries = ALL_ENTRIES;
             }


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

When brute-forcing effects, Absorption was always added to the set of possible effects, and then later added again when using the tracked data. This lead to a crash with an error along the lines of "java.lang.IllegalArgumentException: Multiple entries with same key", while using modules such as Crystal Aura. My changes make it so that only the tracked data code adds the Absorption to the list of all possible effects.

## Related issues

I think this is the related [issue](https://github.com/MeteorDevelopment/meteor-client/issues/4378).

# How Has This Been Tested?

Using the Crystal Aura in-game on a few servers and against other players.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
