### PR TITLE
Add item frame peek

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/PeekCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/PeekCommand.java
@@ -16,7 +16,7 @@ import net.minecraft.text.Text;
 
 public class PeekCommand extends Command {
     private static final ItemStack[] ITEMS = new ItemStack[27];
-    private static final SimpleCommandExceptionType CANT_PEEK = new SimpleCommandExceptionType(Text.literal("You must be holding a storage block or looking at the item frame."));
+    private static final SimpleCommandExceptionType CANT_PEEK = new SimpleCommandExceptionType(Text.literal("You must be holding a storage block or looking at an item frame."));
 
     public PeekCommand() {
         super("peek", "Lets you see what's inside storage block items.");
@@ -27,9 +27,8 @@ public class PeekCommand extends Command {
         builder.executes(context -> {
             if (Utils.openContainer(mc.player.getMainHandStack(), ITEMS, true)) return SINGLE_SUCCESS;
             else if (Utils.openContainer(mc.player.getOffHandStack(), ITEMS, true)) return SINGLE_SUCCESS;
-            else if (mc.targetedEntity != null &&
-                mc.targetedEntity instanceof ItemFrameEntity &&
-                Utils.openContainer(((ItemFrameEntity)mc.targetedEntity).getHeldItemStack(), ITEMS, true)
+            else if (mc.targetedEntity instanceof ItemFrameEntity &&
+                Utils.openContainer(((ItemFrameEntity) mc.targetedEntity).getHeldItemStack(), ITEMS, true)
             ) return SINGLE_SUCCESS;
             else throw CANT_PEEK.create();
         });

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/PeekCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/PeekCommand.java
@@ -10,12 +10,13 @@ import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.utils.Utils;
 import net.minecraft.command.CommandSource;
+import net.minecraft.entity.decoration.ItemFrameEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.text.Text;
 
 public class PeekCommand extends Command {
     private static final ItemStack[] ITEMS = new ItemStack[27];
-    private static final SimpleCommandExceptionType NOT_HOLDING_SHULKER_BOX = new SimpleCommandExceptionType(Text.literal("You must be holding a storage block with items in it."));
+    private static final SimpleCommandExceptionType CANT_PEEK = new SimpleCommandExceptionType(Text.literal("You must be holding a storage block or looking at the item frame."));
 
     public PeekCommand() {
         super("peek", "Lets you see what's inside storage block items.");
@@ -26,7 +27,11 @@ public class PeekCommand extends Command {
         builder.executes(context -> {
             if (Utils.openContainer(mc.player.getMainHandStack(), ITEMS, true)) return SINGLE_SUCCESS;
             else if (Utils.openContainer(mc.player.getOffHandStack(), ITEMS, true)) return SINGLE_SUCCESS;
-            else throw NOT_HOLDING_SHULKER_BOX.create();
+            else if (mc.targetedEntity != null &&
+                mc.targetedEntity instanceof ItemFrameEntity &&
+                Utils.openContainer(((ItemFrameEntity)mc.targetedEntity).getHeldItemStack(), ITEMS, true)
+            ) return SINGLE_SUCCESS;
+            else throw CANT_PEEK.create();
         });
     }
 }


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Added support for container item in item frames for the `peek` command


# How Has This Been Tested?

The command was executed:
* Without item frame
* Empty item frame
* Item frame with non-container item
* Item frame with map
* Item frame with container item

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
