### PR TITLE
Fix compatibility with Future Client

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/PlayerListHudMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/PlayerListHudMixin.java
@@ -17,12 +17,18 @@ import net.minecraft.client.network.PlayerListEntry;
 import net.minecraft.text.Text;
 import net.minecraft.util.math.MathHelper;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.*;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import java.util.List;
+
 @Mixin(PlayerListHud.class)
-public class PlayerListHudMixin {
+public abstract class PlayerListHudMixin {
+    @Shadow
+    protected abstract List<PlayerListEntry> collectPlayerEntries();
+
     @ModifyConstant(constant = @Constant(longValue = 80L), method = "collectPlayerEntries")
     private long modifyCount(long count) {
         BetterTab module = Modules.get().get(BetterTab.class);
@@ -51,7 +57,7 @@ public class PlayerListHudMixin {
 
         int newO;
         int newP = 1;
-        int totalPlayers = newO = module.tabSize.get();
+        int totalPlayers = newO = this.collectPlayerEntries().size();
         while (newO > module.tabHeight.get()) {
             newO = (totalPlayers + ++newP - 1) / newP;
         }

--- a/src/main/java/meteordevelopment/meteorclient/mixin/PlayerListHudMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/PlayerListHudMixin.java
@@ -5,6 +5,8 @@
 
 package meteordevelopment.meteorclient.mixin;
 
+import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.ref.LocalIntRef;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.misc.BetterTab;
 import net.minecraft.client.MinecraftClient;
@@ -42,10 +44,20 @@ public class PlayerListHudMixin {
         return module.isActive() && module.accurateLatency.get() ? width + 30 : width;
     }
 
-    @ModifyConstant(constant = @Constant(intValue = 20), method = "render")
-    private int modifyHeight(int height) {
+    @Inject(method = "render", at = @At(value = "INVOKE", target = "Ljava/lang/Math;min(II)I", shift = At.Shift.BEFORE))
+    private void modifyHeight(CallbackInfo ci, @Local(ordinal = 5)LocalIntRef o, @Local(ordinal = 6)LocalIntRef p) {
         BetterTab module = Modules.get().get(BetterTab.class);
-        return module.isActive() ? module.tabHeight.get() : height;
+        if (!module.isActive()) return;
+
+        int newO;
+        int newP = 1;
+        int totalPlayers = newO = module.tabSize.get();
+        while (newO > module.tabHeight.get()) {
+            newO = (totalPlayers + ++newP - 1) / newP;
+        }
+
+        o.set(newO);
+        p.set(newP);
     }
 
     @Inject(method = "renderLatencyIcon", at = @At("HEAD"), cancellable = true)


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

I've reimplemented modifyHeight() in PlayerListHudMixin.java to restore mixin compatibility with Future Client and prevent crashes, while maintaining full functionality of the BetterTab module in both clients.

## Related issues
This pull request is related to the following issues:
[#4422](https://github.com/MeteorDevelopment/meteor-client/issues/4422),
[#4353](https://github.com/MeteorDevelopment/meteor-client/issues/4353),
[#4303](https://github.com/MeteorDevelopment/meteor-client/issues/4303),
[#4141](https://github.com/MeteorDevelopment/meteor-client/issues/4141),
[#4094](https://github.com/MeteorDevelopment/meteor-client/issues/4094)

# How Has This Been Tested?

I tested these changes on Minecraft version 1.20.4 with the newest versions of both Future Client and Rusherhack installed. No additional conflicts occurred, and both Meteor's BetterTab and Future's ExtraTab function as desired.

This is Meteor's BetterTab on 2b2t:
![Meteor BetterTab fixed](https://github.com/MeteorDevelopment/meteor-client/assets/103238549/3af71b27-0c0a-431a-a30c-159535020cea)
and this is Future's ExtraTab right afterwards:
![Future ExtraTab compatible](https://github.com/MeteorDevelopment/meteor-client/assets/103238549/debe41c6-e1b7-4192-98f8-596f02e53968)


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
