### PR TITLE
Fixed game crash caused by ChatInputSuggestor

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/ChatInputSuggestorMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ChatInputSuggestorMixin.java
@@ -52,7 +52,7 @@ public abstract class ChatInputSuggestorMixin {
             }
 
             int cursor = textField.getCursor();
-            if (cursor >= 1 && (this.window == null || !this.completingSuggestions)) {
+            if (cursor >= length && (this.window == null || !this.completingSuggestions)) {
                 this.pendingSuggestions = Commands.DISPATCHER.getCompletionSuggestions(this.parse, cursor);
                 this.pendingSuggestions.thenRun(() -> {
                     if (this.pendingSuggestions.isDone()) {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Use length instead of 1 to prevent a crash that happens when you use the left arrow key in the chat and the command prefix is more than one character long.

## Related issues

None

# How Has This Been Tested?

Self explanatory

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [ ] I have tested the code in both development and production environments.
