### PR TITLE
Fix BetterTooltips Crash

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/events/game/ItemStackTooltipEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/game/ItemStackTooltipEvent.java
@@ -5,9 +5,55 @@
 
 package meteordevelopment.meteorclient.events.game;
 
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.item.ItemStack;
 import net.minecraft.text.Text;
 
 import java.util.List;
 
-public record ItemStackTooltipEvent(ItemStack itemStack, List<Text> list) {}
+public class ItemStackTooltipEvent {
+    private final ItemStack itemStack;
+    private List<Text> list;
+
+    public ItemStackTooltipEvent(ItemStack itemStack, List<Text> list) {
+        this.itemStack = itemStack;
+        this.list = list;
+    }
+
+    public List<Text> list() {
+        return list;
+    }
+
+    public ItemStack itemStack() {
+        return itemStack;
+    }
+
+    public void appendStart(Text text) {
+        copyIfImmutable();
+        int index = list.isEmpty() ? 0 : 1;
+        list.add(index, text);
+    }
+
+    public void appendEnd(Text text) {
+        copyIfImmutable();
+        list.add(text);
+    }
+
+    public void append(int index, Text text) {
+        copyIfImmutable();
+        list.add(index, text);
+    }
+
+    public void set(int index, Text text) {
+        copyIfImmutable();
+        list.set(index, text);
+    }
+
+    private void copyIfImmutable() {
+        // ItemStack#getTooltip can sometimes return List.of(), which is immutable.
+        // Some modules like BetterTooltips try to modify that list anyway, which causes a crash if we don't replace it.
+        if (List.of().getClass().getSuperclass().isInstance(list)) {
+            list = new ObjectArrayList<>(list);
+        }
+    }
+}

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ItemStackMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ItemStackMixin.java
@@ -24,6 +24,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static meteordevelopment.meteorclient.MeteorClient.mc;
@@ -32,7 +33,8 @@ import static meteordevelopment.meteorclient.MeteorClient.mc;
 public abstract class ItemStackMixin {
     @ModifyReturnValue(method = "getTooltip", at = @At("RETURN"))
     private List<Text> onGetTooltip(List<Text> original) {
-        if (Utils.canUpdate()) {
+        if (Utils.canUpdate()) { // getTooltip can return List.of(), which is immutable. Prevents crash in BetterTooltips.
+            if (original.isEmpty()) original = new ArrayList<>();
             ItemStackTooltipEvent event = MeteorClient.EVENT_BUS.post(new ItemStackTooltipEvent((ItemStack) (Object) this, original));
             return event.list();
         }

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ItemStackMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ItemStackMixin.java
@@ -24,7 +24,6 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static meteordevelopment.meteorclient.MeteorClient.mc;
@@ -33,8 +32,7 @@ import static meteordevelopment.meteorclient.MeteorClient.mc;
 public abstract class ItemStackMixin {
     @ModifyReturnValue(method = "getTooltip", at = @At("RETURN"))
     private List<Text> onGetTooltip(List<Text> original) {
-        if (Utils.canUpdate()) { // getTooltip can return List.of(), which is immutable. Prevents crash in BetterTooltips.
-            if (original.isEmpty()) original = new ArrayList<>();
+        if (Utils.canUpdate()) {
             ItemStackTooltipEvent event = MeteorClient.EVENT_BUS.post(new ItemStackTooltipEvent((ItemStack) (Object) this, original));
             return event.list();
         }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BetterTooltips.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BetterTooltips.java
@@ -256,7 +256,7 @@ public class BetterTooltips extends Module {
         // Hide hidden (empty) tooltips unless the tooltip hide flag setting is true.
         if (!tooltip.get() && event.list().isEmpty()) {
             // Hold-to-preview tooltip text is always added when needed.
-            appendHoldToPreviewTooltipText(event);
+            appendPreviewTooltipText(event, false);
             return;
         }
 
@@ -314,7 +314,7 @@ public class BetterTooltips extends Module {
         }
 
         // Hold to preview tooltip
-        appendHoldToPreviewTooltipText(event);
+        appendPreviewTooltipText(event, true);
     }
 
     @EventHandler
@@ -404,17 +404,20 @@ public class BetterTooltips extends Module {
         }
     }
 
-    private void appendHoldToPreviewTooltipText(ItemStackTooltipEvent event) {
-        if ((shulkers.get() && !previewShulkers() && Utils.hasItems(event.itemStack()))
-            || (event.itemStack().getItem() == Items.ENDER_CHEST && echest.get() && !previewEChest())
-            || (event.itemStack().getItem() == Items.FILLED_MAP && maps.get() && !previewMaps())
-            || (event.itemStack().getItem() == Items.WRITABLE_BOOK && books.get() && !previewBooks())
-            || (event.itemStack().getItem() == Items.WRITTEN_BOOK && books.get() && !previewBooks())
-            || (event.itemStack().getItem() instanceof EntityBucketItem && entitiesInBuckets.get() && !previewEntities())
-            || (event.itemStack().getItem() instanceof BannerItem && banners.get() && !previewBanners())
-            || (event.itemStack().getItem() instanceof BannerPatternItem && banners.get() && !previewBanners())
-            || (event.itemStack().getItem() == Items.SHIELD && banners.get() && !previewBanners())) {
-            event.appendEnd(Text.literal(""));
+    private void appendPreviewTooltipText(ItemStackTooltipEvent event, boolean spacer) {
+        if (!isPressed() && (
+            shulkers.get() && Utils.hasItems(event.itemStack())
+            || (event.itemStack().getItem() == Items.ENDER_CHEST && echest.get())
+            || (event.itemStack().getItem() == Items.FILLED_MAP && maps.get())
+            || (event.itemStack().getItem() == Items.WRITABLE_BOOK && books.get())
+            || (event.itemStack().getItem() == Items.WRITTEN_BOOK && books.get())
+            || (event.itemStack().getItem() instanceof EntityBucketItem && entitiesInBuckets.get())
+            || (event.itemStack().getItem() instanceof BannerItem && banners.get())
+            || (event.itemStack().getItem() instanceof BannerPatternItem && banners.get())
+            || (event.itemStack().getItem() == Items.SHIELD && banners.get())
+        )) {
+            // we don't want to add the spacer if the tooltip is hidden
+            if (spacer) event.appendEnd(Text.literal(""));
             event.appendEnd(Text.literal("Hold " + Formatting.YELLOW + keybind + Formatting.RESET + " to preview"));
         }
     }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BetterTooltips.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BetterTooltips.java
@@ -253,6 +253,17 @@ public class BetterTooltips extends Module {
 
     @EventHandler
     private void appendTooltip(ItemStackTooltipEvent event) {
+        // Hide hidden (empty) tooltips unless the tooltip hide flag setting is true.
+        // If the tooltip is empty, adjust insertIndex downward to avoid throwing IndexOutOfBoundsException.
+        int insertIndex = 1;
+        if (!tooltip.get() && event.list().isEmpty()) {
+            // Hold-to-preview tooltip text is always added when needed.
+            appendHoldToPreviewTooltipText(event);
+            return;
+        } else if (event.list().isEmpty()) {
+            insertIndex = 0;
+        }
+
         // Status effects
         if (statusEffects.get()) {
             if (event.itemStack().getItem() == Items.SUSPICIOUS_STEW) {
@@ -260,13 +271,13 @@ public class BetterTooltips extends Module {
                 if (stewEffectsComponent != null) {
                     for (StewEffect effectTag : stewEffectsComponent.effects()) {
                         StatusEffectInstance effect = new StatusEffectInstance(effectTag.effect(), effectTag.duration(), 0);
-                        event.list().add(1, getStatusText(effect));
+                        event.list().add(insertIndex, getStatusText(effect));
                     }
                 }
             } else {
                 FoodComponent food = event.itemStack().get(DataComponentTypes.FOOD);
                 if (food != null) {
-                    food.effects().forEach(e -> event.list().add(1, getStatusText(e.effect())));
+                    food.effects().forEach(e -> event.list().add(event.list().isEmpty() ? 0 : 1, getStatusText(e.effect())));
                 }
             }
         }
@@ -277,12 +288,12 @@ public class BetterTooltips extends Module {
                 BlockStateComponent blockStateComponent = event.itemStack().get(DataComponentTypes.BLOCK_STATE);
                 if (blockStateComponent != null) {
                     String level = blockStateComponent.properties().get("honey_level");
-                    event.list().add(1, Text.literal(String.format("%sHoney level: %s%s%s.", Formatting.GRAY, Formatting.YELLOW, level, Formatting.GRAY)));
+                    event.list().add(insertIndex, Text.literal(String.format("%sHoney level: %s%s%s.", Formatting.GRAY, Formatting.YELLOW, level, Formatting.GRAY)));
                 }
 
                 List<BeehiveBlockEntity.BeeData> bees = event.itemStack().get(DataComponentTypes.BEES);
                 if (bees != null) {
-                    event.list().add(1, Text.literal(String.format("%sBees: %s%d%s.", Formatting.GRAY, Formatting.YELLOW, bees.size(), Formatting.GRAY)));
+                    event.list().add(insertIndex, Text.literal(String.format("%sBees: %s%d%s.", Formatting.GRAY, Formatting.YELLOW, bees.size(), Formatting.GRAY)));
                 }
             }
         }
@@ -307,18 +318,7 @@ public class BetterTooltips extends Module {
         }
 
         // Hold to preview tooltip
-        if ((shulkers.get() && !previewShulkers() && Utils.hasItems(event.itemStack()))
-            || (event.itemStack().getItem() == Items.ENDER_CHEST && echest.get() && !previewEChest())
-            || (event.itemStack().getItem() == Items.FILLED_MAP && maps.get() && !previewMaps())
-            || (event.itemStack().getItem() == Items.WRITABLE_BOOK && books.get() && !previewBooks())
-            || (event.itemStack().getItem() == Items.WRITTEN_BOOK && books.get() && !previewBooks())
-            || (event.itemStack().getItem() instanceof EntityBucketItem && entitiesInBuckets.get() && !previewEntities())
-            || (event.itemStack().getItem() instanceof BannerItem && banners.get() && !previewBanners())
-            || (event.itemStack().getItem() instanceof BannerPatternItem && banners.get() && !previewBanners())
-            || (event.itemStack().getItem() == Items.SHIELD && banners.get() && !previewBanners())) {
-            event.list().add(Text.literal(""));
-            event.list().add(Text.literal("Hold " + Formatting.YELLOW + keybind + Formatting.RESET + " to preview"));
-        }
+        appendHoldToPreviewTooltipText(event);
     }
 
     @EventHandler
@@ -405,6 +405,21 @@ public class BetterTooltips extends Module {
                     tooltip.add((Text.translatable("container.shulkerBox.more", counts.size() - 5)).formatted(Formatting.ITALIC));
                 }
             }
+        }
+    }
+
+    private void appendHoldToPreviewTooltipText(ItemStackTooltipEvent event) {
+        if ((shulkers.get() && !previewShulkers() && Utils.hasItems(event.itemStack()))
+            || (event.itemStack().getItem() == Items.ENDER_CHEST && echest.get() && !previewEChest())
+            || (event.itemStack().getItem() == Items.FILLED_MAP && maps.get() && !previewMaps())
+            || (event.itemStack().getItem() == Items.WRITABLE_BOOK && books.get() && !previewBooks())
+            || (event.itemStack().getItem() == Items.WRITTEN_BOOK && books.get() && !previewBooks())
+            || (event.itemStack().getItem() instanceof EntityBucketItem && entitiesInBuckets.get() && !previewEntities())
+            || (event.itemStack().getItem() instanceof BannerItem && banners.get() && !previewBanners())
+            || (event.itemStack().getItem() instanceof BannerPatternItem && banners.get() && !previewBanners())
+            || (event.itemStack().getItem() == Items.SHIELD && banners.get() && !previewBanners())) {
+            event.list().add(Text.literal(""));
+            event.list().add(Text.literal("Hold " + Formatting.YELLOW + keybind + Formatting.RESET + " to preview"));
         }
     }
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BetterTooltips.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BetterTooltips.java
@@ -254,14 +254,10 @@ public class BetterTooltips extends Module {
     @EventHandler
     private void appendTooltip(ItemStackTooltipEvent event) {
         // Hide hidden (empty) tooltips unless the tooltip hide flag setting is true.
-        // If the tooltip is empty, adjust insertIndex downward to avoid throwing IndexOutOfBoundsException.
-        int insertIndex = 1;
         if (!tooltip.get() && event.list().isEmpty()) {
             // Hold-to-preview tooltip text is always added when needed.
             appendHoldToPreviewTooltipText(event);
             return;
-        } else if (event.list().isEmpty()) {
-            insertIndex = 0;
         }
 
         // Status effects
@@ -271,13 +267,13 @@ public class BetterTooltips extends Module {
                 if (stewEffectsComponent != null) {
                     for (StewEffect effectTag : stewEffectsComponent.effects()) {
                         StatusEffectInstance effect = new StatusEffectInstance(effectTag.effect(), effectTag.duration(), 0);
-                        event.list().add(insertIndex, getStatusText(effect));
+                        event.appendStart(getStatusText(effect));
                     }
                 }
             } else {
                 FoodComponent food = event.itemStack().get(DataComponentTypes.FOOD);
                 if (food != null) {
-                    food.effects().forEach(e -> event.list().add(event.list().isEmpty() ? 0 : 1, getStatusText(e.effect())));
+                    food.effects().forEach(e -> event.appendStart(getStatusText(e.effect())));
                 }
             }
         }
@@ -288,12 +284,12 @@ public class BetterTooltips extends Module {
                 BlockStateComponent blockStateComponent = event.itemStack().get(DataComponentTypes.BLOCK_STATE);
                 if (blockStateComponent != null) {
                     String level = blockStateComponent.properties().get("honey_level");
-                    event.list().add(insertIndex, Text.literal(String.format("%sHoney level: %s%s%s.", Formatting.GRAY, Formatting.YELLOW, level, Formatting.GRAY)));
+                    event.appendStart(Text.literal(String.format("%sHoney level: %s%s%s.", Formatting.GRAY, Formatting.YELLOW, level, Formatting.GRAY)));
                 }
 
                 List<BeehiveBlockEntity.BeeData> bees = event.itemStack().get(DataComponentTypes.BEES);
                 if (bees != null) {
-                    event.list().add(insertIndex, Text.literal(String.format("%sBees: %s%d%s.", Formatting.GRAY, Formatting.YELLOW, bees.size(), Formatting.GRAY)));
+                    event.appendStart(Text.literal(String.format("%sBees: %s%d%s.", Formatting.GRAY, Formatting.YELLOW, bees.size(), Formatting.GRAY)));
                 }
             }
         }
@@ -311,9 +307,9 @@ public class BetterTooltips extends Module {
                 if (byteCount >= 1024) count = String.format("%.2f kb", byteCount / (float) 1024);
                 else count = String.format("%d bytes", byteCount);
 
-                event.list().add(Text.literal(count).formatted(Formatting.GRAY));
+                event.appendEnd(Text.literal(count).formatted(Formatting.GRAY));
             } catch (Exception e) {
-                event.list().add(Text.literal("Error getting bytes.").formatted(Formatting.RED));
+                event.appendEnd(Text.literal("Error getting bytes.").formatted(Formatting.RED));
             }
         }
 
@@ -418,8 +414,8 @@ public class BetterTooltips extends Module {
             || (event.itemStack().getItem() instanceof BannerItem && banners.get() && !previewBanners())
             || (event.itemStack().getItem() instanceof BannerPatternItem && banners.get() && !previewBanners())
             || (event.itemStack().getItem() == Items.SHIELD && banners.get() && !previewBanners())) {
-            event.list().add(Text.literal(""));
-            event.list().add(Text.literal("Hold " + Formatting.YELLOW + keybind + Formatting.RESET + " to preview"));
+            event.appendEnd(Text.literal(""));
+            event.appendEnd(Text.literal("Hold " + Formatting.YELLOW + keybind + Formatting.RESET + " to preview"));
         }
     }
 


### PR DESCRIPTION
## Type of change

- [x ] Bug fix
- [ ] New feature

## Description

I modified ItemStackMixin#onGetTooltip to return an empty ArrayList instead of an immutable list when there is no tooltip.

This prevents a crash when BetterTooltips attempts to add to that immutable list.

## Related issues

https://github.com/MeteorDevelopment/meteor-client/issues/4912

# How Has This Been Tested?

It hasn't.

# Checklist:

- [x ] My code follows the style guidelines of this project.
- [x ] I have added comments to my code in more complex areas.
- [ ] I have tested the code in both development and production environments.
