### PR TITLE
use real command source for meteor commands

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/commands/Command.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/Command.java
@@ -9,32 +9,34 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.ArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.builder.RequiredArgumentBuilder;
+import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.systems.config.Config;
 import meteordevelopment.meteorclient.utils.Utils;
 import meteordevelopment.meteorclient.utils.player.ChatUtils;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.command.CommandRegistryAccess;
 import net.minecraft.command.CommandSource;
 import net.minecraft.registry.BuiltinRegistries;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.text.Text;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 public abstract class Command {
     protected static final CommandRegistryAccess REGISTRY_ACCESS = CommandManager.createRegistryAccess(BuiltinRegistries.createWrapperLookup());
+    protected static final int SINGLE_SUCCESS = com.mojang.brigadier.Command.SINGLE_SUCCESS;
+    protected static final MinecraftClient mc = MeteorClient.mc;
 
     private final String name;
     private final String title;
     private final String description;
-    private final List<String> aliases = new ArrayList<>();
+    private final List<String> aliases;
 
     public Command(String name, String description, String... aliases) {
         this.name = name;
         this.title = Utils.nameToTitle(name);
         this.description = description;
-        Collections.addAll(this.aliases, aliases);
+        this.aliases = List.of(aliases);
     }
 
     // Helper methods to painlessly infer the CommandSource generic type argument

--- a/src/main/java/meteordevelopment/meteorclient/commands/Commands.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/Commands.java
@@ -10,7 +10,6 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import meteordevelopment.meteorclient.commands.commands.*;
 import meteordevelopment.meteorclient.pathing.PathManagers;
 import meteordevelopment.meteorclient.utils.PostInit;
-import net.minecraft.client.network.ClientCommandSource;
 import net.minecraft.command.CommandSource;
 
 import java.util.ArrayList;
@@ -21,7 +20,6 @@ import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class Commands {
     public static final CommandDispatcher<CommandSource> DISPATCHER = new CommandDispatcher<>();
-    public static final CommandSource COMMAND_SOURCE = new ClientCommandSource(null, mc);
     public static final List<Command> COMMANDS = new ArrayList<>();
 
     @PostInit(dependencies = PathManagers.class)
@@ -74,7 +72,7 @@ public class Commands {
     }
 
     public static void dispatch(String message) throws CommandSyntaxException {
-        DISPATCHER.execute(message, COMMAND_SOURCE);
+        DISPATCHER.execute(message, mc.getNetworkHandler().getCommandSource());
     }
 
     public static Command get(String name) {

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ChatInputSuggestorMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ChatInputSuggestorMixin.java
@@ -23,6 +23,8 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import java.util.concurrent.CompletableFuture;
 
+import static meteordevelopment.meteorclient.MeteorClient.mc;
+
 @Mixin(ChatInputSuggestor.class)
 public abstract class ChatInputSuggestorMixin {
     @Shadow private ParseResults<CommandSource> parse;
@@ -46,7 +48,7 @@ public abstract class ChatInputSuggestorMixin {
             reader.setCursor(reader.getCursor() + length);
 
             if (this.parse == null) {
-                this.parse = Commands.DISPATCHER.parse(reader, Commands.COMMAND_SOURCE);
+                this.parse = Commands.DISPATCHER.parse(reader, mc.getNetworkHandler().getCommandSource());
             }
 
             int cursor = textField.getCursor();


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

- use real command source to prevent some argument types from crashing with a weird error
- add useful fields to `Command`
- lower `Command` memory usage

# How Has This Been Tested?

i have secretly been implementing all of these as mixins in my addons for a while

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
