### PR TITLE
Feedback color

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/ConfigTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/ConfigTab.java
@@ -11,7 +11,9 @@ import meteordevelopment.meteorclient.gui.tabs.TabScreen;
 import meteordevelopment.meteorclient.gui.tabs.WindowTabScreen;
 import meteordevelopment.meteorclient.settings.Settings;
 import meteordevelopment.meteorclient.systems.config.Config;
+import meteordevelopment.meteorclient.gui.widgets.pressable.WButton;
 import meteordevelopment.meteorclient.utils.misc.NbtUtils;
+import meteordevelopment.meteorclient.utils.player.ChatUtils;
 import meteordevelopment.meteorclient.utils.render.prompts.YesNoPrompt;
 import net.minecraft.client.gui.screen.Screen;
 
@@ -41,6 +43,8 @@ public class ConfigTab extends Tab {
 
             onClosed(() -> {
                 String prefix = Config.get().prefix.get();
+
+                ChatUtils.changePrefixColor(Config.get().chatFeedbackPrefixColor.get().getPacked());
 
                 if (prefix.isBlank()) {
                     YesNoPrompt.create(theme, this.parent)

--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/ConfigTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/ConfigTab.java
@@ -11,7 +11,6 @@ import meteordevelopment.meteorclient.gui.tabs.TabScreen;
 import meteordevelopment.meteorclient.gui.tabs.WindowTabScreen;
 import meteordevelopment.meteorclient.settings.Settings;
 import meteordevelopment.meteorclient.systems.config.Config;
-import meteordevelopment.meteorclient.gui.widgets.pressable.WButton;
 import meteordevelopment.meteorclient.utils.misc.NbtUtils;
 import meteordevelopment.meteorclient.utils.player.ChatUtils;
 import meteordevelopment.meteorclient.utils.render.prompts.YesNoPrompt;
@@ -42,9 +41,8 @@ public class ConfigTab extends Tab {
             settings.onActivated();
 
             onClosed(() -> {
-                String prefix = Config.get().prefix.get();
-
                 ChatUtils.changePrefixColor(Config.get().chatFeedbackPrefixColor.get().getPacked());
+                String prefix = Config.get().prefix.get();
 
                 if (prefix.isBlank()) {
                     YesNoPrompt.create(theme, this.parent)

--- a/src/main/java/meteordevelopment/meteorclient/systems/config/Config.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/config/Config.java
@@ -118,6 +118,14 @@ public class Config extends System<Config> {
         .build()
     );
 
+    public final Setting<SettingColor> chatFeedbackPrefixColor = sgChat.add(new ColorSetting.Builder()
+        .name("chat-feedback-prefix-color")
+        .description("The color of [Meteor] when chat feedback is given")
+        .defaultValue(new SettingColor(145,61,226))
+        .visible(chatFeedback::get)
+        .build()
+    );
+
     // Misc
 
     public final Setting<Integer> rotationHoldTicks = sgMisc.add(new IntSetting.Builder()

--- a/src/main/java/meteordevelopment/meteorclient/utils/player/ChatUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/ChatUtils.java
@@ -38,8 +38,16 @@ public class ChatUtils {
         PREFIX = Text.empty()
             .setStyle(Style.EMPTY.withFormatting(Formatting.GRAY))
             .append("[")
-            .append(Text.literal("Meteor").setStyle(Style.EMPTY.withColor(TextColor.fromRgb(MeteorClient.ADDON.color.getPacked()))))
+            .append(Text.literal("Meteor").setStyle(Style.EMPTY.withColor(TextColor.fromRgb(Config.get().chatFeedbackPrefixColor.get().getPacked()))))
             .append("] ");
+    }
+
+    public static void changePrefixColor(int color) {
+        PREFIX = Text.empty()
+            .setStyle(Style.EMPTY.withFormatting(Formatting.GRAY))
+            .append("[")
+            .append(Text.literal("Meteor").setStyle(Style.EMPTY.withColor(TextColor.fromRgb(color)))
+            .append("] "));
     }
 
     public static Text getMeteorPrefix() {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

I added the ability to change the color of the "[Meteor]" prefix in chat feedback. I did this because a member of the meteor discord was asking if it could be changed.

# How Has This Been Tested?

<img width="1098" alt="Screenshot 2024-06-13 at 6 17 08 PM" src="https://github.com/MeteorDevelopment/meteor-client/assets/74616162/4ae9e578-ca98-41f5-8af0-5f4f5eac4b86">
<img width="634" alt="Screenshot 2024-06-13 at 6 34 01 PM" src="https://github.com/MeteorDevelopment/meteor-client/assets/74616162/ab670c2e-85d5-4842-9a6e-a1cd29ae0891">


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
