### PR TITLE
Security patches

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/NbtCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/NbtCommand.java
@@ -11,6 +11,7 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.commands.arguments.CompoundNbtTagArgumentType;
 import meteordevelopment.meteorclient.systems.config.Config;
+import meteordevelopment.meteorclient.utils.misc.text.MeteorClickEvent;
 import net.minecraft.command.CommandSource;
 import net.minecraft.command.argument.NbtPathArgumentType;
 import net.minecraft.item.ItemStack;
@@ -84,7 +85,7 @@ public class NbtCommand extends Command {
                 MutableText copyButton = Text.literal("NBT");
                 copyButton.setStyle(copyButton.getStyle()
                         .withFormatting(Formatting.UNDERLINE)
-                        .withClickEvent(new ClickEvent(
+                        .withClickEvent(new MeteorClickEvent(
                                 ClickEvent.Action.RUN_COMMAND,
                                 this.toString("copy")
                         ))

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/SwarmCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/SwarmCommand.java
@@ -67,6 +67,8 @@ public class SwarmCommand extends Command {
                                         swarm.mode.set(Swarm.Mode.Worker);
                                         swarm.worker = new SwarmWorker(StringArgumentType.getString(context, "ip"), IntegerArgumentType.getInteger(context, "port"));
 
+                                        info("Connected to (highlight)%s.", swarm.worker.getConnection());
+
                                         return SINGLE_SUCCESS;
                                 })
                         )

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ScreenMixin.java
@@ -12,6 +12,7 @@ import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.movement.GUIMove;
 import meteordevelopment.meteorclient.systems.modules.render.NoRender;
 import meteordevelopment.meteorclient.utils.Utils;
+import meteordevelopment.meteorclient.utils.misc.text.MeteorClickEvent;
 import net.minecraft.client.gui.screen.ChatScreen;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.text.Style;
@@ -35,7 +36,7 @@ public abstract class ScreenMixin {
 
     @Inject(method = "handleTextClick", at = @At(value = "INVOKE", target = "Lorg/slf4j/Logger;error(Ljava/lang/String;Ljava/lang/Object;)V", ordinal = 1, remap = false), cancellable = true)
     private void onRunCommand(Style style, CallbackInfoReturnable<Boolean> cir) {
-        if (style.getClickEvent().getValue().startsWith(Config.get().prefix.get())) {
+        if (style.getClickEvent() instanceof MeteorClickEvent clickEvent && clickEvent.getValue().startsWith(Config.get().prefix.get())) {
             try {
                 Commands.dispatch(style.getClickEvent().getValue().substring(Config.get().prefix.get().length()));
                 cir.setReturnValue(true);

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterChat.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterChat.java
@@ -22,6 +22,7 @@ import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.utils.Utils;
 import meteordevelopment.meteorclient.utils.misc.MeteorIdentifier;
+import meteordevelopment.meteorclient.utils.misc.text.MeteorClickEvent;
 import meteordevelopment.meteorclient.utils.player.ChatUtils;
 import meteordevelopment.meteorclient.utils.render.color.Color;
 import meteordevelopment.orbit.EventHandler;
@@ -518,7 +519,7 @@ public class BetterChat extends Module {
 
         sendButton.setStyle(sendButton.getStyle()
             .withFormatting(Formatting.DARK_RED)
-            .withClickEvent(new ClickEvent(
+            .withClickEvent(new MeteorClickEvent(
                 ClickEvent.Action.RUN_COMMAND,
                 Commands.get("say").toString(message)
             ))

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/swarm/SwarmWorker.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/swarm/SwarmWorker.java
@@ -41,7 +41,7 @@ public class SwarmWorker extends Thread {
             while (!isInterrupted()) {
                 String read = in.readUTF();
 
-                if (!read.equals("")) {
+                if (read.startsWith("swarm")) {
                     ChatUtils.infoPrefix("Swarm", "Received command: (highlight)%s", read);
 
                     try {

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/text/MeteorClickEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/text/MeteorClickEvent.java
@@ -1,0 +1,20 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.utils.misc.text;
+
+import net.minecraft.text.ClickEvent;
+import net.minecraft.text.Style;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * This class does nothing except ensure that {@link ClickEvent}'s containing Meteor Client commands can only be executed if they come from the client.
+ * @see meteordevelopment.meteorclient.mixin.ScreenMixin#onRunCommand(Style, CallbackInfoReturnable)
+ */
+public class MeteorClickEvent extends ClickEvent {
+    public MeteorClickEvent(Action action, String value) {
+        super(action, value);
+    }
+}

--- a/src/main/java/meteordevelopment/meteorclient/utils/player/ChatUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/ChatUtils.java
@@ -11,6 +11,7 @@ import meteordevelopment.meteorclient.mixininterface.IChatHud;
 import meteordevelopment.meteorclient.pathing.BaritoneUtils;
 import meteordevelopment.meteorclient.systems.config.Config;
 import meteordevelopment.meteorclient.utils.PostInit;
+import meteordevelopment.meteorclient.utils.misc.text.MeteorClickEvent;
 import net.minecraft.text.*;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Pair;
@@ -248,7 +249,7 @@ public class ChatUtils {
         ));
 
         if (BaritoneUtils.IS_AVAILABLE) {
-            style = style.withClickEvent(new ClickEvent(
+            style = style.withClickEvent(new MeteorClickEvent(
                 ClickEvent.Action.RUN_COMMAND,
                 String.format("%sgoto %d %d %d", BaritoneUtils.getPrefix(), (int) pos.x, (int) pos.y, (int) pos.z)
             ));


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

Patches a vulnerability within Meteor Client where when clicking a message with a click event sent by a malicious server, it could establish a swarm connection and execute arbitrary Minecraft & Meteor Client commands from the client.
This connection had the ability to:
- Send any signed chat message (which could lead to a Microsoft account ban).
- Overwrite any specific non-protected file in the same drive as the Meteor Client folder.
- If Meteor Rejects is installed, shut down the computer.

In order to fix this vulnerability and prevent future ones, this pull request:
- Prevents Meteor Client commands from being executed from a click event that does not come from the client
- Prevents `.notebot` from writing to files outside of its directory.
- Prevents swarm from executing commands outside of its command tree.
- Adds a confirmation dialog to `.swarm join`

# How Has This Been Tested?

Extensively tested using a proof-of-concept malicious server.

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
