### PR TITLE
Added feature #4764 with universal enitity selection

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/AutoLog.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/AutoLog.java
@@ -66,21 +66,21 @@ public class AutoLog extends Module {
         .build()
     );
 
-    private final Setting<Set<EntityType<?>>> entities = sgGeneral.add(new EntityTypeListSetting.Builder()
+    private final Setting<Set<EntityType<?>>> entities = sgGeneral.add(new EntityTypeListSetting.Builder() //Player chooses the entity from a list
         .name("entities")
         .description("Select specific entities.")
         .defaultValue(EntityType.END_CRYSTAL)
         .build()
     );
 
-    private final Setting<Boolean> TotalCount = sgGeneral.add(new BoolSetting.Builder()
+    private final Setting<Boolean> TotalCount = sgGeneral.add(new BoolSetting.Builder() //Allows player to select whether the number of enitites will be for each type or all selected combined
         .name("Total the Entities")
         .description("Whether total number of all selected entites or each entity")
         .defaultValue(false)
         .visible(() -> !entities.get().isEmpty())
         .build());
 
-    private final Setting<Integer> TotCount = sgGeneral.add(new IntSetting.Builder() //Number of TNT Minecart
+    private final Setting<Integer> TotCount = sgGeneral.add(new IntSetting.Builder() //Number of all total combined Entities
         .name("Total Count")
         .description("Total number of all selected entites combined have to be near you before you disconnect.")
         .defaultValue(10)
@@ -90,7 +90,7 @@ public class AutoLog extends Module {
         .build()
     );
 
-    private final Setting<Integer> EachCount = sgGeneral.add(new IntSetting.Builder() //Number of TNT Minecart
+    private final Setting<Integer> EachCount = sgGeneral.add(new IntSetting.Builder() //Number of each type of selected Entity
         .name("Each Count")
         .description("Minimum number of each entity have to be near you before you disconnect.")
         .defaultValue(2)
@@ -100,7 +100,7 @@ public class AutoLog extends Module {
         .build()
     );
 
-    private final Setting<Integer> range = sgGeneral.add(new IntSetting.Builder() //range for TNT Minecart
+    private final Setting<Integer> range = sgGeneral.add(new IntSetting.Builder() //range for selected entity
         .name("Range")
         .description("How close a entity has to be to you before you disconnect.")
         .defaultValue(5)
@@ -168,21 +168,21 @@ public class AutoLog extends Module {
             }
         }
 
-        if (!entities.get().isEmpty()) {
+        if (!entities.get().isEmpty()) { // Check if the entities list is not empty
             int totalEntities = 0;
             Map<EntityType<?>, Integer> entityCounts = new HashMap<>();
 
-            for (Entity entity : mc.world.getEntities()) {
-                if (PlayerUtils.isWithin(entity, range.get()) && entities.get().contains(entity.getType())) {
+            for (Entity entity : mc.world.getEntities()) { // Iterate through all entities in the world
+                if (PlayerUtils.isWithin(entity, range.get()) && entities.get().contains(entity.getType())) { // Check if the entity is within the specified range and is in the selected entities list
                     totalEntities++;
-                    entityCounts.put(entity.getType(), entityCounts.getOrDefault(entity.getType(), 0) + 1);
+                    entityCounts.put(entity.getType(), entityCounts.getOrDefault(entity.getType(), 0) + 1); // Increment the count for the entity type
                 }
             }
 
-            if (TotalCount.get() && totalEntities >= TotCount.get()) {
+            if (TotalCount.get() && totalEntities >= TotCount.get()) { // Check if the total count of entities exceeds the limit
                 disconnect("Total number of selected entities within range exceeded the limit.");
                 if (toggleOff.get()) this.toggle();
-            } else if (!TotalCount.get()) {
+            } else if (!TotalCount.get()) { // Check if the count of each entity type exceeds the limit
                 for (Map.Entry<EntityType<?>, Integer> entry : entityCounts.entrySet()) {
                     if (entry.getValue() >= EachCount.get()) {
                         disconnect("Number of " + entry.getKey().getName().getString() + " within range exceeded the limit.");

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/AutoLog.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/AutoLog.java
@@ -76,7 +76,7 @@ public class AutoLog extends Module {
     );
 
     private final Setting<Boolean> totalCount = sgEntities.add(new BoolSetting.Builder()
-        .name("total-count")
+        .name("total-the-count")
         .description("Whether total number of all selected entities or each entity.")
         .defaultValue(false)
         .visible(() -> !entities.get().isEmpty())
@@ -86,7 +86,7 @@ public class AutoLog extends Module {
         .name("total-count")
         .description("Total number of all selected entities combined have to be near you before you disconnect.")
         .defaultValue(10)
-        .range(1, Integer.MAX_VALUE)
+        .min(1)
         .sliderMax(32)
         .visible(() -> totalCount.get() && !entities.get().isEmpty())
         .build()
@@ -96,7 +96,7 @@ public class AutoLog extends Module {
         .name("each-count")
         .description("Minimum number of each entity have to be near you before you disconnect.")
         .defaultValue(2)
-        .range(1, Integer.MAX_VALUE)
+        .min(1)
         .sliderMax(16)
         .visible(() -> !totalCount.get() && !entities.get().isEmpty())
         .build()
@@ -106,7 +106,7 @@ public class AutoLog extends Module {
         .name("range")
         .description("How close an entity has to be to you before you disconnect.")
         .defaultValue(5)
-        .range(1, 128)
+        .min(1)
         .sliderMax(16)
         .visible(() -> !entities.get().isEmpty())
         .build()
@@ -185,7 +185,9 @@ public class AutoLog extends Module {
             for (Entity entity : mc.world.getEntities()) {
                 if (PlayerUtils.isWithin(entity, range.get()) && entities.get().contains(entity.getType())) {
                     totalEntities++;
-                    entityCounts.put(entity.getType(), entityCounts.getOrDefault(entity.getType(), 0) + 1);
+                    if (!totalCount.get()) {
+                        entityCounts.put(entity.getType(), entityCounts.getOrDefault(entity.getType(), 0) + 1);
+                    }
                 }
             }
 


### PR DESCRIPTION
## Type of change

- [] Bug fix
- [ ✔] New feature

## Description

Added the feature requested in #4764 with universal entity selection. The new feature allows player to select any entity(or entities) from list to monitor. When they come close to player in variable distance and variable number the player automatically gets disconnected.

## Related issues

#4764 

# How Has This Been Tested?

Tested in flat World with restrictive conditions using various mobs and entities including but not limited to pigs, end crystal, TNT minecart etc.

# Checklist:

- [✔] My code follows the style guidelines of this project.
- [✔] I have added comments to my code in more complex areas.
- [✔] I have tested the code in both development and production environments.
