### PR TITLE
Clean up plugins scanning

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayNetworkHandlerAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayNetworkHandlerAccessor.java
@@ -8,6 +8,8 @@ package meteordevelopment.meteorclient.mixin;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.network.message.LastSeenMessagesCollector;
 import net.minecraft.network.message.MessageChain;
+import net.minecraft.registry.DynamicRegistryManager;
+import net.minecraft.resource.featuretoggle.FeatureSet;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
@@ -21,4 +23,10 @@ public interface ClientPlayNetworkHandlerAccessor {
 
     @Accessor("lastSeenMessagesCollector")
     LastSeenMessagesCollector getLastSeenMessagesCollector();
+
+    @Accessor("combinedDynamicRegistries")
+    DynamicRegistryManager.Immutable getCombinedDynamicRegistries();
+
+    @Accessor("enabledFeatures")
+    FeatureSet getEnabledFeatures();
 }

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayNetworkHandlerMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayNetworkHandlerMixin.java
@@ -5,7 +5,6 @@
 
 package meteordevelopment.meteorclient.mixin;
 
-import baritone.api.BaritoneAPI;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.commands.Commands;

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ConnectScreenAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ConnectScreenAccessor.java
@@ -1,0 +1,17 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.mixin;
+
+import net.minecraft.client.gui.screen.multiplayer.ConnectScreen;
+import net.minecraft.network.ClientConnection;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(ConnectScreen.class)
+public interface ConnectScreenAccessor {
+    @Accessor("connection")
+    ClientConnection getConnection();
+}

--- a/src/main/resources/meteor-client.accesswidener
+++ b/src/main/resources/meteor-client.accesswidener
@@ -69,9 +69,9 @@ accessible   class   net/minecraft/client/gui/screen/ingame/BeaconScreen$EffectB
 accessible   class   net/minecraft/client/resource/ResourceReloadLogger$ReloadState
 
 accessible   field   net/minecraft/block/AbstractBlock collidable Z
-accessible field net/minecraft/util/math/Direction HORIZONTAL [Lnet/minecraft/util/math/Direction;
+accessible   field   net/minecraft/util/math/Direction HORIZONTAL [Lnet/minecraft/util/math/Direction;
 
-accessible field net/minecraft/item/ItemGroups INVENTORY Lnet/minecraft/registry/RegistryKey;
+accessible   field   net/minecraft/item/ItemGroups INVENTORY Lnet/minecraft/registry/RegistryKey;
 
-accessible field net/minecraft/client/render/item/ItemRenderer TRIDENT Lnet/minecraft/client/util/ModelIdentifier;
-accessible field net/minecraft/client/render/item/ItemRenderer SPYGLASS Lnet/minecraft/client/util/ModelIdentifier;
+accessible   field   net/minecraft/client/render/item/ItemRenderer TRIDENT Lnet/minecraft/client/util/ModelIdentifier;
+accessible   field   net/minecraft/client/render/item/ItemRenderer SPYGLASS Lnet/minecraft/client/util/ModelIdentifier;

--- a/src/main/resources/meteor-client.mixins.json
+++ b/src/main/resources/meteor-client.mixins.json
@@ -63,6 +63,7 @@
     "CloseHandledScreenC2SPacketAccessor",
     "CobwebBlockMixin",
     "CompassAnglePredicateProviderMixin",
+    "ConnectScreenAccessor",
     "ConnectScreenMixin",
     "CrashReportMixin",
     "CreativeInventoryScreenAccessor",


### PR DESCRIPTION
## Type of change

- [x] Bug fix 🤷 
- [ ] New feature

## Description

The plugins scanning was previously quite slow and messy. This cleans it up, removing the need to spam unecessary packets to the server. It also speeds it up in the majority of the scenarios.

# How Has This Been Tested?

Various online servers.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
