### PR TITLE
Allow Trajectories to be used with off-hand item

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Trajectories.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Trajectories.java
@@ -140,8 +140,6 @@ public class Trajectories extends Module {
 
         // Get item
         ItemStack itemStack = player.getMainHandStack();
-        if (itemStack == null) itemStack = player.getOffHandStack();
-        if (itemStack == null) return;
         if (!items.get().contains(itemStack.getItem())) {
             itemStack = player.getOffHandStack();
             if (!items.get().contains(itemStack.getItem())) return;

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Trajectories.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Trajectories.java
@@ -142,7 +142,10 @@ public class Trajectories extends Module {
         ItemStack itemStack = player.getMainHandStack();
         if (itemStack == null) itemStack = player.getOffHandStack();
         if (itemStack == null) return;
-        if (!items.get().contains(itemStack.getItem())) return;
+        if (!items.get().contains(itemStack.getItem())) {
+            itemStack = player.getOffHandStack();
+            if (!items.get().contains(itemStack.getItem())) return;
+        }
 
         // Calculate paths
         if (!simulator.set(player, itemStack, 0, accurate.get(), tickDelta)) return;


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Allows Trajectories to be used with off-hand item stack, by checking both the MainHand and OffHand stacks when determining whether the item in the stack is in the whitelist instead of just the MainHand stack before returning, even if the MainHand stack is not null.

# How Has This Been Tested?

![image](https://github.com/MeteorDevelopment/meteor-client/assets/52387455/fe1b0b85-011c-47dd-8a87-8d14814f3e10)

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
