### PR TITLE
fix(AutoWalk): Calculate x & z on first tick

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/pathing/BaritonePathManager.java
+++ b/src/main/java/meteordevelopment/meteorclient/pathing/BaritonePathManager.java
@@ -178,8 +178,8 @@ public class BaritonePathManager implements IPathManager {
         }
 
         public void tick() {
-            if (timer > 20) {
-                timer = 0;
+            if (timer <= 0) {
+                timer = 20;
 
                 Vec3d pos = mc.player.getPos();
                 float theta = (float) Math.toRadians(yaw);
@@ -188,7 +188,7 @@ public class BaritonePathManager implements IPathManager {
                 z = (int) Math.floor(pos.z + (double) MathHelper.cos(theta) * 100);
             }
 
-            timer++;
+            timer--;
         }
 
         public boolean isInGoal(int x, int y, int z) {


### PR DESCRIPTION

## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Calculate x & z on first tick() in the BaritonePathManager GoalDirection class, to fix AutoWalk smart mode so baritone walks in the direction the player is facing. This fixes an issue where smart mode always starts walking towards 0,0.

## Related issues

- #4373 

# How Has This Been Tested?

- [x] verified player travels in the direction the player is facing when  AutoWalk is enabled in smart mode
- [x] verified simple mode is un-affected 

This `GoalDirection` code seems to only be used by AutoWalk, so this _shouldn't_ affect anything else.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
