### PR TITLE
hostnames can contain minus hyphens

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
@@ -595,6 +595,6 @@ public class Utils {
 
     public static boolean ipFilter(String text, char character) {
         if (text.contains(":") && character == ':') return false;
-        return (character >= 'a' && character <= 'z') || (character >= 'A' && character <= 'Z') || (character >= '0' && character <= '9') || character == '.';
+        return (character >= 'a' && character <= 'z') || (character >= 'A' && character <= 'Z') || (character >= '0' && character <= '9') || character == '.' || character == '-';
     }
 }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Hostnames can contain minus hyphens

## Related issues

# How Has This Been Tested?

type - in the address section of the EditProxyScreen 

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [ ] I have tested the code in both development and production environments.
