### PR TITLE
Fix BetterChat getSender fallback when Timestamps are active

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterChat.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterChat.java
@@ -220,6 +220,7 @@ public class BetterChat extends Module {
 
     private static final Pattern antiSpamRegex = Pattern.compile(" \\(([0-9]+)\\)$");
     private static final Pattern timestampRegex = Pattern.compile("^(<[0-9]{2}:[0-9]{2}>\\s)");
+    private static final Pattern usernameRegex = Pattern.compile("^(?:<[0-9]{2}:[0-9]{2}>\\s)?<(.*?)>.*");
 
     private final Char2CharMap SMALL_CAPS = new Char2CharOpenHashMap();
     private final SimpleDateFormat dateFormat = new SimpleDateFormat("HH:mm");
@@ -426,11 +427,10 @@ public class BetterChat extends Module {
 
         // If the packet did not contain a sender field then try to get the sender from the message
         if (sender == null) {
-            int openingI = text.indexOf('<');
-            int closingI = text.indexOf('>');
+            Matcher usernameMatcher = usernameRegex.matcher(text);
 
-            if (openingI != -1 && closingI != -1 && closingI > openingI) {
-                String username = text.substring(openingI + 1, closingI);
+            if (usernameMatcher.matches()) {
+                String username = usernameMatcher.group(1);
 
                 PlayerListEntry entry = mc.getNetworkHandler().getPlayerListEntry(username);
                 if (entry != null) sender = entry.getProfile();


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

When Timestamps setting is active in BetterChat, fallback username matcher in `BetterChat::getSender()` won't be able to extract the username from message because both timestamp and username are contained within `<`, `>` symbols. New regex matcher in this PR takes this into consideration by making an optional matching group for timestamps before the username.

## Related issues

None

# How Has This Been Tested?

![image](https://github.com/MeteorDevelopment/meteor-client/assets/4098364/c865bf09-d823-4ee7-bca2-16e640072cae)

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
