### PR TITLE
Fixed incompatibility with BleachHack

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/BlockCollisionSpliteratorMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/BlockCollisionSpliteratorMixin.java
@@ -5,6 +5,8 @@
 
 package meteordevelopment.meteorclient.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.events.world.CollisionShapeEvent;
 import net.minecraft.block.BlockState;
@@ -17,16 +19,22 @@ import net.minecraft.world.BlockCollisionSpliterator;
 import net.minecraft.world.BlockView;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(BlockCollisionSpliterator.class)
 public abstract class BlockCollisionSpliteratorMixin {
-    @Redirect(method = "computeNext", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BlockState;getCollisionShape(Lnet/minecraft/world/BlockView;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/ShapeContext;)Lnet/minecraft/util/shape/VoxelShape;"))
-    private VoxelShape onComputeNextCollisionBox(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
-        VoxelShape shape = state.getCollisionShape(world, pos, context);
 
-        if (world != MinecraftClient.getInstance().world)
+    @WrapOperation(method = "computeNext",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/block/BlockState;getCollisionShape(Lnet/minecraft/world/BlockView;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/ShapeContext;)Lnet/minecraft/util/shape/VoxelShape;"
+        )
+    )
+    private VoxelShape onComputeNextCollisionBox(BlockState state, BlockView world, BlockPos pos, ShapeContext context, Operation<VoxelShape> original) {
+        VoxelShape shape = original.call(state, world, pos, context);
+
+        if (world != MinecraftClient.getInstance().world) {
             return shape;
+        }
 
         CollisionShapeEvent event = MeteorClient.EVENT_BUS.post(CollisionShapeEvent.get(state, pos, shape));
         return event.isCancelled() ? VoxelShapes.empty() : event.shape;


### PR DESCRIPTION
## Type of change

- [x ] Bug fix
- [ ] New feature

## Description

Both Meteor and Bleach target the same method with a `@Redirect` mixin, which caused a crash. To fix that, I replaced the `@Redirect` in Meteor with a `@WrapOperation`, which is functionally the same, but doesn't crash when another mod injects in the same place.

# How Has This Been Tested?

Tested it in singleplayer by testing the Jesus module in both Meteor and Bleach.

# Checklist:

- [x ] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [x ] I have tested the code in both development and production environments.
