### PR TITLE
[Bug Fix] Fixed Right click to pick new position.

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/input/WBlockPosEdit.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/input/WBlockPosEdit.java
@@ -83,6 +83,9 @@ public class WBlockPosEdit extends WHorizontalList {
             set(event.result.getBlockPos());
             newValueCheck();
 
+            clear();
+            init();
+
             clicking = false;
             event.cancel();
             MeteorClient.EVENT_BUS.unsubscribe(this);


### PR DESCRIPTION
Fixed Right click to pick new position.

## Type of change

- [x] Bug fix

## Description

Fixed a bug with the right click location picking option not setting location of the block on click. Example, Waypoint location picker.

![Screenshot 2024-08-09 111139](https://github.com/user-attachments/assets/8330cfd4-f6da-4de7-aa42-395dc682c3fa)

## Related issues

None

# How Has This Been Tested?

https://github.com/user-attachments/assets/64f961ae-f80f-45fd-9ba0-36771b43ab2c

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have tested the code in both development and production environments.
