### PR TITLE
Optimize status effect map setting

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/StatusEffectAmplifierMapSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/StatusEffectAmplifierMapSettingScreen.java
@@ -5,7 +5,7 @@
 
 package meteordevelopment.meteorclient.gui.screens.settings;
 
-import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Reference2IntMap;
 import meteordevelopment.meteorclient.gui.GuiTheme;
 import meteordevelopment.meteorclient.gui.WindowScreen;
 import meteordevelopment.meteorclient.gui.widgets.containers.WTable;
@@ -23,13 +23,13 @@ import java.util.Comparator;
 import java.util.List;
 
 public class StatusEffectAmplifierMapSettingScreen extends WindowScreen {
-    private final Setting<Object2IntMap<StatusEffect>> setting;
+    private final Setting<Reference2IntMap<StatusEffect>> setting;
 
     private WTable table;
 
     private String filterText = "";
 
-    public StatusEffectAmplifierMapSettingScreen(GuiTheme theme, Setting<Object2IntMap<StatusEffect>> setting) {
+    public StatusEffectAmplifierMapSettingScreen(GuiTheme theme, Setting<Reference2IntMap<StatusEffect>> setting) {
         super(theme, "Modify Amplifiers");
 
         this.setting = setting;

--- a/src/main/java/meteordevelopment/meteorclient/settings/StatusEffectAmplifierMapSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/StatusEffectAmplifierMapSetting.java
@@ -5,6 +5,7 @@
 
 package meteordevelopment.meteorclient.settings;
 
+import it.unimi.dsi.fastutil.objects.Reference2IntArrayMap;
 import it.unimi.dsi.fastutil.objects.Reference2IntMap;
 import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap;
 import net.minecraft.entity.effect.StatusEffect;
@@ -63,7 +64,7 @@ public class StatusEffectAmplifierMapSetting extends Setting<Reference2IntMap<St
     }
 
     private static Reference2IntMap<StatusEffect> createStatusEffectMap() {
-        Reference2IntMap<StatusEffect> map = new Reference2IntOpenHashMap<>(Registries.STATUS_EFFECT.getIds().size());
+        Reference2IntMap<StatusEffect> map = new Reference2IntArrayMap<>(Registries.STATUS_EFFECT.getIds().size());
 
         Registries.STATUS_EFFECT.forEach(potion -> map.put(potion, 0));
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/StatusEffectAmplifierMapSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/StatusEffectAmplifierMapSetting.java
@@ -5,9 +5,8 @@
 
 package meteordevelopment.meteorclient.settings;
 
-import it.unimi.dsi.fastutil.objects.Object2IntArrayMap;
-import it.unimi.dsi.fastutil.objects.Object2IntMap;
-import meteordevelopment.meteorclient.utils.Utils;
+import it.unimi.dsi.fastutil.objects.Reference2IntMap;
+import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap;
 import net.minecraft.entity.effect.StatusEffect;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.registry.Registries;
@@ -15,20 +14,22 @@ import net.minecraft.util.Identifier;
 
 import java.util.function.Consumer;
 
-public class StatusEffectAmplifierMapSetting extends Setting<Object2IntMap<StatusEffect>> {
-    public StatusEffectAmplifierMapSetting(String name, String description, Object2IntMap<StatusEffect> defaultValue, Consumer<Object2IntMap<StatusEffect>> onChanged, Consumer<Setting<Object2IntMap<StatusEffect>>> onModuleActivated, IVisible visible) {
+public class StatusEffectAmplifierMapSetting extends Setting<Reference2IntMap<StatusEffect>> {
+    public static final Reference2IntMap<StatusEffect> EMPTY_STATUS_EFFECT_MAP = createStatusEffectMap();
+
+    public StatusEffectAmplifierMapSetting(String name, String description, Reference2IntMap<StatusEffect> defaultValue, Consumer<Reference2IntMap<StatusEffect>> onChanged, Consumer<Setting<Reference2IntMap<StatusEffect>>> onModuleActivated, IVisible visible) {
         super(name, description, defaultValue, onChanged, onModuleActivated, visible);
     }
 
     @Override
     public void resetImpl() {
-        value = new Object2IntArrayMap<>(defaultValue);
+        value = new Reference2IntOpenHashMap<>(defaultValue);
     }
 
     @Override
-    protected Object2IntMap<StatusEffect> parseImpl(String str) {
+    protected Reference2IntMap<StatusEffect> parseImpl(String str) {
         String[] values = str.split(",");
-        Object2IntMap<StatusEffect> effects = Utils.createStatusEffectMap();
+        Reference2IntMap<StatusEffect> effects = new Reference2IntOpenHashMap<>(EMPTY_STATUS_EFFECT_MAP);
 
         try {
             for (String value : values) {
@@ -45,7 +46,7 @@ public class StatusEffectAmplifierMapSetting extends Setting<Object2IntMap<Statu
     }
 
     @Override
-    protected boolean isValueValid(Object2IntMap<StatusEffect> value) {
+    protected boolean isValueValid(Reference2IntMap<StatusEffect> value) {
         return true;
     }
 
@@ -61,8 +62,16 @@ public class StatusEffectAmplifierMapSetting extends Setting<Object2IntMap<Statu
         return tag;
     }
 
+    private static Reference2IntMap<StatusEffect> createStatusEffectMap() {
+        Reference2IntMap<StatusEffect> map = new Reference2IntOpenHashMap<>(Registries.STATUS_EFFECT.getIds().size());
+
+        Registries.STATUS_EFFECT.forEach(potion -> map.put(potion, 0));
+
+        return map;
+    }
+
     @Override
-    public Object2IntMap<StatusEffect> load(NbtCompound tag) {
+    public Reference2IntMap<StatusEffect> load(NbtCompound tag) {
         get().clear();
 
         NbtCompound valueTag = tag.getCompound("value");
@@ -74,9 +83,9 @@ public class StatusEffectAmplifierMapSetting extends Setting<Object2IntMap<Statu
         return get();
     }
 
-    public static class Builder extends SettingBuilder<Builder, Object2IntMap<StatusEffect>, StatusEffectAmplifierMapSetting> {
+    public static class Builder extends SettingBuilder<Builder, Reference2IntMap<StatusEffect>, StatusEffectAmplifierMapSetting> {
         public Builder() {
-            super(new Object2IntArrayMap<>(0));
+            super(new Reference2IntOpenHashMap<>(0));
         }
 
         @Override

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/PotionSpoof.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/PotionSpoof.java
@@ -64,24 +64,24 @@ public class PotionSpoof extends Module {
     public void onDeactivate() {
         if (!clearEffects.get() || !Utils.canUpdate()) return;
 
-        for (StatusEffect effect : spoofPotions.get().keySet()) {
-            if (spoofPotions.get().getInt(effect) <= 0) continue;
-            if (mc.player.hasStatusEffect(effect)) mc.player.removeStatusEffect(effect);
+        for (Reference2IntMap.Entry<StatusEffect> entry : spoofPotions.get().reference2IntEntrySet()) {
+            if (entry.getIntValue() <= 0) continue;
+            if (mc.player.hasStatusEffect(entry.getKey())) mc.player.removeStatusEffect(entry.getKey());
         }
     }
 
     @EventHandler
     private void onTick(TickEvent.Post event) {
-        for (StatusEffect statusEffect : spoofPotions.get().keySet()) {
-            int level = spoofPotions.get().getInt(statusEffect);
+        for (Reference2IntMap.Entry<StatusEffect> entry : spoofPotions.get().reference2IntEntrySet()) {
+            int level = entry.getIntValue();
             if (level <= 0) continue;
 
-            if (mc.player.hasStatusEffect(statusEffect)) {
-                StatusEffectInstance instance = mc.player.getStatusEffect(statusEffect);
+            if (mc.player.hasStatusEffect(entry.getKey())) {
+                StatusEffectInstance instance = mc.player.getStatusEffect(entry.getKey());
                 ((StatusEffectInstanceAccessor) instance).setAmplifier(level - 1);
                 if (instance.getDuration() < 20) ((StatusEffectInstanceAccessor) instance).setDuration(20);
             } else {
-                mc.player.addStatusEffect(new StatusEffectInstance(statusEffect, 20, level - 1));
+                mc.player.addStatusEffect(new StatusEffectInstance(entry.getKey(), 20, level - 1));
             }
         }
     }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/PotionSpoof.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/PotionSpoof.java
@@ -5,7 +5,7 @@
 
 package meteordevelopment.meteorclient.systems.modules.player;
 
-import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Reference2IntMap;
 import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.mixin.StatusEffectInstanceAccessor;
 import meteordevelopment.meteorclient.settings.*;
@@ -23,7 +23,7 @@ import static net.minecraft.entity.effect.StatusEffects.*;
 public class PotionSpoof extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
 
-    private final Setting<Object2IntMap<StatusEffect>> spoofPotions = sgGeneral.add(new StatusEffectAmplifierMapSetting.Builder()
+    private final Setting<Reference2IntMap<StatusEffect>> spoofPotions = sgGeneral.add(new StatusEffectAmplifierMapSetting.Builder()
         .name("spoofed-potions")
         .description("Potions to add.")
         .defaultValue(Utils.createStatusEffectMap())

--- a/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
@@ -9,11 +9,14 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.systems.VertexSorter;
 import it.unimi.dsi.fastutil.objects.Object2IntArrayMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Reference2IntMap;
+import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap;
 import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.gui.tabs.TabScreen;
 import meteordevelopment.meteorclient.mixin.*;
 import meteordevelopment.meteorclient.mixininterface.IMinecraftClient;
+import meteordevelopment.meteorclient.settings.StatusEffectAmplifierMapSetting;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.render.BetterTooltips;
 import meteordevelopment.meteorclient.systems.modules.world.Timer;
@@ -241,12 +244,8 @@ public class Utils {
         return compoundTag != null && compoundTag.contains("Items", 9);
     }
 
-    public static Object2IntMap<StatusEffect> createStatusEffectMap() {
-        Object2IntMap<StatusEffect> map = new Object2IntArrayMap<>(Registries.STATUS_EFFECT.getIds().size());
-
-        Registries.STATUS_EFFECT.forEach(potion -> map.put(potion, 0));
-
-        return map;
+    public static Reference2IntMap<StatusEffect> createStatusEffectMap() {
+        return new Reference2IntOpenHashMap<>(StatusEffectAmplifierMapSetting.EMPTY_STATUS_EFFECT_MAP);
     }
 
     public static String getEnchantSimpleName(Enchantment enchantment, int length) {

--- a/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
@@ -7,10 +7,7 @@ package meteordevelopment.meteorclient.utils;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.systems.VertexSorter;
-import it.unimi.dsi.fastutil.objects.Object2IntArrayMap;
-import it.unimi.dsi.fastutil.objects.Object2IntMap;
-import it.unimi.dsi.fastutil.objects.Reference2IntMap;
-import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap;
+import it.unimi.dsi.fastutil.objects.*;
 import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.gui.tabs.TabScreen;
@@ -245,7 +242,7 @@ public class Utils {
     }
 
     public static Reference2IntMap<StatusEffect> createStatusEffectMap() {
-        return new Reference2IntOpenHashMap<>(StatusEffectAmplifierMapSetting.EMPTY_STATUS_EFFECT_MAP);
+        return new Reference2IntArrayMap<>(StatusEffectAmplifierMapSetting.EMPTY_STATUS_EFFECT_MAP);
     }
 
     public static String getEnchantSimpleName(Enchantment enchantment, int length) {


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

map is always created on init, so it can be made into a singleton, and copied for faster subsequent uses
also you can use referential equality on `StatusEffect`
also entryset > keyset + hashing

# How Has This Been Tested?

my blood, sweat, and tears

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
