### PR TITLE
Prevent the ViaFabricPlus settings button overlapping with ours in the multiplayer menu.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,10 @@ repositories {
         name = "vram"
         url = "https://maven.vram.io//"
     }
+    maven {
+        name = "ViaVersion"
+        url = "https://repo.viaversion.com"
+    }
     mavenCentral()
 }
 
@@ -58,6 +62,7 @@ dependencies {
     modCompileOnly("maven.modrinth:iris:${project.iris_version}") { transitive = false }
     //modCompileOnly("io.vram:canvas-fabric-mc119:1.0.+") { transitive = false } // TODO: 1.19.3
     modCompileOnly("maven.modrinth:indium:${project.indium_version}") { transitive = false }
+    modCompileOnly("de.florianmichael:ViaFabricPlus:${project.viafabricplus_version}") { transitive = false }
 
     // Baritone (https://github.com/MeteorDevelopment/baritone)
     modCompileOnly "meteordevelopment:baritone:${project.baritone_version}-SNAPSHOT"

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,3 +42,6 @@ reflections_version=0.10.2
 
 # Netty (https://github.com/netty/netty)
 netty_version=4.1.90.Final
+
+# ViaFabricPlus (https://github.com/ViaVersion/ViaFabricPlus)
+viafabricplus_version=3.2.1

--- a/src/main/java/meteordevelopment/meteorclient/MixinPlugin.java
+++ b/src/main/java/meteordevelopment/meteorclient/MixinPlugin.java
@@ -29,6 +29,7 @@ public class MixinPlugin implements IMixinConfigPlugin {
     private static boolean isLithiumPresent;
     public static boolean isIrisPresent;
     private static boolean isIndiumPresent;
+    private static boolean isVFPPresent;
 
     @Override
     public void onLoad(String mixinPackage) {
@@ -74,6 +75,7 @@ public class MixinPlugin implements IMixinConfigPlugin {
         isLithiumPresent = FabricLoader.getInstance().isModLoaded("lithium");
         isIrisPresent = FabricLoader.getInstance().isModLoaded("iris");
         isIndiumPresent = FabricLoader.getInstance().isModLoaded("indium");
+        isVFPPresent = FabricLoader.getInstance().isModLoaded("viafabricplus");
 
         loaded = true;
     }
@@ -105,6 +107,9 @@ public class MixinPlugin implements IMixinConfigPlugin {
         }
         else if (mixinClassName.startsWith(mixinPackage + ".indium")) {
             return isIndiumPresent;
+        }
+        else if (mixinClassName.startsWith(mixinPackage + ".viafabricplus")) {
+            return isVFPPresent;
         }
 
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/viafabricplus/GeneralSettingsMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/viafabricplus/GeneralSettingsMixin.java
@@ -14,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.At;
 public class GeneralSettingsMixin {
     // specifies the '2' value on this line:
     // public final ModeSetting multiplayerScreenButtonOrientation = new ModeSetting(this, Text.translatable("general_settings.viafabricplus.multiplayer_screen_button_orientation"), 2, ORIENTATION_OPTIONS);
-    @ModifyExpressionValue(method = "<init>", at = @At(value = "CONSTANT", args = "intValue=2", ordinal = 1))
+    @ModifyExpressionValue(method = "<init>", at = @At(value = "CONSTANT", args = "intValue=2", ordinal = 1), remap = false)
     private int modifyDefaultPosition(int original) {
         return 4;
     }

--- a/src/main/java/meteordevelopment/meteorclient/mixin/viafabricplus/GeneralSettingsMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/viafabricplus/GeneralSettingsMixin.java
@@ -1,0 +1,21 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.mixin.viafabricplus;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import de.florianmichael.viafabricplus.settings.impl.GeneralSettings;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(GeneralSettings.class)
+public class GeneralSettingsMixin {
+    // specifies the '2' value on this line:
+    // public final ModeSetting multiplayerScreenButtonOrientation = new ModeSetting(this, Text.translatable("general_settings.viafabricplus.multiplayer_screen_button_orientation"), 2, ORIENTATION_OPTIONS);
+    @ModifyExpressionValue(method = "<init>", at = @At(value = "CONSTANT", args = "intValue=2", ordinal = 1))
+    private int modifyDefaultPosition(int original) {
+        return 4;
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -30,7 +30,8 @@
     "meteor-client-sodium.mixins.json",
     "meteor-client-canvas.mixins.json",
     "meteor-client-lithium.mixins.json",
-    "meteor-client-indium.mixins.json"
+    "meteor-client-indium.mixins.json",
+    "meteor-client-viafabricplus.mixins.json"
   ],
   "accessWidener": "meteor-client.accesswidener",
   "custom": {

--- a/src/main/resources/meteor-client-viafabricplus.mixins.json
+++ b/src/main/resources/meteor-client-viafabricplus.mixins.json
@@ -1,0 +1,12 @@
+{
+  "required": false,
+  "package": "meteordevelopment.meteorclient.mixin.viafabricplus",
+  "compatibilityLevel": "JAVA_21",
+  "plugin": "meteordevelopment.meteorclient.MixinPlugin",
+  "client": [
+    "GeneralSettingsMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Changes the default position of the ViaFabricPlus settings button in the multiplayer screen to prevent it from overlapping with our account and proxy buttons. Will not change instances that already have the settings file, but if VFP is added alongside meteor from now on the default position will be updated.

# How Has This Been Tested?

Development and production.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
