### PR TITLE
improve io stream handling

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
@@ -52,7 +52,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.chunk.Chunk;
-import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Range;
 import org.joml.Matrix4f;
@@ -481,19 +481,13 @@ public class Utils {
 
     public static byte[] readBytes(InputStream in) {
         try {
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
-
-            byte[] buffer = new byte[256];
-            int read;
-            while ((read = in.read(buffer)) > 0) out.write(buffer, 0, read);
-
-            in.close();
-            return out.toByteArray();
+            return in.readAllBytes();
         } catch (IOException e) {
-            e.printStackTrace();
+            MeteorClient.LOG.error("Error reading from stream.", e);
+            return new byte[0];
+        } finally {
+            IOUtils.closeQuietly(in);
         }
-
-        return new byte[0];
     }
 
     public static boolean canUpdate() {

--- a/src/main/java/meteordevelopment/meteorclient/utils/files/StreamUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/files/StreamUtils.java
@@ -5,6 +5,9 @@
 
 package meteordevelopment.meteorclient.utils.files;
 
+import meteordevelopment.meteorclient.MeteorClient;
+import org.apache.commons.io.IOUtils;
+
 import java.io.*;
 
 public class StreamUtils {
@@ -14,29 +17,19 @@ public class StreamUtils {
     public static void copy(File from, File to) {
         try (InputStream in = new FileInputStream(from);
              OutputStream out = new FileOutputStream(to)) {
-            copy(in, out);
+            in.transferTo(out);
         } catch (IOException e) {
-            e.printStackTrace();
+            MeteorClient.LOG.error("Error copying from file '%s' to file '%s'.".formatted(from.getName(), to.getName()), e);
         }
     }
 
     public static void copy(InputStream in, File to) {
         try (OutputStream out = new FileOutputStream(to)) {
-            copy(in, out);
-            in.close();
+            in.transferTo(out);
         } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
-
-    public static void copy(InputStream in, OutputStream out) {
-        byte[] bytes = new byte[512];
-        int read;
-
-        try {
-            while ((read = in.read(bytes)) != -1) out.write(bytes, 0, read);
-        } catch (IOException e) {
-            e.printStackTrace();
+            MeteorClient.LOG.error("Error writing to file '%s'.".formatted(to.getName()));
+        } finally {
+            IOUtils.closeQuietly(in);
         }
     }
 }


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

- replace `printStackTrace` calls with slf4j logging
- make sure `InputStream` is closed even when an exception is thrown
- replace manual copying of `InputStream` into `ByteArrayOutputStream` with builtin `InputStream#readAllBytes` and `InputStream#transferTo` methods

since the buffer size was increased as a result, this also causes the game to launch faster
![image](https://github.com/MeteorDevelopment/meteor-client/assets/32882447/81f48c98-d020-4149-9400-d20c2315d7ff)

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
