### PR TITLE
Add Null Checks to TextRendererMixin

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/TextRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/TextRendererMixin.java
@@ -15,6 +15,9 @@ import org.spongepowered.asm.mixin.injection.At;
 public class TextRendererMixin {
     @ModifyExpressionValue(method = "accept", at = @At(value = "INVOKE", target = "Lnet/minecraft/text/Style;isObfuscated()Z"))
     private boolean onRenderObfuscatedStyle(boolean original) {
+        if (Modules.get() == null || Modules.get().get(NoRender.class) == null) {
+            return original;
+        }
         return !Modules.get().get(NoRender.class).noObfuscation() && original;
     }
 }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

This pull request adds null safety checks to the [TextRendererMixin](https://github.com/MeteorDevelopment/meteor-client/blob/53b141f12797234904b4968808e631ffb02919f9/src/main/java/meteordevelopment/meteorclient/mixin/TextRendererMixin.java#L15). The changes prevent a `NullPointerException` from occurring when the `TextRendererMixin` tries to access the `Modules` system before it has been initialized.

## Related issues

This improves compatibility with other mods that utilize Minecraft's text renderer.

# How Has This Been Tested?

I loaded it up on Fabric 1.20.4, gave myself an item with an obfuscated name and toggled obfuscation in NoRender module to ensure it still works.

![image](https://github.com/MeteorDevelopment/meteor-client/assets/37921711/f7d39250-8388-4d9c-a319-7722ed40ab08)
![image](https://github.com/MeteorDevelopment/meteor-client/assets/37921711/847e5021-bd35-4eab-82fd-778d916e73d6)


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
