### PR TITLE
AutoEat module conflict fix

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoEat.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoEat.java
@@ -16,6 +16,9 @@ import meteordevelopment.meteorclient.systems.modules.combat.AnchorAura;
 import meteordevelopment.meteorclient.systems.modules.combat.BedAura;
 import meteordevelopment.meteorclient.systems.modules.combat.CrystalAura;
 import meteordevelopment.meteorclient.systems.modules.combat.KillAura;
+import meteordevelopment.meteorclient.systems.modules.world.Nuker;
+import meteordevelopment.meteorclient.systems.modules.world.InfinityMiner;
+import meteordevelopment.meteorclient.systems.modules.player.AutoFish;
 import meteordevelopment.meteorclient.utils.Utils;
 import meteordevelopment.meteorclient.utils.player.InvUtils;
 import meteordevelopment.meteorclient.utils.player.SlotUtils;
@@ -31,7 +34,7 @@ import java.util.List;
 import java.util.function.BiPredicate;
 
 public class AutoEat extends Module {
-    private static final Class<? extends Module>[] AURAS = new Class[]{KillAura.class, CrystalAura.class, AnchorAura.class, BedAura.class};
+    private static final Class<? extends Module>[] MODULELIST = new Class[]{KillAura.class, CrystalAura.class, AnchorAura.class, BedAura.class, Nuker.class, InfinityMiner.class, AutoFish.class};
 
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
     private final SettingGroup sgThreshold = settings.createGroup("Threshold");
@@ -56,9 +59,9 @@ public class AutoEat extends Module {
         .build()
     );
 
-    private final Setting<Boolean> pauseAuras = sgGeneral.add(new BoolSetting.Builder()
-        .name("pause-auras")
-        .description("Pauses all auras when eating.")
+    private final Setting<Boolean> pauseModules = sgGeneral.add(new BoolSetting.Builder()
+        .name("pause-modules")
+        .description("Pauses all Auras, Nuker, InfinityMiner and AutoFish when eating.")
         .defaultValue(true)
         .build()
     );
@@ -166,10 +169,10 @@ public class AutoEat extends Module {
         prevSlot = mc.player.getInventory().selectedSlot;
         eat();
 
-        // Pause auras
+        // Pause Auras, Nuker, InfinityMiner and AutoFish
         wasAura.clear();
-        if (pauseAuras.get()) {
-            for (Class<? extends Module> klass : AURAS) {
+        if (pauseModules.get()) {
+            for (Class<? extends Module> klass : MODULELIST) {
                 Module module = Modules.get().get(klass);
 
                 if (module.isActive()) {
@@ -200,9 +203,9 @@ public class AutoEat extends Module {
 
         eating = false;
 
-        // Resume auras
-        if (pauseAuras.get()) {
-            for (Class<? extends Module> klass : AURAS) {
+        // Resume Auras, Nuker, InfinityMiner and AutoFish
+        if (pauseModules.get()) {
+            for (Class<? extends Module> klass : MODULELIST) {
                 Module module = Modules.get().get(klass);
 
                 if (wasAura.contains(klass) && !module.isActive()) {


### PR DESCRIPTION
## Type of change

* [x] Bug fix

## Description

Pauses Nuker, InfinityMiner and AutoFish when auto eat is active.
(Simple edit)

Note: This is the same code, https://github.com/MeteorDevelopment/meteor-client/pull/4508, updated to the latest version. It was closed because of this [force-pushed](https://github.com/MeteorDevelopment/meteor-client/compare/9d01a175aca913e51df8bc2b2af3be7779fefd51..271a0e5da2e6bc7e3da7798df3724b79d0ece4ec) commit.

## Related issues

This PR fixes these issues. 
Closes https://github.com/MeteorDevelopment/meteor-client/issues/4237
Closes https://github.com/MeteorDevelopment/meteor-client/issues/4166
Closes https://github.com/MeteorDevelopment/meteor-client/issues/4041
Closes https://github.com/MeteorDevelopment/meteor-client/issues/2229

Solves the same issue differently.
Closes https://github.com/MeteorDevelopment/meteor-client/pull/4167
Closes https://github.com/MeteorDevelopment/meteor-client/pull/4062

# How Has This Been Tested?

Tested for months on 2b2t. This problem still exists, and is solved with this PR.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.