### PR TITLE
Velocity prevent fishing rod pull

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/FishingBobberEntityMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/FishingBobberEntityMixin.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.mixin;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import meteordevelopment.meteorclient.systems.modules.Modules;
+import meteordevelopment.meteorclient.systems.modules.movement.Velocity;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.projectile.FishingBobberEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import static meteordevelopment.meteorclient.MeteorClient.mc;
+
+@Mixin(FishingBobberEntity.class)
+public class FishingBobberEntityMixin {
+    @WrapOperation(method = "handleStatus", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/projectile/FishingBobberEntity;pullHookedEntity(Lnet/minecraft/entity/Entity;)V"))
+    private void preventFishingRodPull(FishingBobberEntity instance, Entity entity, Operation<Void> original) {
+        if (!instance.getWorld().isClient || entity != mc.player) original.call(instance, entity);
+
+        Velocity velocity = Modules.get().get(Velocity.class);
+        if (!velocity.isActive() || !velocity.fishing.get()) original.call(instance, entity);
+    }
+}

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Velocity.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Velocity.java
@@ -126,6 +126,13 @@ public class Velocity extends Module {
         .build()
     );
 
+    public final Setting<Boolean> fishing = sgGeneral.add(new BoolSetting.Builder()
+        .name("fishing")
+        .description("Prevents you from being pulled by fishing rods.")
+        .defaultValue(false)
+        .build()
+    );
+
     public Velocity() {
         super(Categories.Movement, "velocity", "Prevents you from being moved by external forces.");
     }

--- a/src/main/resources/meteor-client.mixins.json
+++ b/src/main/resources/meteor-client.mixins.json
@@ -90,6 +90,7 @@
     "FireworkRocketEntityMixin",
     "FireworksSparkParticleMixin",
     "FireworksSparkParticleSubMixin",
+    "FishingBobberEntityMixin",
     "FluidRendererMixin",
     "FoliageColorsMixin",
     "GameOptionsMixin",


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature

## Description

Fishing rod pulling is handled entirely clientside, so the velocity packet modification didn't work.

# How Has This Been Tested?

Yep

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
