### PR TITLE
Make Waypoints use Type

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/WaypointsModule.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/WaypointsModule.java
@@ -161,6 +161,7 @@ public class WaypointsModule extends Module {
                 .icon("skull")
                 .pos(BlockPos.ofFloored(deathPos).up(2))
                 .dimension(PlayerUtils.getDimension())
+                .type(Waypoint.Type.DEATH)
                 .build();
 
             Waypoints.get().add(waypoint);
@@ -175,7 +176,7 @@ public class WaypointsModule extends Module {
         ListIterator<Waypoint> wps = Waypoints.get().iteratorReverse();
         while (wps.hasPrevious()) {
             Waypoint wp = wps.previous();
-            if (wp.name.get().startsWith("Death ") && "skull".equals(wp.icon.get())) {
+            if (wp.getType() == Waypoint.Type.DEATH) {
                 oldWpC++;
                 if (oldWpC > max)
                     Waypoints.get().remove(wp);

--- a/src/main/java/meteordevelopment/meteorclient/systems/waypoints/Waypoint.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/waypoints/Waypoint.java
@@ -22,6 +22,13 @@ import java.util.Map;
 import java.util.Objects;
 
 public class Waypoint implements ISerializable<Waypoint> {
+    // enum to store our Waypoints Type
+    public enum Type {
+        PLAYER_CREATED,
+        DEATH
+    }
+    private Type type;
+
     public final Settings settings = new Settings();
 
     private final SettingGroup sgVisual = settings.createGroup("Visual");
@@ -93,7 +100,15 @@ public class Waypoint implements ISerializable<Waypoint> {
         .build()
     );
 
-    private Waypoint() {}
+    private Waypoint(Type type) {
+        this.type = type;
+    }
+
+    // Getter for type
+    public Type getType() {
+        return type;
+    }
+
     public Waypoint(NbtElement tag) {
         fromTag((NbtCompound) tag);
     }
@@ -140,6 +155,7 @@ public class Waypoint implements ISerializable<Waypoint> {
         private String name = "", icon = "";
         private BlockPos pos = BlockPos.ORIGIN;
         private Dimension dimension = Dimension.Overworld;
+        private Type type = Type.PLAYER_CREATED;
 
         public Builder name(String name) {
             this.name = name;
@@ -161,8 +177,15 @@ public class Waypoint implements ISerializable<Waypoint> {
             return this;
         }
 
+        public Builder type(Type type) {
+            this.type = type;
+            return this;
+        }
+
+
+
         public Waypoint build() {
-            Waypoint waypoint = new Waypoint();
+            Waypoint waypoint = new Waypoint(type);
 
             if (!name.equals(waypoint.name.getDefaultValue())) waypoint.name.set(name);
             if (!icon.equals(waypoint.icon.getDefaultValue())) waypoint.icon.set(icon);


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Previously, the deletion of Waypoints was simply determined based on a hardcoded condition:
```java
if (wp.name.get().startsWith("Death ") && "skull".equals(wp.icon.get())) {
```
This isn't really the best, as if the default name of Deaths in `addDeath()` were to change, this clause would also have to be modified. Also Waypoint Types could be useful in the future, if perhaps adding waypoint categories ever were to become a thing. Overall this is just something good to have in case.
# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
