### PR TITLE
Title disabler in No Render module

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/InGameHudMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/InGameHudMixin.java
@@ -98,6 +98,11 @@ public abstract class InGameHudMixin {
         if (Modules.get().get(NoRender.class).noCrosshair()) ci.cancel();
     }
 
+    @Inject(method = "renderTitleAndSubtitle", at = @At("HEAD"), cancellable = true)
+    private void onRenderTitle(DrawContext context, float tickDelta, CallbackInfo ci) {
+        if (Modules.get().get(NoRender.class).noTitle()) ci.cancel();
+    }
+
     @Inject(method = "renderHeldItemTooltip", at = @At("HEAD"), cancellable = true)
     private void onRenderHeldItemTooltip(DrawContext context, CallbackInfo ci) {
         if (Modules.get().get(NoRender.class).noHeldItemName()) ci.cancel();

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/NoRender.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/NoRender.java
@@ -140,6 +140,12 @@ public class NoRender extends Module {
         .defaultValue(false)
         .build()
     );
+    private final Setting<Boolean> noTitle = sgHUD.add(new BoolSetting.Builder()
+        .name("title")
+        .description("Disables rendering of the title.")
+        .defaultValue(false)
+        .build()
+    );
 
     private final Setting<Boolean> noHeldItemName = sgHUD.add(new BoolSetting.Builder()
         .name("held-item-name")
@@ -435,6 +441,9 @@ public class NoRender extends Module {
 
     public boolean noCrosshair() {
         return isActive() && noCrosshair.get();
+    }
+    public boolean noTitle() {
+        return isActive() && noTitle.get();
     }
 
     public boolean noHeldItemName() {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

New setting in No Render that disables title on the screen

## Related issues

#2519 (solved via packet canceller, but disable rendering is better)

# How Has This Been Tested?

https://github.com/MeteorDevelopment/meteor-client/assets/68079109/ab54d4e8-afe6-433e-a8d6-d447ea016566

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have tested the code in both development and production environments.
