### PR TITLE
Added Cachebusting to the badges and removed the tokei.rs badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 <div align="center">
     <a href="https://discord.gg/bBGQZvd"><img src="https://img.shields.io/discord/689197705683140636?logo=discord" alt="Discord"/></a>
     <br>
-    <img src="https://img.shields.io/github/last-commit/MeteorDevelopment/meteor-client" alt="GitHub last commit"/>
-    <img src="https://img.shields.io/github/commit-activity/w/MeteorDevelopment/meteor-client" alt="GitHub commit activity"/>
-    <img src="https://img.shields.io/github/contributors/MeteorDevelopment/meteor-client" alt="GitHub contributors"/>
+    <img src="https://img.shields.io/github/last-commit/MeteorDevelopment/meteor-client?ac=1" alt="GitHub last commit"/>
+    <img src="https://img.shields.io/github/commit-activity/w/MeteorDevelopment/meteor-client?ac=1" alt="GitHub commit activity"/>
+    <img src="https://img.shields.io/github/contributors/MeteorDevelopment/meteor-client?ac=1" alt="GitHub contributors"/>
     <br>
-    <img src="https://img.shields.io/github/languages/code-size/MeteorDevelopment/meteor-client" alt="GitHub code size in bytes"/>
-    <img src="https://tokei.rs/b1/github/MeteorDevelopment/meteor-client" alt="GitHub lines of code"/>
+    <img src="https://img.shields.io/github/languages/code-size/MeteorDevelopment/meteor-client?ac=1" alt="GitHub code size in bytes"/>
+   <!-- <img src="https://tokei.rs/b1/github/MeteorDevelopment/meteor-client?ac=1" alt="GitHub lines of code"/> -->
 </div>
 
 ## Usage


### PR DESCRIPTION
https://www.keycdn.com/support/what-is-cache-busting

Tokei.rs is down for more than a week and the defective badge looks unprofessional 

https://www.isitdownrightnow.com/tokei.rs.html

## Type of change
<!--
- [ ] Bug fix
- [ ] New feature-->
- [x] Maintenance 

## Description

A summary of the changes along with the reasoning behind the changes.
The Readme is the first thing you look at, I figured to remove the unreliable badge and to add Cache-busting because that's the only method to stop GitHub from caching the stats, presenting old information.



# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas. (none)
- [x] I have tested the code in both development and production environments. (not applicable)
