### PR TITLE
Fix crash when you pass an invalid slot number

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/MeteorStarscript.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/MeteorStarscript.java
@@ -387,6 +387,7 @@ public class MeteorStarscript {
         if (argCount != 1) ss.error("player.get_item() requires 1 argument, got %d.", argCount);
 
         int i = (int) ss.popNumber("First argument to player.get_item() needs to be a number.");
+        if (i < 0 || i > 35) ss.error("First argument to player.get_item() needs to be between 0 and 35 (inclusive).", i);
         return mc.player != null ? wrap(mc.player.getInventory().getStack(i)) : Value.null_();
     }
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/MeteorStarscript.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/MeteorStarscript.java
@@ -387,7 +387,7 @@ public class MeteorStarscript {
         if (argCount != 1) ss.error("player.get_item() requires 1 argument, got %d.", argCount);
 
         int i = (int) ss.popNumber("First argument to player.get_item() needs to be a number.");
-        if (i < 0 || i > 35) ss.error("First argument to player.get_item() needs to be between 0 and 35 (inclusive).", i);
+        if (i < 0) ss.error("First argument to player.get_item() needs to be a non-negative integer.", i);
         return mc.player != null ? wrap(mc.player.getInventory().getStack(i)) : Value.null_();
     }
 


### PR DESCRIPTION
java.lang.ArrayIndexOutOfBoundsException: Index -4 out of bounds for length 36
	at java.base/java.util.Arrays$ArrayList.get(Unknown Source)

## Type of change

- [X] Bug fix
- [ ] New feature

## Description

passing an invalid slot number to player.get_item used to crash

# How Has This Been Tested?

has not i cannot build on my phone

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [ ] I have tested the code in both development and production environments.
