### PR TITLE
Fix Speed and LongJump override timer

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/LongJump.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/LongJump.java
@@ -144,7 +144,9 @@ public class LongJump extends Module {
 
     @EventHandler
     private void onPlayerMove(PlayerMoveEvent event) {
-        Modules.get().get(Timer.class).setOverride(PlayerUtils.isMoving() ? timer.get() : Timer.OFF);
+        if (timer.get() != Timer.OFF) {
+            Modules.get().get(Timer.class).setOverride(PlayerUtils.isMoving() ? timer.get() : Timer.OFF);
+        }
         switch (jumpMode.get()) {
             case Vanilla -> {
                 if (PlayerUtils.isMoving() && mc.options.jumpKey.isPressed()) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/speed/Speed.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/speed/Speed.java
@@ -118,7 +118,9 @@ public class Speed extends Module {
         if (vanillaOnGround.get() && !mc.player.isOnGround() && speedMode.get() == SpeedModes.Vanilla) return;
         if (!inLiquids.get() && (mc.player.isTouchingWater() || mc.player.isInLava())) return;
 
-        Modules.get().get(Timer.class).setOverride(PlayerUtils.isMoving() ? timer.get() : Timer.OFF);
+        if (timer.get() != Timer.OFF) {
+            Modules.get().get(Timer.class).setOverride(PlayerUtils.isMoving() ? timer.get() : Timer.OFF);
+        }
 
         currentMode.onMove(event);
     }


### PR DESCRIPTION
Fix Speed and LongJump override timer for other Timer modules (in addons)

## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Does not override the timer value if it is set to 1 in the settings

## Related issues

Timer+ did not work with Speed and LongJump
Already fixed in Meteor Plus, after aprove will remove the fix from Meteor Plus

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
