### PR TITLE
Fixed an error in arguments that made it impossible to use non-English characters, words with spaces and symbols.

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/FriendArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/FriendArgumentType.java
@@ -36,7 +36,7 @@ public class FriendArgumentType implements ArgumentType<String> {
     private FriendArgumentType() {}
 
     @Override
-    public String parse(StringReader reader) throws CommandSyntaxException {
+    public String parse(StringReader reader) {
         String argument = reader.getRemaining();
         reader.setCursor(reader.getTotalLength());
         return argument;

--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/FriendArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/FriendArgumentType.java
@@ -37,7 +37,9 @@ public class FriendArgumentType implements ArgumentType<String> {
 
     @Override
     public String parse(StringReader reader) throws CommandSyntaxException {
-        return reader.readString();
+        String argument = reader.getRemaining();
+        reader.setCursor(reader.getTotalLength());
+        return argument;
     }
 
     @Override

--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/PlayerArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/PlayerArgumentType.java
@@ -40,7 +40,8 @@ public class PlayerArgumentType implements ArgumentType<PlayerEntity> {
 
     @Override
     public PlayerEntity parse(StringReader reader) throws CommandSyntaxException {
-        String argument = reader.readString();
+        String argument = reader.getRemaining();
+        reader.setCursor(reader.getTotalLength());
         PlayerEntity playerEntity = null;
 
         for (PlayerEntity p : mc.world.getPlayers()) {

--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/PlayerListEntryArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/PlayerListEntryArgumentType.java
@@ -40,7 +40,8 @@ public class PlayerListEntryArgumentType implements ArgumentType<PlayerListEntry
 
     @Override
     public PlayerListEntry parse(StringReader reader) throws CommandSyntaxException {
-        String argument = reader.readString();
+        String argument = reader.getRemaining();
+        reader.setCursor(reader.getTotalLength());
         PlayerListEntry playerListEntry = null;
 
         for (PlayerListEntry p : mc.getNetworkHandler().getPlayerList()) {


### PR DESCRIPTION
## Type of change

- [x] Bug fix

## Description
Fixed an error in arguments that made it impossible to use non-English characters, words with spaces and symbols.(https://github.com/MeteorDevelopment/meteor-client/pull/4492)

# How Has This Been Tested?

It was tested with the command .friends add абоба

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have tested the code in both development and production environments.
