### PR TITLE
Added pause in creative mode to BetterTooltips

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BetterTooltips.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BetterTooltips.java
@@ -78,7 +78,7 @@ public class BetterTooltips extends Module {
 
     private final Setting<Boolean> pauseInCreative = sgGeneral.add(new BoolSetting.Builder()
         .name("pause-in-creative")
-        .description("Pauses while player is in creative mode.")
+        .description("Pauses middle click open while the player is in creative mode.")
         .defaultValue(true)
         .visible(middleClickOpen::get)
         .build()

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BetterTooltips.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BetterTooltips.java
@@ -76,6 +76,14 @@ public class BetterTooltips extends Module {
         .build()
     );
 
+    private final Setting<Boolean> pauseInCreative = sgGeneral.add(new BoolSetting.Builder()
+        .name("pause-in-creative")
+        .description("Pauses while player is in creative mode.")
+        .defaultValue(true)
+        .visible(middleClickOpen::get)
+        .build()
+    );
+
     // Previews
 
     private final Setting<Boolean> shulkers = sgPreviews.add(new BoolSetting.Builder()
@@ -438,7 +446,8 @@ public class BetterTooltips extends Module {
     }
 
     public boolean middleClickOpen() {
-        return isActive() && middleClickOpen.get();
+        return (isActive() && middleClickOpen.get())
+            && (!pauseInCreative.get() || !mc.player.isInCreativeMode());
     }
 
     public boolean previewShulkers() {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Pausing open peek screen when player is in creative mode.
Because in creative mode, mid button can copy items

# How Has This Been Tested?

https://github.com/MeteorDevelopment/meteor-client/assets/78586843/e94ca4c0-0867-4e36-ac4c-0ec0602b3e36

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.