### PR TITLE
Fixed ServerSpoof sending incorrect client brand

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/events/game/ClientBrandRetrieverEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/game/ClientBrandRetrieverEvent.java
@@ -1,0 +1,22 @@
+package meteordevelopment.meteorclient.events.game;
+
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import meteordevelopment.meteorclient.events.Cancellable;
+
+public class ClientBrandRetrieverEvent extends Cancellable {
+	private static final ClientBrandRetrieverEvent INSTANCE = new ClientBrandRetrieverEvent();
+	
+	public CallbackInfoReturnable<String> info;
+	
+
+    public static ClientBrandRetrieverEvent get(CallbackInfoReturnable<String> info) {
+    	ClientBrandRetrieverEvent event = INSTANCE;
+    	
+    	event.setCancelled(false);
+    	event.info = info;
+    	
+    	return event;
+    }
+}
+

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientBrandRetrieverMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientBrandRetrieverMixin.java
@@ -1,0 +1,25 @@
+package meteordevelopment.meteorclient.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import meteordevelopment.meteorclient.MeteorClient;
+import meteordevelopment.meteorclient.events.game.ClientBrandRetrieverEvent;
+import net.minecraft.client.ClientBrandRetriever;
+
+@Mixin(ClientBrandRetriever.class)
+public class ClientBrandRetrieverMixin {
+	@Inject(at = @At("HEAD"), method = "getClientModName", cancellable = true, remap = false)
+	private static void getConfiguredClientBrand(CallbackInfoReturnable<String> info) {
+		ClientBrandRetrieverEvent event = MeteorClient.EVENT_BUS.post(ClientBrandRetrieverEvent.get(info));
+		
+		if(event.isCancelled()) {
+			return;
+		}
+		
+		info.setReturnValue(event.info.getReturnValue());
+		
+	}
+}

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/ServerSpoof.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/ServerSpoof.java
@@ -5,10 +5,19 @@
 
 package meteordevelopment.meteorclient.systems.modules.misc;
 
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
 import io.netty.buffer.Unpooled;
 import meteordevelopment.meteorclient.MeteorClient;
+import meteordevelopment.meteorclient.events.game.ClientBrandRetrieverEvent;
 import meteordevelopment.meteorclient.events.packets.PacketEvent;
-import meteordevelopment.meteorclient.settings.*;
+import meteordevelopment.meteorclient.settings.BoolSetting;
+import meteordevelopment.meteorclient.settings.Setting;
+import meteordevelopment.meteorclient.settings.SettingGroup;
+import meteordevelopment.meteorclient.settings.StringListSetting;
+import meteordevelopment.meteorclient.settings.StringSetting;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.orbit.EventHandler;
@@ -22,9 +31,6 @@ import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
-import org.apache.commons.lang3.StringUtils;
-
-import java.util.List;
 
 public class ServerSpoof extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
@@ -73,14 +79,34 @@ public class ServerSpoof extends Module {
     }
 
     private class Listener {
+    	
+    	@EventHandler
+    	private void onClientBrandRetrive(ClientBrandRetrieverEvent event) {
+    		if (spoofBrand.get()) event.info.setReturnValue(brand.get());
+    	}
+    	
         @EventHandler
         private void onPacketSend(PacketEvent.Send event) {
             if (!isActive()) return;
             if (!(event.packet instanceof CustomPayloadC2SPacket)) return;
             Identifier id = ((CustomPayloadC2SPacket) event.packet).payload().id();
+            
+            if(spoofBrand.get()) {
+            	if (id.equals(BrandCustomPayload.ID)) {
+                    event.packet.write(new PacketByteBuf(Unpooled.buffer()).writeString(brand.get()));
+                } else if (StringUtils.containsIgnoreCase(id.toString(), "fabric:registry/sync")) {
+	                event.cancel();
+	                return;
+	            } else if (StringUtils.containsIgnoreCase(id.toString(), "fabric:container/open")) {
+	                event.cancel();
+	                return;
+	            } else if (StringUtils.containsIgnoreCase(id.toString(), "fabric-screen-handler-api-v1:open_screen")) {
+	                event.cancel();
+	                return;
+	            }
+            }
 
-            if (spoofBrand.get() && id.equals(BrandCustomPayload.ID))
-                event.packet.write(new PacketByteBuf(Unpooled.buffer()).writeString(brand.get()));
+            
 
             if (blockChannels.get()) {
                 for (String channel : channels.get()) {

--- a/src/main/resources/meteor-client.mixins.json
+++ b/src/main/resources/meteor-client.mixins.json
@@ -4,6 +4,7 @@
   "compatibilityLevel": "JAVA_17",
   "plugin": "meteordevelopment.meteorclient.MixinPlugin",
   "client": [
+    "ClientBrandRetrieverMixin",
     "AbstractBlockAccessor",
     "AbstractBlockMixin",
     "AbstractBlockStateMixin",


### PR DESCRIPTION
## Type of change

- [x] Bug fix

## Description

Fixes a bug where turning on brand spoofing in server spoof does not spoof the brand.

## Related issues

Fixes issue: https://github.com/MeteorDevelopment/meteor-client/issues/2404

# How Has This Been Tested?

Tested server brand spoofing using Vulcan anti cheat.

**Warning:** I do not have access to Wraith anti cheat so I could not test the server spoof with that. Vulcan does not seem to detect the fact that branding is being spoofed. This is Vulcan though so who can say how good this test is...

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
