### PR TITLE
fixed lithium border collisions #4618

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/lithium/LithiumEntityCollisionsMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/lithium/LithiumEntityCollisionsMixin.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.mixin.lithium;
+
+import me.jellysquid.mods.lithium.common.entity.LithiumEntityCollisions;
+import meteordevelopment.meteorclient.systems.modules.Modules;
+import meteordevelopment.meteorclient.systems.modules.world.Collisions;
+import net.minecraft.util.math.Box;
+import net.minecraft.world.border.WorldBorder;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(value = LithiumEntityCollisions.class)
+public class LithiumEntityCollisionsMixin {
+    @Inject(method = "isWithinWorldBorder", at = @At("HEAD"), cancellable = true)
+    private static void onIsWithinWorldBorder(WorldBorder border, Box box, CallbackInfoReturnable<Boolean> cir) {
+        if (Modules.get().get(Collisions.class).ignoreBorder()) {
+            cir.setReturnValue(true);
+        }
+    }
+}

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/Collisions.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/Collisions.java
@@ -113,6 +113,6 @@ public class Collisions extends Module {
     }
 
     public boolean ignoreBorder() {
-        return  isActive() && ignoreBorder.get();
+        return isActive() && ignoreBorder.get();
     }
 }

--- a/src/main/resources/meteor-client-lithium.mixins.json
+++ b/src/main/resources/meteor-client-lithium.mixins.json
@@ -4,7 +4,8 @@
   "compatibilityLevel": "JAVA_21",
   "plugin": "meteordevelopment.meteorclient.MixinPlugin",
   "client": [
-    "ChunkAwareBlockCollisionSweeperMixin"
+    "ChunkAwareBlockCollisionSweeperMixin",
+    "LithiumEntityCollisionsMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

see the linked issue.

In singleplayer other entities will ignore the border too.
This also happens with the normal WorldBorderMixin.

## Related issues

#4618 

# How Has This Been Tested?

Tested in single and multiplayer
 - create a world
 - /worldborder set 50
 - enable collisions and the ignore-border option
 - go through the border

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
