### PR TITLE
refactor: rename 'WindowResizedEvent' to 'ResolutionChangedEvent'

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/events/game/ResolutionChangedEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/game/ResolutionChangedEvent.java
@@ -5,10 +5,10 @@
 
 package meteordevelopment.meteorclient.events.game;
 
-public class WindowResizedEvent {
-    private static final WindowResizedEvent INSTANCE = new WindowResizedEvent();
+public class ResolutionChangedEvent {
+    private static final ResolutionChangedEvent INSTANCE = new ResolutionChangedEvent();
 
-    public static WindowResizedEvent get() {
+    public static ResolutionChangedEvent get() {
         return INSTANCE;
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/mixin/MinecraftClientMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MinecraftClientMixin.java
@@ -12,7 +12,7 @@ import meteordevelopment.meteorclient.events.entity.player.ItemUseCrosshairTarge
 import meteordevelopment.meteorclient.events.game.GameLeftEvent;
 import meteordevelopment.meteorclient.events.game.OpenScreenEvent;
 import meteordevelopment.meteorclient.events.game.ResourcePacksReloadedEvent;
-import meteordevelopment.meteorclient.events.game.WindowResizedEvent;
+import meteordevelopment.meteorclient.events.game.ResolutionChangedEvent;
 import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.gui.WidgetScreen;
 import meteordevelopment.meteorclient.mixininterface.IMinecraftClient;
@@ -163,7 +163,7 @@ public abstract class MinecraftClientMixin implements IMinecraftClient {
 
     @Inject(method = "onResolutionChanged", at = @At("TAIL"))
     private void onResolutionChanged(CallbackInfo info) {
-        MeteorClient.EVENT_BUS.post(WindowResizedEvent.get());
+        MeteorClient.EVENT_BUS.post(ResolutionChangedEvent.get());
     }
 
     @Inject(method = "getFramerateLimit", at = @At("HEAD"), cancellable = true)

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Blur.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Blur.java
@@ -7,7 +7,7 @@ package meteordevelopment.meteorclient.systems.modules.render;
 
 import it.unimi.dsi.fastutil.ints.IntDoubleImmutablePair;
 import meteordevelopment.meteorclient.MeteorClient;
-import meteordevelopment.meteorclient.events.game.WindowResizedEvent;
+import meteordevelopment.meteorclient.events.game.ResolutionChangedEvent;
 import meteordevelopment.meteorclient.events.render.RenderAfterWorldEvent;
 import meteordevelopment.meteorclient.gui.WidgetScreen;
 import meteordevelopment.meteorclient.renderer.*;
@@ -107,7 +107,7 @@ public class Blur extends Module {
         super(Categories.Render, "blur", "Blurs background when in GUI screens.");
 
         // The listeners need to run even when the module is not enabled
-        MeteorClient.EVENT_BUS.subscribe(new ConsumerListener<>(WindowResizedEvent.class, event -> {
+        MeteorClient.EVENT_BUS.subscribe(new ConsumerListener<>(ResolutionChangedEvent.class, event -> {
             // Resize all fbos
             for (int i = 0; i < fbos.length; i++) {
                 if (fbos[i] != null) {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor

## Description

This pull request renames the  `WindowResizedEvent` to `ResolutionChangedEvent` as the title implies, because the name `WindowResizedEvent` implies that the event notifies every time the window dimensions (width & height) have been changed. But the event only notifies when the actual resolution changes, which is the intended behavior for the only use in the client: the Blur module. 

The change also implies more directly where the event is created, at the end of the `onResolutionChanged` in the `MinecraftClient` class.

It could be called `WindowResolutionChangedEvent` to be even clearer, but that name would be very long.

## Related issues

\-

# How Has This Been Tested?

No logic changes; verified that Blur works on resize.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
