### PR TITLE
Improve ClickTP adding paperclip exploit

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/ClickTP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/ClickTP.java
@@ -6,9 +6,6 @@
 package meteordevelopment.meteorclient.systems.modules.movement;
 
 import meteordevelopment.meteorclient.events.world.TickEvent;
-import meteordevelopment.meteorclient.settings.DoubleSetting;
-import meteordevelopment.meteorclient.settings.Setting;
-import meteordevelopment.meteorclient.settings.SettingGroup;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.orbit.EventHandler;
@@ -25,8 +22,6 @@ import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.world.RaycastContext;
-
-import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class ClickTP extends Module {
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/ClickTP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/ClickTP.java
@@ -13,6 +13,8 @@ import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.orbit.EventHandler;
 import net.minecraft.block.BlockState;
+import net.minecraft.client.render.Camera;
+import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
@@ -20,17 +22,13 @@ import net.minecraft.util.hit.EntityHitResult;
 import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.world.RaycastContext;
+
+import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class ClickTP extends Module {
-    private final SettingGroup sgGeneral = settings.getDefaultGroup();
-
-    private final Setting<Double> maxDistance = sgGeneral.add(new DoubleSetting.Builder()
-        .name("max-distance")
-        .description("The maximum distance you can teleport.")
-        .defaultValue(5)
-        .build()
-    );
 
     public ClickTP() {
         super(Categories.Movement, "click-tp", "Teleports you to the block you click on.");
@@ -41,9 +39,28 @@ public class ClickTP extends Module {
         if (mc.player.isUsingItem()) return;
 
         if (mc.options.useKey.isPressed()) {
-            HitResult hitResult = mc.player.raycast(maxDistance.get(), 1f / 20f, false);
+            HitResult simulateHit = mc.player.raycast(6, 1f / 20f, false);
+            if (simulateHit.getType() == HitResult.Type.ENTITY && mc.player.interact(((EntityHitResult) simulateHit).getEntity(), Hand.MAIN_HAND) != ActionResult.PASS) return;
 
-            if (hitResult.getType() == HitResult.Type.ENTITY && mc.player.interact(((EntityHitResult) hitResult).getEntity(), Hand.MAIN_HAND) != ActionResult.PASS) return;
+            Camera camera = mc.gameRenderer.getCamera();
+            Vec3d cameraPos = camera.getPos();
+
+            // Calculate the direction the camera is looking based on its pitch and yaw, and extend this direction 210 units away from the camera position
+            // 210 is used here as the maximum distance for this exploit is 200 blocks
+            // This is done to be able to click tp while in freecam
+            Vec3d direction = Vec3d.fromPolar(camera.getPitch(), camera.getYaw()).multiply(210);
+            Vec3d targetPos = cameraPos.add(direction);
+
+            RaycastContext context = new RaycastContext(
+                cameraPos,   // start position of the ray
+                targetPos,   // end position of the ray
+                RaycastContext.ShapeType.OUTLINE,
+                RaycastContext.FluidHandling.NONE,
+                mc.player
+            );
+
+            HitResult hitResult = mc.world.raycast(context);
+
 
             if (hitResult.getType() == HitResult.Type.BLOCK) {
                 BlockPos pos = ((BlockHitResult) hitResult).getBlockPos();
@@ -58,7 +75,15 @@ public class ClickTP extends Module {
 
                 double height = shape.isEmpty() ? 1 : shape.getMax(Direction.Axis.Y);
 
-                mc.player.setPosition(pos.getX() + 0.5 + side.getOffsetX(), pos.getY() + height, pos.getZ() + 0.5 + side.getOffsetZ());
+                Vec3d newPos = new Vec3d(pos.getX() + 0.5 + side.getOffsetX(), pos.getY() + height, pos.getZ() + 0.5 + side.getOffsetZ());
+                int packetsRequired = (int) Math.ceil(mc.player.getPos().distanceTo(newPos) / 10) - 1; // subtract 1 to account for the final packet with movement
+
+                for (int packetNumber = 0; packetNumber < (packetsRequired); packetNumber++) {
+                    mc.player.networkHandler.sendPacket(new PlayerMoveC2SPacket.OnGroundOnly(true));
+                }
+
+                mc.player.networkHandler.sendPacket(new PlayerMoveC2SPacket.PositionAndOnGround(newPos.x, newPos.y, newPos.z, true));
+                mc.player.setPosition(newPos);
             }
         }
     }


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Added the liveoverflow teleportation exploit to click tp and made it work while using freecam.

## Related issues

#2775 

Tested on a papermc server

https://github.com/MeteorDevelopment/meteor-client/assets/57022279/e881687e-4e40-4688-aef9-c5d6646c19b6



# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
