### PR TITLE
Nametags: Add option to show item durability as a percentage.

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Nametags.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Nametags.java
@@ -147,6 +147,14 @@ public class Nametags extends Module {
         .build()
     );
 
+    private final Setting<Boolean> itemDurability = sgPlayers.add(new BoolSetting.Builder()
+        .name("show-durability")
+        .description("Displays item durability as a percentage.")
+        .defaultValue(false)
+        .visible(displayItems::get)
+        .build()
+    );
+
     private final Setting<Double> itemSpacing = sgPlayers.add(new DoubleSetting.Builder()
         .name("item-spacing")
         .description("The spacing between items.")
@@ -498,6 +506,16 @@ public class Nametags extends Module {
                 ItemStack stack = getItem(player, i);
 
                 RenderUtils.drawItem(event.drawContext, stack, (int) x, (int) y, 2, true);
+
+                if (stack.isDamageable() && itemDurability.get()) {
+                    text.begin(0.75, false, true);
+
+                    int damagePercentage = Math.round(((stack.getMaxDamage() - stack.getDamage()) * 100f) / (float) stack.getMaxDamage());
+                    Color damageColor = new Color(stack.getItemBarColor());
+
+                    text.render(damagePercentage + "%", (int) x, (int) y, damageColor.a(255), true);
+                    text.end();
+                }
 
                 if (maxEnchantCount > 0 && displayEnchants.get()) {
                     text.begin(0.5 * enchantTextScale.get(), false, true);

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Nametags.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Nametags.java
@@ -147,14 +147,6 @@ public class Nametags extends Module {
         .build()
     );
 
-    private final Setting<Boolean> itemDurability = sgPlayers.add(new BoolSetting.Builder()
-        .name("show-durability")
-        .description("Displays item durability as a percentage.")
-        .defaultValue(false)
-        .visible(displayItems::get)
-        .build()
-    );
-
     private final Setting<Double> itemSpacing = sgPlayers.add(new DoubleSetting.Builder()
         .name("item-spacing")
         .description("The spacing between items.")
@@ -168,6 +160,14 @@ public class Nametags extends Module {
         .name("ignore-empty-slots")
         .description("Doesn't add spacing where an empty item stack would be.")
         .defaultValue(true)
+        .visible(displayItems::get)
+        .build()
+    );
+
+    private final Setting<Boolean> itemDurability = sgPlayers.add(new BoolSetting.Builder()
+        .name("show-durability")
+        .description("Displays item durability as a percentage.")
+        .defaultValue(false)
         .visible(displayItems::get)
         .build()
     );

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Nametags.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Nametags.java
@@ -164,10 +164,10 @@ public class Nametags extends Module {
         .build()
     );
 
-    private final Setting<Boolean> itemDurability = sgPlayers.add(new BoolSetting.Builder()
-        .name("show-durability")
-        .description("Displays item durability as a percentage.")
-        .defaultValue(false)
+    private final Setting<Durability> itemDurability = sgPlayers.add(new EnumSetting.Builder<Durability>()
+        .name("durability")
+        .description("Displays item durability as either a total, percentage, or neither.")
+        .defaultValue(Durability.None)
         .visible(displayItems::get)
         .build()
     );
@@ -507,13 +507,17 @@ public class Nametags extends Module {
 
                 RenderUtils.drawItem(event.drawContext, stack, (int) x, (int) y, 2, true);
 
-                if (stack.isDamageable() && itemDurability.get()) {
+                if (stack.isDamageable() && itemDurability.get() != Durability.None) {
                     text.begin(0.75, false, true);
 
-                    int damagePercentage = Math.round(((stack.getMaxDamage() - stack.getDamage()) * 100f) / (float) stack.getMaxDamage());
+                    String damageText = switch (itemDurability.get()) {
+                        case Percentage -> String.format("%.0f%%", ((stack.getMaxDamage() - stack.getDamage()) * 100f) / (float) stack.getMaxDamage());
+                        case Total -> Integer.toString(stack.getMaxDamage() - stack.getDamage());
+                        default -> "err";
+                    };
                     Color damageColor = new Color(stack.getItemBarColor());
 
-                    text.render(damagePercentage + "%", (int) x, (int) y, damageColor.a(255), true);
+                    text.render(damageText, (int) x, (int) y, damageColor.a(255), true);
                     text.end();
                 }
 
@@ -677,6 +681,12 @@ public class Nametags extends Module {
     public enum Position {
         Above,
         OnTop
+    }
+
+    public enum Durability {
+        None,
+        Total,
+        Percentage
     }
 
     public enum DistanceColorMode {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature

## Description

An option to display item percentage durability on player nametags. Disabled by default.

## Related issues

None

# How Has This Been Tested?

![2024-04-01_03-47-area](https://github.com/MeteorDevelopment/meteor-client/assets/55615254/b5eccd87-cc82-4c76-b980-39bb6d9233b6)

- Tested in singleplayer with freecam, fake players, other players on LAN
- Tested in a multiplayer server with 50+ players without significant FPS drop (77 -> 73 FPS)

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
