### PR TITLE
Fix bind command

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/BindCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/BindCommand.java
@@ -12,8 +12,6 @@ import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import net.minecraft.command.CommandSource;
 
-import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
-
 public class BindCommand extends Command {
     public BindCommand() {
         super("bind", "Binds a specified module to the next pressed key.");
@@ -24,6 +22,7 @@ public class BindCommand extends Command {
         builder.then(argument("module", ModuleArgumentType.create()).executes(context -> {
             Module module = context.getArgument("module", Module.class);
             Modules.get().setModuleToBind(module);
+            Modules.get().awaitKeyRelease();
             module.info("Press a key to bind the module to.");
             return SINGLE_SUCCESS;
         }));

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
@@ -221,6 +221,10 @@ public class Modules extends System<Modules> {
         this.moduleToBind = moduleToBind;
     }
 
+    /***
+     * @see meteordevelopment.meteorclient.commands.commands.BindCommand
+     * For ensuring we don't instantly bind the module to the enter key.
+     */
     public void awaitKeyRelease() {
         this.awaitingKeyRelease = true;
     }
@@ -243,6 +247,8 @@ public class Modules extends System<Modules> {
         if (!isBinding()) return false;
 
         if (awaitingKeyRelease) {
+            if (!isKey || value != GLFW.GLFW_KEY_ENTER) return false;
+
             awaitingKeyRelease = false;
             return false;
         }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
@@ -74,6 +74,7 @@ public class Modules extends System<Modules> {
 
     private final List<Module> active = new ArrayList<>();
     private Module moduleToBind;
+    private boolean awaitingKeyRelease = false;
 
     public Modules() {
         super("modules");
@@ -220,6 +221,10 @@ public class Modules extends System<Modules> {
         this.moduleToBind = moduleToBind;
     }
 
+    public void awaitKeyRelease() {
+        this.awaitingKeyRelease = true;
+    }
+
     public boolean isBinding() {
         return moduleToBind != null;
     }
@@ -236,6 +241,11 @@ public class Modules extends System<Modules> {
 
     private boolean onBinding(boolean isKey, int value, int modifiers) {
         if (!isBinding()) return false;
+
+        if (awaitingKeyRelease) {
+            awaitingKeyRelease = false;
+            return false;
+        }
 
         if (moduleToBind.keybind.canBindTo(isKey, value, modifiers)) {
             moduleToBind.keybind.set(isKey, value, modifiers);


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

As of the commit to add support for modifiers with keybinds, the bind command was broken as it would always bind the module to the enter key. This fixes that by waiting for the user to release the enter key after executing the command before allowing them to bind the module.

## Related issues

closes #4610 

# How Has This Been Tested?

Development.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [ ] I have tested the code in both development and production environments.
