### PR TITLE
No mining trace no longer crashes if client.crosshairTarget is null

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/GameRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/GameRendererMixin.java
@@ -122,6 +122,8 @@ public abstract class GameRendererMixin {
 
     @Inject(method = "updateCrosshairTarget", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/GameRenderer;findCrosshairTarget(Lnet/minecraft/entity/Entity;DDF)Lnet/minecraft/util/hit/HitResult;"), cancellable = true)
     private void onUpdateTargetedEntity(float tickDelta, CallbackInfo info) {
+        if (client.crosshairTarget == null) { return; }
+
         if (Modules.get().get(NoMiningTrace.class).canWork() && client.crosshairTarget.getType() == HitResult.Type.BLOCK) {
             client.getProfiler().pop();
             info.cancel();


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

No mining trace no longer crashes if `client.crosshairTarget` is null.

## Related issues

Fixes [#4788](https://github.com/MeteorDevelopment/meteor-client/issues/4788)