### PR TITLE
Fix AutoTool for Wool Blocks

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoTool.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoTool.java
@@ -22,6 +22,7 @@ import net.minecraft.block.*;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.enchantment.Enchantments;
 import net.minecraft.item.*;
+import net.minecraft.registry.tag.BlockTags;
 
 import java.util.List;
 import java.util.function.Predicate;
@@ -189,7 +190,7 @@ public class AutoTool extends Module {
 
     public static double getScore(ItemStack itemStack, BlockState state, boolean silkTouchEnderChest, boolean fortuneOre, EnchantPreference enchantPreference, Predicate<ItemStack> good) {
         if (!good.test(itemStack) || !isTool(itemStack)) return -1;
-        if (!itemStack.isSuitableFor(state) && !(itemStack.getItem() instanceof SwordItem && (state.getBlock() instanceof BambooBlock || state.getBlock() instanceof BambooShootBlock)) && !(itemStack.getItem() instanceof ShearsItem && state.getBlock() instanceof LeavesBlock || isWoolBlock(state.getBlock()))) return -1;
+        if (!itemStack.isSuitableFor(state) && !(itemStack.getItem() instanceof SwordItem && (state.getBlock() instanceof BambooBlock || state.getBlock() instanceof BambooShootBlock)) && !(itemStack.getItem() instanceof ShearsItem && state.getBlock() instanceof LeavesBlock || state.isIn(BlockTags.WOOL))) return -1;
 
         if (silkTouchEnderChest
             && state.getBlock() == Blocks.ENDER_CHEST
@@ -227,24 +228,6 @@ public class AutoTool extends Module {
         return isTool(itemStack.getItem());
     }
 
-    private static boolean isWoolBlock(Block block) {
-        return block == Blocks.WHITE_WOOL
-            || block == Blocks.BLACK_WOOL
-            || block == Blocks.BLUE_WOOL
-            || block == Blocks.BROWN_WOOL
-            || block == Blocks.GRAY_WOOL
-            || block == Blocks.CYAN_WOOL
-            || block == Blocks.GREEN_WOOL
-            || block == Blocks.LIGHT_BLUE_WOOL
-            || block == Blocks.LIGHT_GRAY_WOOL
-            || block == Blocks.LIME_WOOL
-            || block == Blocks.MAGENTA_WOOL
-            || block == Blocks.ORANGE_WOOL
-            || block == Blocks.PINK_WOOL
-            || block == Blocks.PURPLE_WOOL
-            || block == Blocks.RED_WOOL
-            || block == Blocks.YELLOW_WOOL;
-    }
 
     private static boolean isFortunable(Block block) {
         if (block == Blocks.ANCIENT_DEBRIS) return false;

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoTool.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoTool.java
@@ -189,7 +189,7 @@ public class AutoTool extends Module {
 
     public static double getScore(ItemStack itemStack, BlockState state, boolean silkTouchEnderChest, boolean fortuneOre, EnchantPreference enchantPreference, Predicate<ItemStack> good) {
         if (!good.test(itemStack) || !isTool(itemStack)) return -1;
-        if (!itemStack.isSuitableFor(state) && !(itemStack.getItem() instanceof SwordItem && (state.getBlock() instanceof BambooBlock || state.getBlock() instanceof BambooShootBlock)) && !(itemStack.getItem() instanceof ShearsItem && (state.getBlock() instanceof LeavesBlock))) return -1;
+        if (!itemStack.isSuitableFor(state) && !(itemStack.getItem() instanceof SwordItem && (state.getBlock() instanceof BambooBlock || state.getBlock() instanceof BambooShootBlock)) && !(itemStack.getItem() instanceof ShearsItem && state.getBlock() instanceof LeavesBlock || isWoolBlock(state.getBlock()))) return -1;
 
         if (silkTouchEnderChest
             && state.getBlock() == Blocks.ENDER_CHEST
@@ -225,6 +225,25 @@ public class AutoTool extends Module {
     }
     public static boolean isTool(ItemStack itemStack) {
         return isTool(itemStack.getItem());
+    }
+
+    private static boolean isWoolBlock(Block block) {
+        return block == Blocks.WHITE_WOOL
+            || block == Blocks.BLACK_WOOL
+            || block == Blocks.BLUE_WOOL
+            || block == Blocks.BROWN_WOOL
+            || block == Blocks.GRAY_WOOL
+            || block == Blocks.CYAN_WOOL
+            || block == Blocks.GREEN_WOOL
+            || block == Blocks.LIGHT_BLUE_WOOL
+            || block == Blocks.LIGHT_GRAY_WOOL
+            || block == Blocks.LIME_WOOL
+            || block == Blocks.MAGENTA_WOOL
+            || block == Blocks.ORANGE_WOOL
+            || block == Blocks.PINK_WOOL
+            || block == Blocks.PURPLE_WOOL
+            || block == Blocks.RED_WOOL
+            || block == Blocks.YELLOW_WOOL;
     }
 
     private static boolean isFortunable(Block block) {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Fixes AutoTool not switching to shears when breaking wool blocks.

## Related issues

closes #4065

# How Has This Been Tested?

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
