### PR TITLE
Fixed server spoof not spoofing branding properly and added exposed only distance setting to X-Ray

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/events/game/ClientBrandRetrieverEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/game/ClientBrandRetrieverEvent.java
@@ -1,0 +1,21 @@
+package meteordevelopment.meteorclient.events.game;
+
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import meteordevelopment.meteorclient.events.Cancellable;
+
+public class ClientBrandRetrieverEvent extends Cancellable {
+	private static final ClientBrandRetrieverEvent INSTANCE = new ClientBrandRetrieverEvent();
+	
+	public CallbackInfoReturnable<String> info;
+	
+
+    public static ClientBrandRetrieverEvent get(CallbackInfoReturnable<String> info) {
+    	ClientBrandRetrieverEvent event = INSTANCE;
+    	
+    	event.setCancelled(false);
+    	event.info = info;
+    	
+    	return event;
+    }
+}

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientBrandRetrieverMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientBrandRetrieverMixin.java
@@ -1,0 +1,29 @@
+package meteordevelopment.meteorclient.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import meteordevelopment.meteorclient.MeteorClient;
+import meteordevelopment.meteorclient.events.game.ClientBrandRetrieverEvent;
+import meteordevelopment.meteorclient.events.world.CollisionShapeEvent;
+import net.minecraft.client.ClientBrandRetriever;
+
+@Mixin(ClientBrandRetriever.class)
+public class ClientBrandRetrieverMixin {
+	@Inject(at = @At("HEAD"), method = "getClientModName", cancellable = true, remap = false)
+	private static void getConfiguredClientBrand(CallbackInfoReturnable<String> info) {
+		System.out.println("info: " + info.getReturnValue());
+		ClientBrandRetrieverEvent event = MeteorClient.EVENT_BUS.post(ClientBrandRetrieverEvent.get(info));
+
+		System.out.println(event.info.getReturnValue());
+		
+		if(event.isCancelled()) {
+			return;
+		}
+		
+		info.setReturnValue(event.info.getReturnValue());
+		
+	}
+}

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientBrandRetrieverMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientBrandRetrieverMixin.java
@@ -14,10 +14,7 @@ import net.minecraft.client.ClientBrandRetriever;
 public class ClientBrandRetrieverMixin {
 	@Inject(at = @At("HEAD"), method = "getClientModName", cancellable = true, remap = false)
 	private static void getConfiguredClientBrand(CallbackInfoReturnable<String> info) {
-		System.out.println("info: " + info.getReturnValue());
 		ClientBrandRetrieverEvent event = MeteorClient.EVENT_BUS.post(ClientBrandRetrieverEvent.get(info));
-
-		System.out.println(event.info.getReturnValue());
 		
 		if(event.isCancelled()) {
 			return;

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/ServerSpoof.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/ServerSpoof.java
@@ -82,7 +82,6 @@ public class ServerSpoof extends Module {
     	
     	@EventHandler
     	private void onClientBrandRetrive(ClientBrandRetrieverEvent event) {
-    		System.out.println("Listener: " + event.info.getReturnValue());
     		if (spoofBrand.get()) event.info.setReturnValue(brand.get());
     	}
     	

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/ServerSpoof.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/ServerSpoof.java
@@ -5,10 +5,19 @@
 
 package meteordevelopment.meteorclient.systems.modules.misc;
 
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
 import io.netty.buffer.Unpooled;
 import meteordevelopment.meteorclient.MeteorClient;
+import meteordevelopment.meteorclient.events.game.ClientBrandRetrieverEvent;
 import meteordevelopment.meteorclient.events.packets.PacketEvent;
-import meteordevelopment.meteorclient.settings.*;
+import meteordevelopment.meteorclient.settings.BoolSetting;
+import meteordevelopment.meteorclient.settings.Setting;
+import meteordevelopment.meteorclient.settings.SettingGroup;
+import meteordevelopment.meteorclient.settings.StringListSetting;
+import meteordevelopment.meteorclient.settings.StringSetting;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.orbit.EventHandler;
@@ -22,9 +31,6 @@ import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
-import org.apache.commons.lang3.StringUtils;
-
-import java.util.List;
 
 public class ServerSpoof extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
@@ -73,6 +79,13 @@ public class ServerSpoof extends Module {
     }
 
     private class Listener {
+    	
+    	@EventHandler
+    	private void onClientBrandRetrive(ClientBrandRetrieverEvent event) {
+    		System.out.println("Listener: " + event.info.getReturnValue());
+    		if (spoofBrand.get()) event.info.setReturnValue(brand.get());
+    	}
+    	
         @EventHandler
         private void onPacketSend(PacketEvent.Send event) {
             if (!isActive()) return;

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/ServerSpoof.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/ServerSpoof.java
@@ -90,23 +90,23 @@ public class ServerSpoof extends Module {
             if (!isActive()) return;
             if (!(event.packet instanceof CustomPayloadC2SPacket)) return;
             Identifier id = ((CustomPayloadC2SPacket) event.packet).payload().id();
-
-            if (spoofBrand.get() && id.equals(BrandCustomPayload.ID)) {
-                event.packet.write(new PacketByteBuf(Unpooled.buffer()).writeString(brand.get()));
-                for (String channel : channels.get()) {
-                    if (id.toString().equalsIgnoreCase("fabric:registry/sync")) {
-                        event.cancel();
-                        return;
-                    } else if (id.toString().equalsIgnoreCase("fabric:container/open")) {
-                        event.cancel();
-                        return;
-                    } else if (id.toString().equalsIgnoreCase("fabric-screen-handler-api-v1:open_screen")) {
-                        event.cancel();
-                        return;
-                    } 
-                }
-            	
+            
+            if(spoofBrand.get()) {
+            	if (id.equals(BrandCustomPayload.ID)) {
+                    event.packet.write(new PacketByteBuf(Unpooled.buffer()).writeString(brand.get()));
+                } else if (StringUtils.containsIgnoreCase(id.toString(), "fabric:registry/sync")) {
+	                event.cancel();
+	                return;
+	            } else if (StringUtils.containsIgnoreCase(id.toString(), "fabric:container/open")) {
+	                event.cancel();
+	                return;
+	            } else if (StringUtils.containsIgnoreCase(id.toString(), "fabric-screen-handler-api-v1:open_screen")) {
+	                event.cancel();
+	                return;
+	            }
             }
+
+            
 
             if (blockChannels.get()) {
                 for (String channel : channels.get()) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/ServerSpoof.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/ServerSpoof.java
@@ -91,8 +91,22 @@ public class ServerSpoof extends Module {
             if (!(event.packet instanceof CustomPayloadC2SPacket)) return;
             Identifier id = ((CustomPayloadC2SPacket) event.packet).payload().id();
 
-            if (spoofBrand.get() && id.equals(BrandCustomPayload.ID))
+            if (spoofBrand.get() && id.equals(BrandCustomPayload.ID)) {
                 event.packet.write(new PacketByteBuf(Unpooled.buffer()).writeString(brand.get()));
+                for (String channel : channels.get()) {
+                    if (id.toString().equalsIgnoreCase("fabric:registry/sync")) {
+                        event.cancel();
+                        return;
+                    } else if (id.toString().equalsIgnoreCase("fabric:container/open")) {
+                        event.cancel();
+                        return;
+                    } else if (id.toString().equalsIgnoreCase("fabric-screen-handler-api-v1:open_screen")) {
+                        event.cancel();
+                        return;
+                    } 
+                }
+            	
+            }
 
             if (blockChannels.get()) {
                 for (String channel : channels.get()) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Xray.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Xray.java
@@ -63,6 +63,18 @@ public class Xray extends Module {
             if (isActive()) mc.worldRenderer.reload();
         })
         .build());
+    
+    private final Setting<Integer> exposedOnlyDistance = sgGeneral.add(new IntSetting.Builder()
+            .name("exposed-only-distance")
+            .description("Specify the distance of opeque blocks for ore to be considered as exposed.")
+            .defaultValue(1)
+            .min(1)
+            .max(10)
+            .visible(exposedOnly::get)
+            .onChanged(onChanged -> {
+                if (isActive()) mc.worldRenderer.reload();
+            })
+            .build());
 
     public Xray() {
         super(Categories.Render, "xray", "Only renders specified blocks. Good for mining.");
@@ -105,14 +117,14 @@ public class Xray extends Module {
         if (!returns && !isBlocked(state.getBlock(), pos)) {
             BlockPos adjPos = pos.offset(facing);
             BlockState adjState = view.getBlockState(adjPos);
-            return adjState.getCullingFace(view, adjPos, facing.getOpposite()) != VoxelShapes.fullCube() || adjState.getBlock() != state.getBlock() || BlockUtils.isExposed(adjPos);
+            return adjState.getCullingFace(view, adjPos, facing.getOpposite()) != VoxelShapes.fullCube() || adjState.getBlock() != state.getBlock() || BlockUtils.isExposed(adjPos, exposedOnlyDistance.get());
         }
 
         return returns;
     }
 
     public boolean isBlocked(Block block, BlockPos blockPos) {
-        return !(blocks.get().contains(block) && (!exposedOnly.get() || (blockPos == null || BlockUtils.isExposed(blockPos))));
+        return !(blocks.get().contains(block) && (!exposedOnly.get() || (blockPos == null || BlockUtils.isExposed(blockPos, exposedOnlyDistance.get()))));
     }
 
     public static int getAlpha(BlockState state, BlockPos pos) {

--- a/src/main/java/meteordevelopment/meteorclient/utils/world/BlockUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/world/BlockUtils.java
@@ -5,6 +5,8 @@
 
 package meteordevelopment.meteorclient.utils.world;
 
+import static meteordevelopment.meteorclient.MeteorClient.mc;
+
 import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.utils.PreInit;
@@ -13,7 +15,23 @@ import meteordevelopment.meteorclient.utils.player.InvUtils;
 import meteordevelopment.meteorclient.utils.player.Rotations;
 import meteordevelopment.orbit.EventHandler;
 import meteordevelopment.orbit.EventPriority;
-import net.minecraft.block.*;
+import net.minecraft.block.AbstractPressurePlateBlock;
+import net.minecraft.block.AirBlock;
+import net.minecraft.block.AnvilBlock;
+import net.minecraft.block.BedBlock;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.BlockWithEntity;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.ButtonBlock;
+import net.minecraft.block.CraftingTableBlock;
+import net.minecraft.block.DoorBlock;
+import net.minecraft.block.FenceGateBlock;
+import net.minecraft.block.NoteBlock;
+import net.minecraft.block.ShapeContext;
+import net.minecraft.block.SlabBlock;
+import net.minecraft.block.StairsBlock;
+import net.minecraft.block.TrapdoorBlock;
 import net.minecraft.block.enums.BlockHalf;
 import net.minecraft.block.enums.SlabType;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -32,8 +50,6 @@ import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.shape.VoxelShapes;
 import net.minecraft.world.LightType;
 import net.minecraft.world.World;
-
-import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class BlockUtils {
     public static boolean breaking;
@@ -317,12 +333,31 @@ public class BlockUtils {
 
     private static final ThreadLocal<BlockPos.Mutable> EXPOSED_POS = ThreadLocal.withInitial(BlockPos.Mutable::new);
 
-    public static boolean isExposed(BlockPos blockPos) {
-        for (Direction direction : Direction.values()) {
-            if (!mc.world.getBlockState(EXPOSED_POS.get().set(blockPos, direction)).isOpaque()) return true;
-        }
+    public static boolean isExposed(BlockPos blockPos, Integer distanceToCheck) {
+    	
+    	boolean isPosExposed = false;
+    	
+    	BlockState currBlockState = mc.world.getBlockState(blockPos);
 
-        return false;
+		outerloop:
+		for (Direction direction : Direction.values()) {
+			boolean foundAir = false;
+			for (int i = 1; i <= distanceToCheck+1; i++) {
+				if(i >= distanceToCheck && foundAir) {
+					isPosExposed = true;
+					break outerloop;
+				}
+				BlockState neighbourBlockState = mc.world.getBlockState(blockPos.offset(direction, i));
+				if(!mc.world.getBlockState(blockPos.offset(direction, i)).isOpaque()) {
+					foundAir = true;
+				} else {
+					break;
+				}
+            }
+		}
+    	
+
+        return isPosExposed;
     }
 
     public static double getBreakDelta(int slot, BlockState state) {

--- a/src/main/java/meteordevelopment/meteorclient/utils/world/BlockUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/world/BlockUtils.java
@@ -330,34 +330,23 @@ public class BlockUtils {
         Potential,
         Always
     }
-
+    
     private static final ThreadLocal<BlockPos.Mutable> EXPOSED_POS = ThreadLocal.withInitial(BlockPos.Mutable::new);
 
-    public static boolean isExposed(BlockPos blockPos, Integer distanceToCheck) {
-    	
-    	boolean isPosExposed = false;
-    	
-    	BlockState currBlockState = mc.world.getBlockState(blockPos);
-
-		outerloop:
-		for (Direction direction : Direction.values()) {
-			boolean foundAir = false;
-			for (int i = 1; i <= distanceToCheck+1; i++) {
-				if(i >= distanceToCheck && foundAir) {
-					isPosExposed = true;
-					break outerloop;
-				}
-				BlockState neighbourBlockState = mc.world.getBlockState(blockPos.offset(direction, i));
-				if(!mc.world.getBlockState(blockPos.offset(direction, i)).isOpaque()) {
-					foundAir = true;
-				} else {
-					break;
-				}
+public static boolean isExposed(BlockPos blockPos, Integer distanceToCheck) {
+	
+	outerloop:
+        for (Direction direction : Direction.values()) {
+        	EXPOSED_POS.get().set(blockPos);
+            for (int i = 1; i <= distanceToCheck; i++) {
+                BlockState neighbourBlockState = mc.world.getBlockState(EXPOSED_POS.get().move(direction, 1));
+                if(neighbourBlockState.isOpaque()) {
+                    continue outerloop;
+                }
             }
-		}
-    	
-
-        return isPosExposed;
+            return true;
+        }
+        return false;
     }
 
     public static double getBreakDelta(int slot, BlockState state) {

--- a/src/main/java/meteordevelopment/meteorclient/utils/world/BlockUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/world/BlockUtils.java
@@ -333,9 +333,9 @@ public class BlockUtils {
     
     private static final ThreadLocal<BlockPos.Mutable> EXPOSED_POS = ThreadLocal.withInitial(BlockPos.Mutable::new);
 
-public static boolean isExposed(BlockPos blockPos, Integer distanceToCheck) {
+    public static boolean isExposed(BlockPos blockPos, Integer distanceToCheck) {
 	
-	outerloop:
+    	outerloop:
         for (Direction direction : Direction.values()) {
         	EXPOSED_POS.get().set(blockPos);
             for (int i = 1; i <= distanceToCheck; i++) {

--- a/src/main/resources/meteor-client.mixins.json
+++ b/src/main/resources/meteor-client.mixins.json
@@ -4,6 +4,7 @@
   "compatibilityLevel": "JAVA_17",
   "plugin": "meteordevelopment.meteorclient.MixinPlugin",
   "client": [
+  "ClientBrandRetrieverMixin",
     "AbstractBlockAccessor",
     "AbstractBlockMixin",
     "AbstractBlockStateMixin",


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [x] New feature

## Description

Fixes a bug where turning on brand spoofing in server spoof does not spoof the brand.

Adds a feature to x-ray to filter blocks based on how may blocks should be opaque, just like baritone has.

## Related issues

Fixes issue: #2404  

# How Has This Been Tested?

Checked if the exposedOnly option works with paper anti x-ray using [recommended settings from paper website](https://docs.papermc.io/paper/anti-xray)

Tested server brand spoofing using Vulcan anti cheat.

**Warning:** I do not have access to Wraith anti cheat so I could not test the server spoof with that. Vulcan does not seem to detect the fact that branding is being spoofed. This is Vulcan though so who can say how good this test is...

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.