### PR TITLE
fix chest swapping after getting an error with pitch40

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFly.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFly.java
@@ -341,11 +341,11 @@ public class ElytraFly extends Module {
 
     @Override
     public void onActivate() {
+        currentMode.onActivate();
         if ((chestSwap.get() == ChestSwapMode.Always || chestSwap.get() == ChestSwapMode.WaitForGround)
-            && mc.player.getEquippedStack(EquipmentSlot.CHEST).getItem() != Items.ELYTRA) {
+            && mc.player.getEquippedStack(EquipmentSlot.CHEST).getItem() != Items.ELYTRA && isActive()) {
             Modules.get().get(ChestSwap.class).swap();
         }
-        currentMode.onActivate();
     }
 
     @Override

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFly.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFly.java
@@ -341,11 +341,11 @@ public class ElytraFly extends Module {
 
     @Override
     public void onActivate() {
-        currentMode.onActivate();
         if ((chestSwap.get() == ChestSwapMode.Always || chestSwap.get() == ChestSwapMode.WaitForGround)
             && mc.player.getEquippedStack(EquipmentSlot.CHEST).getItem() != Items.ELYTRA) {
             Modules.get().get(ChestSwap.class).swap();
         }
+        currentMode.onActivate();
     }
 
     @Override


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

When chestswap is set to 'always' and you get an error while enabling Pitch40 elytra fly (`"Player must be above uppper bounds!"`), the module itself remains disabled while your chestplate still gets swapped as if the module was active.

![image](https://github.com/MeteorDevelopment/meteor-client/assets/108220065/f86751d8-c64e-4638-9a64-91f9b4406d0f)

Now the module has a chance to call its `toggle()` in peace without the chestplate getting swapped again by ElytraFly's `onActivate()`. 

# How Has This Been Tested?
By seeing if it still swaps the chestplate for an elytra.

![image](https://github.com/MeteorDevelopment/meteor-client/assets/108220065/7ad4df95-c61d-48c5-a155-831b21002ab5)

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas. (there are no complex areas)
- [x] I have tested the code in both development and production environments.
