### PR TITLE
fixed hud having no default elements

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/Hud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/Hud.java
@@ -208,12 +208,13 @@ public class Hud extends System<Hud> implements Iterable<HudElement> {
     @EventHandler
     private void onTick(TickEvent.Post event) {
         if (Utils.isLoading()) return;
-        if (!(active || HudEditorScreen.isOpen())) return;
 
         if (resetToDefaultElements) {
             resetToDefaultElementsImpl();
             resetToDefaultElements = false;
         }
+
+        if (!(active || HudEditorScreen.isOpen())) return;
 
         for (HudElement element : elements) {
             if (element.isActive()) element.tick(HudRenderer.INSTANCE);


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

The default hud elements only generate after opening the hud tab or enabling hud on first boot with the mod.

## Steps to reproduce:
Delete the meteor client folder in the minecraft directory to simulate a fresh install.
Open the game and close it again without opening the hud tab.
Start the game again and open the hud tab.
The hud is empty.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [ ] I have tested the code in both development and production environments.
