### PR TITLE
Fixed potential crash due to Enums implementing interfaces/abstract methods

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/GuiTheme.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/GuiTheme.java
@@ -115,7 +115,7 @@ public abstract class GuiTheme implements ISerializable<GuiTheme> {
 
     public abstract <T> WDropdown<T> dropdown(T[] values, T value);
     public <T extends Enum<?>> WDropdown<T> dropdown(T value) {
-        Class<?> klass = value.getClass();
+        Class<?> klass = value.getDeclaringClass();
         T[] values = (T[]) klass.getEnumConstants();
         return dropdown(values, value);
     }

--- a/src/main/java/meteordevelopment/meteorclient/settings/EnumSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/EnumSetting.java
@@ -19,7 +19,7 @@ public class EnumSetting<T extends Enum<?>> extends Setting<T> {
     public EnumSetting(String name, String description, T defaultValue, Consumer<T> onChanged, Consumer<Setting<T>> onModuleActivated, IVisible visible) {
         super(name, description, defaultValue, onChanged, onModuleActivated, visible);
 
-        values = (T[]) defaultValue.getClass().getEnumConstants();
+        values = (T[]) defaultValue.getDeclaringClass().getEnumConstants();
         suggestions = new ArrayList<>(values.length);
         for (T value : values) suggestions.add(value.toString());
     }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

It is possible that `getEnumConstants` returns null, even though it has been called on the class returned by `getClass` of an enum constant. This is the case if the Enum contains an abstract method or an interface which are implemented by the constants, like this:
```java
enum SomeEnum implements SomeInterface {
    SomeEnumConstant {
        @Override
        public void someMethodInheritedFromTheInterface() { ... }
        
        @Override
        public void someAbstractMethod() { ... }
    };
    
    public abstract void someAbstractMethod();
}

SomeEnum.SomeEnumConstant.getClass().getEnumConstants() == null
```
In this case `SomeEnumConstant.getClass().getEnumConstants()` returns null because the class returned by getClass is not actually SomeEnum but something like SomeEnum$1 for each implmenting constant. Instead `getDeclaringClass` should be used to get the actual enum class.

## Related issues

--

# How Has This Been Tested?

Noticed it while writing an Add-On, this definitely fixes it.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
