### PR TITLE
Added glow ESP so that ESP can esily be used with shaders.

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/ESP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/ESP.java
@@ -74,6 +74,7 @@ public class ESP extends Module {
     public final Setting<ShapeMode> shapeMode = sgGeneral.add(new EnumSetting.Builder<ShapeMode>()
         .name("shape-mode")
         .description("How the shapes are rendered.")
+        .visible(() -> mode.get() != Mode.Glow)
         .defaultValue(ShapeMode.Both)
         .build()
     );
@@ -81,7 +82,7 @@ public class ESP extends Module {
     public final Setting<Double> fillOpacity = sgGeneral.add(new DoubleSetting.Builder()
         .name("fill-opacity")
         .description("The opacity of the shape fill.")
-        .visible(() -> shapeMode.get() != ShapeMode.Lines)
+        .visible(() -> shapeMode.get() != ShapeMode.Lines && mode.get() != Mode.Glow)
         .defaultValue(0.3)
         .range(0, 1)
         .sliderMax(1)
@@ -348,13 +349,17 @@ public class ESP extends Module {
     public boolean isShader() {
         return isActive() && mode.get() == Mode.Shader;
     }
+    
+    public boolean isGlow() {
+        return isActive() && mode.get() == Mode.Glow;
+    }
 
     public enum Mode {
         Box,
         Wireframe,
         _2D,
-        Shader;
-
+        Shader,
+        Glow;
         @Override
         public String toString() {
             return this == _2D ? "2D" : super.toString();


### PR DESCRIPTION
## Type of change

- [x] New feature

## Description

Added glow ESP so that ESP can esily be used with shaders.
Makes mobs glow as if they have a glow potion effect.

# How Has This Been Tested?

Tested with iris and sodium.
Shaders work well as it is using vanilla glow effect.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
