### PR TITLE
Fixed Criticals not working

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/events/packets/PacketEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/packets/PacketEvent.java
@@ -27,7 +27,6 @@ public class PacketEvent {
     public static class Send extends Cancellable {
         private static final Send INSTANCE = new Send();
 
-        // overwriting this will overwrite the packet being sent
         public Packet<?> packet;
 
         public static Send get(Packet<?> packet) {

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientConnectionMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientConnectionMixin.java
@@ -5,8 +5,6 @@
 
 package meteordevelopment.meteorclient.mixin;
 
-import com.llamalad7.mixinextras.sugar.Local;
-import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.proxy.Socks4ProxyHandler;
@@ -69,9 +67,9 @@ public abstract class ClientConnectionMixin {
     }
 
     @Inject(at = @At("HEAD"), method = "send(Lnet/minecraft/network/packet/Packet;Lnet/minecraft/network/PacketCallbacks;)V", cancellable = true)
-    private void onSendPacketHead(CallbackInfo info, @Local(argsOnly = true) Packet<?> packet) {
+    private void onSendPacketHead(Packet<?> packet, PacketCallbacks callbacks, CallbackInfo ci) {
         if (MeteorClient.EVENT_BUS.post(PacketEvent.Send.get(packet)).isCancelled()) {
-            info.cancel();
+            ci.cancel();
         }
     }
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientConnectionMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientConnectionMixin.java
@@ -69,12 +69,9 @@ public abstract class ClientConnectionMixin {
     }
 
     @Inject(at = @At("HEAD"), method = "send(Lnet/minecraft/network/packet/Packet;Lnet/minecraft/network/PacketCallbacks;)V", cancellable = true)
-    private void onSendPacketHead(CallbackInfo info, @Local LocalRef<Packet<?>> packet) {
-        PacketEvent.Send processedPacket = MeteorClient.EVENT_BUS.post(PacketEvent.Send.get(packet.get()));
-        if (processedPacket.isCancelled()) {
+    private void onSendPacketHead(CallbackInfo info, @Local(argsOnly = true) Packet<?> packet) {
+        if (MeteorClient.EVENT_BUS.post(PacketEvent.Send.get(packet)).isCancelled()) {
             info.cancel();
-        } else {
-            packet.set(processedPacket.packet);
         }
     }
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Fixes Criticals packet/bypass mode.
The bug was introduced in the update to 1.20.5/6 (https://github.com/MeteorDevelopment/meteor-client/pull/4534/commits/653eadc8964cf16aff50d6246a854cae9efa7960)

The issue is that when sending a packet from within the PacketEvent.Send stack, that due to the singleton nature of the event, the packet variable would be changed to the newly sent packet, so that this packet effectively gets sent twice while the original packet, which triggered the event, doesn't get sent.
This caused Criticals in packet or bypass mode to cancel the attack packet and send an additional movement packet instead, and potentially caused issues in other places as well.

# How Has This Been Tested?

I tested it myself, and since I am basically reverting to the state before the update this has been tested for years, if you want.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [ ] I have tested the code in both development and production environments.
