### PR TITLE
Fix BreakDelay

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayerInteractionManagerMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayerInteractionManagerMixin.java
@@ -167,7 +167,7 @@ public abstract class ClientPlayerInteractionManagerMixin implements IClientPlay
     @Redirect(method = "method_41930", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BlockState;calcBlockBreakingDelta(Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/world/BlockView;Lnet/minecraft/util/math/BlockPos;)F"))
     private float deltaChange(BlockState blockState, PlayerEntity player, BlockView world, BlockPos pos) {
         float delta = blockState.calcBlockBreakingDelta(player, world, pos);
-        if (Modules.get().get(BreakDelay.class).noInstaBreak.get() && delta >= 1) {
+        if (Modules.get().get(BreakDelay.class).preventInstaBreak() && delta >= 1) {
             BlockBreakingCooldownEvent event = MeteorClient.EVENT_BUS.post(BlockBreakingCooldownEvent.get(blockBreakingCooldown));
             blockBreakingCooldown = event.cooldown;
             return 0;

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/BreakDelay.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/BreakDelay.java
@@ -6,12 +6,14 @@
 package meteordevelopment.meteorclient.systems.modules.player;
 
 import meteordevelopment.meteorclient.events.entity.player.BlockBreakingCooldownEvent;
+import meteordevelopment.meteorclient.events.meteor.MouseButtonEvent;
 import meteordevelopment.meteorclient.settings.BoolSetting;
 import meteordevelopment.meteorclient.settings.IntSetting;
 import meteordevelopment.meteorclient.settings.Setting;
 import meteordevelopment.meteorclient.settings.SettingGroup;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.meteorclient.utils.misc.input.KeyAction;
 import meteordevelopment.orbit.EventHandler;
 
 public class BreakDelay extends Module {
@@ -26,7 +28,7 @@ public class BreakDelay extends Module {
         .build()
     );
 
-    public final Setting<Boolean> noInstaBreak = sgGeneral.add(new BoolSetting.Builder()
+    private final Setting<Boolean> noInstaBreak = sgGeneral.add(new BoolSetting.Builder()
         .name("no-insta-break")
         .description("Prevent you from breaking blocks instantly.")
         .defaultValue(false)
@@ -37,8 +39,27 @@ public class BreakDelay extends Module {
         super(Categories.Player, "break-delay", "Changes the delay between breaking blocks.");
     }
 
-    @EventHandler()
-    private void onBlockBreakingCooldown(BlockBreakingCooldownEvent event) {
-        event.cooldown = cooldown.get();
+    boolean breakBlockCooldown = false;
+
+    public boolean preventInstaBreak() {
+        return isActive() && noInstaBreak.get();
     }
+
+    @EventHandler
+    private void onBlockBreakingCooldown(BlockBreakingCooldownEvent event) {
+        if (breakBlockCooldown) {
+            event.cooldown = 5;
+            breakBlockCooldown = false;
+        } else {
+            event.cooldown = cooldown.get();
+        }
+    }
+
+    @EventHandler
+    private void onClick(MouseButtonEvent event) {
+        if (event.action == KeyAction.Press && noInstaBreak.get()) {
+            breakBlockCooldown = true;
+        }
+    }
+
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/BreakDelay.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/BreakDelay.java
@@ -35,14 +35,10 @@ public class BreakDelay extends Module {
         .build()
     );
 
+    private boolean breakBlockCooldown = false;
+
     public BreakDelay() {
         super(Categories.Player, "break-delay", "Changes the delay between breaking blocks.");
-    }
-
-    boolean breakBlockCooldown = false;
-
-    public boolean preventInstaBreak() {
-        return isActive() && noInstaBreak.get();
     }
 
     @EventHandler
@@ -62,4 +58,7 @@ public class BreakDelay extends Module {
         }
     }
 
+    public boolean preventInstaBreak() {
+        return isActive() && noInstaBreak.get();
+    }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/BreakDelay.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/BreakDelay.java
@@ -30,7 +30,7 @@ public class BreakDelay extends Module {
 
     private final Setting<Boolean> noInstaBreak = sgGeneral.add(new BoolSetting.Builder()
         .name("no-insta-break")
-        .description("Prevent you from breaking blocks instantly.")
+        .description("Prevents you from misbreaking blocks if you can instantly break them.")
         .defaultValue(false)
         .build()
     );


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Fix the `no-insta-break` setting, which doesn't work and remains active even when the module is disabled.
