### PR TITLE
Fix incorrect Criticals name mode

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Criticals.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Criticals.java
@@ -73,7 +73,7 @@ public class Criticals extends Module {
                     sendPacket(0.0625);
                     sendPacket(0);
                 }
-                case Bypass -> {
+                case NCP_Packet -> {
                     sendPacket(0.11);
                     sendPacket(0.1100013579);
                     sendPacket(0.0000013579);
@@ -142,8 +142,13 @@ public class Criticals extends Module {
 
     public enum Mode {
         Packet,
-        Bypass,
+        NCP_Packet,
         Jump,
-        MiniJump
+        MiniJump;
+
+        @Override
+	    public String toString() {
+		    return super.toString().replace('_', ' ');
+	    }
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Criticals.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Criticals.java
@@ -143,7 +143,8 @@ public class Criticals extends Module {
     public enum Mode {
         Packet,
         NCP_Packet,
-        Jump;
+        Jump,
+        MiniJump;
 
         @Override
 	    public String toString() {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Criticals.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Criticals.java
@@ -143,8 +143,7 @@ public class Criticals extends Module {
     public enum Mode {
         Packet,
         NCP_Packet,
-        Jump,
-        MiniJump;
+        Jump;
 
         @Override
 	    public String toString() {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description
Fix incorrect Criticals mode name

# How Has This Been Tested?
Its dont crash, and all clients has this name for this bypass

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
