### PR TITLE
fix potential `ChunkDataEvent` race condition

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/events/world/ChunkDataEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/world/ChunkDataEvent.java
@@ -5,21 +5,10 @@
 
 package meteordevelopment.meteorclient.events.world;
 
-import meteordevelopment.meteorclient.utils.misc.Pool;
 import net.minecraft.world.chunk.WorldChunk;
 
-public class ChunkDataEvent {
-    private static final Pool<ChunkDataEvent> INSTANCE = new Pool<>(ChunkDataEvent::new);
-
-    public WorldChunk chunk;
-
-    public static ChunkDataEvent get(WorldChunk chunk) {
-        ChunkDataEvent event = INSTANCE.get();
-        event.chunk = chunk;
-        return event;
-    }
-
-    public static void returnChunkDataEvent(ChunkDataEvent event) {
-        INSTANCE.free(event);
-    }
-}
+/**
+ * @implNote Shouldn't be put in a {@link meteordevelopment.meteorclient.utils.misc.Pool} to avoid a race-condition, or in a {@link ThreadLocal} as it is shared between threads.
+ * @author Crosby
+ */
+public record ChunkDataEvent(WorldChunk chunk) {}

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayNetworkHandlerMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayNetworkHandlerMixin.java
@@ -96,7 +96,7 @@ public abstract class ClientPlayNetworkHandlerMixin extends ClientCommonNetworkH
     @Inject(method = "onChunkData", at = @At("TAIL"))
     private void onChunkData(ChunkDataS2CPacket packet, CallbackInfo info) {
         WorldChunk chunk = client.world.getChunk(packet.getChunkX(), packet.getChunkZ());
-        MeteorClient.EVENT_BUS.post(ChunkDataEvent.get(chunk));
+        MeteorClient.EVENT_BUS.post(new ChunkDataEvent(chunk));
     }
 
     @Inject(method = "onScreenHandlerSlotUpdate", at = @At("TAIL"))

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/BlockESP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/BlockESP.java
@@ -96,7 +96,7 @@ public class BlockESP extends Module {
         }
 
         for (Chunk chunk : Utils.chunks()) {
-            searchChunk(chunk, null);
+            searchChunk(chunk);
         }
 
         lastDimension = PlayerUtils.getDimension();
@@ -153,10 +153,10 @@ public class BlockESP extends Module {
 
     @EventHandler
     private void onChunkData(ChunkDataEvent event) {
-        searchChunk(event.chunk, event);
+        searchChunk(event.chunk());
     }
 
-    private void searchChunk(Chunk chunk, ChunkDataEvent event) {
+    private void searchChunk(Chunk chunk) {
         MeteorExecutor.execute(() -> {
             if (!isActive()) return;
             ESPChunk schunk = ESPChunk.searchChunk(chunk, blocks.get());
@@ -173,8 +173,6 @@ public class BlockESP extends Module {
                     updateChunk(chunk.getPos().x, chunk.getPos().z + 1);
                 }
             }
-
-            if (event != null) ChunkDataEvent.returnChunkDataEvent(event);
         });
     }
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/StashFinder.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/StashFinder.java
@@ -94,13 +94,13 @@ public class StashFinder extends Module {
     @EventHandler
     private void onChunkData(ChunkDataEvent event) {
         // Check the distance.
-        double chunkXAbs = Math.abs(event.chunk.getPos().x * 16);
-        double chunkZAbs = Math.abs(event.chunk.getPos().z * 16);
+        double chunkXAbs = Math.abs(event.chunk().getPos().x * 16);
+        double chunkZAbs = Math.abs(event.chunk().getPos().z * 16);
         if (Math.sqrt(chunkXAbs * chunkXAbs + chunkZAbs * chunkZAbs) < minimumDistance.get()) return;
 
-        Chunk chunk = new Chunk(event.chunk.getPos());
+        Chunk chunk = new Chunk(event.chunk().getPos());
 
-        for (BlockEntity blockEntity : event.chunk.getBlockEntities().values()) {
+        for (BlockEntity blockEntity : event.chunk().getBlockEntities().values()) {
             if (!storageBlocks.get().contains(blockEntity.getType())) continue;
 
             if (blockEntity instanceof ChestBlockEntity) chunk.chests++;
@@ -133,8 +133,6 @@ public class StashFinder extends Module {
                 }
             }
         }
-
-        ChunkDataEvent.returnChunkDataEvent(event);
     }
 
     @Override


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

![image](https://github.com/MeteorDevelopment/meteor-client/assets/32882447/db905c74-765c-475d-8648-1991417ea219)

## Related issues

none

# How Has This Been Tested?

Both modules making use of `ChunkDataEvent` active at the same time.
![2024-03-04_01 02 57](https://github.com/MeteorDevelopment/meteor-client/assets/32882447/5a753a2e-77f8-4156-9037-b71d9a724617)

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
