### PR TITLE
Use tickDelta in RenderBlock for smoother rendering

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/utils/render/RenderUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/RenderUtils.java
@@ -164,12 +164,13 @@ public class RenderUtils {
             double x1 = pos.getX(), y1 = pos.getY(), z1 = pos.getZ(),
                    x2 = pos.getX() + 1, y2 = pos.getY() + 1, z2 = pos.getZ() + 1;
 
+            double d = (double) (ticks - event.tickDelta) / duration;
+
             if (fade) {
-                sideColor.a *= (double) ticks / duration;
-                lineColor.a *= (double) ticks / duration;
+                sideColor.a = (int) (sideColor.a * d);
+                lineColor.a = (int) (lineColor.a * d);
             }
             if (shrink) {
-                double d = (double) ticks / duration;
                 x1 += d; y1 += d; z1 += d;
                 x2 -= d; y2 -= d; z2 -= d;
             }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Makes the RenderBlock use Render3DEvent.tickDelta for smoother rendering

## Related issues

None

# How Has This Been Tested?

Tested in development environment with:
```java
RenderUtils.renderTickingBlock(new BlockPos(0, 70, 0).toImmutable(), Color.CYAN, Color.CYAN, ShapeMode.Both, 0, 10, true, false)
RenderUtils.renderTickingBlock(new BlockPos(0, 70, 0).toImmutable(), Color.CYAN, Color.CYAN, ShapeMode.Both, 0, 10, false, true)
```

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
