### PR TITLE
Add a GUI positioning reset button to GUI tab screen

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/GuiTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/GuiTab.java
@@ -11,6 +11,7 @@ import meteordevelopment.meteorclient.gui.tabs.Tab;
 import meteordevelopment.meteorclient.gui.tabs.TabScreen;
 import meteordevelopment.meteorclient.gui.tabs.WindowTabScreen;
 import meteordevelopment.meteorclient.gui.widgets.containers.WTable;
+import meteordevelopment.meteorclient.gui.widgets.pressable.WButton;
 import meteordevelopment.meteorclient.gui.widgets.input.WDropdown;
 import meteordevelopment.meteorclient.utils.misc.NbtUtils;
 import net.minecraft.client.gui.screen.Screen;
@@ -52,6 +53,9 @@ public class GuiTab extends Tab {
                 mc.setScreen(null);
                 tab.openScreen(GuiThemes.get());
             };
+
+            WButton reset = add(theme.button("Reset GUI Layout")).widget();
+            reset.action = () -> theme.clearWindowConfigs();
 
             add(theme.settings(theme.settings)).expandX();
         }


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description
Currently the only way I can see to reset the positioning of the GUI is by using the `.reset` command. Adding a button to the GUI page should make this feature a bit more discoverable.

# How Has This Been Tested?
![image](https://github.com/MeteorDevelopment/meteor-client/assets/17493061/ee9646da-629f-45ef-bceb-a76c1e38c473)


# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [ ] I have tested the code in both development and production environments.