### PR TITLE
Add a blacklist for no mining trace

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/GameRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/GameRendererMixin.java
@@ -6,6 +6,7 @@
 package meteordevelopment.meteorclient.mixin;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.blaze3d.systems.RenderSystem;
 import meteordevelopment.meteorclient.MeteorClient;
@@ -31,6 +32,7 @@ import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.Entity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
+import net.minecraft.util.hit.EntityHitResult;
 import net.minecraft.util.hit.HitResult;
 import org.joml.Matrix4f;
 import org.spongepowered.asm.mixin.Final;
@@ -41,7 +43,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 @Mixin(GameRenderer.class)
@@ -121,11 +122,12 @@ public abstract class GameRendererMixin {
         MeteorClient.EVENT_BUS.post(RenderAfterWorldEvent.get());
     }
 
-    @Inject(method = "findCrosshairTarget", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/projectile/ProjectileUtil;raycast(Lnet/minecraft/entity/Entity;Lnet/minecraft/util/math/Vec3d;Lnet/minecraft/util/math/Vec3d;Lnet/minecraft/util/math/Box;Ljava/util/function/Predicate;D)Lnet/minecraft/util/hit/EntityHitResult;"), cancellable = true)
-    private void onUpdateTargetedEntity(Entity camera, double blockInteractionRange, double entityInteractionRange, float tickDelta, CallbackInfoReturnable<HitResult> cir, @Local HitResult hitResult) {
-        if (Modules.get().get(NoMiningTrace.class).canWork() && hitResult.getType() == HitResult.Type.BLOCK) {
-            cir.setReturnValue(hitResult);
+    @ModifyReturnValue(method = "findCrosshairTarget", at = @At("RETURN"))
+    private HitResult onUpdateTargetedEntity(HitResult original, @Local HitResult hitResult) {
+        if (Modules.get().get(NoMiningTrace.class).canWork(original instanceof EntityHitResult ehr ? ehr.getEntity() : null) && hitResult.getType() == HitResult.Type.BLOCK) {
+            return hitResult;
         }
+        return original;
     }
 
     @Redirect(method = "findCrosshairTarget", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;raycast(DFZ)Lnet/minecraft/util/hit/HitResult;"))

--- a/src/main/java/meteordevelopment/meteorclient/mixin/baritone/ComeCommandMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/baritone/ComeCommandMixin.java
@@ -22,7 +22,7 @@ public abstract class ComeCommandMixin {
     private void getComeCommandTarget(Args args) {
         Freecam freecam = Modules.get().get(Freecam.class);
         if (freecam.isActive()) {
-            float tickDelta = mc.getRenderTickCounter().getTickDelta(true); // todo unsure if true or false
+            float tickDelta = mc.getRenderTickCounter().getTickDelta(true);
             args.set(0, new GoalBlock((int) freecam.getX(tickDelta), (int) freecam.getY(tickDelta), (int) freecam.getZ(tickDelta)));
         }
     }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/NoMiningTrace.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/NoMiningTrace.java
@@ -5,16 +5,28 @@
 
 package meteordevelopment.meteorclient.systems.modules.player;
 
+import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.settings.BoolSetting;
+import meteordevelopment.meteorclient.settings.EntityTypeListSetting;
 import meteordevelopment.meteorclient.settings.Setting;
 import meteordevelopment.meteorclient.settings.SettingGroup;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.orbit.EventHandler;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
 import net.minecraft.item.PickaxeItem;
 
+import java.util.Set;
 public class NoMiningTrace extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
 
+    private final Setting<Set<EntityType<?>>> entities = sgGeneral.add(new EntityTypeListSetting.Builder()
+        .name("entities")
+        .description("Entity blacklist")
+        .defaultValue()
+        .build()
+    );
     private final Setting<Boolean> onlyWhenHoldingPickaxe = sgGeneral.add(new BoolSetting.Builder()
         .name("only-when-holding-a-pickaxe")
         .description("Whether or not to work only when holding a pickaxe.")
@@ -33,6 +45,9 @@ public class NoMiningTrace extends Module {
             return mc.player.getMainHandStack().getItem() instanceof PickaxeItem || mc.player.getOffHandStack().getItem() instanceof PickaxeItem;
         }
 
+        Entity target = mc.targetedEntity;
+        if (target == null) return false;
+        if (entities.get().contains(target.getType())) return false;
         return true;
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/NoMiningTrace.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/NoMiningTrace.java
@@ -5,28 +5,28 @@
 
 package meteordevelopment.meteorclient.systems.modules.player;
 
-import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.settings.BoolSetting;
 import meteordevelopment.meteorclient.settings.EntityTypeListSetting;
 import meteordevelopment.meteorclient.settings.Setting;
 import meteordevelopment.meteorclient.settings.SettingGroup;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
-import meteordevelopment.orbit.EventHandler;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.item.PickaxeItem;
 
 import java.util.Set;
+
 public class NoMiningTrace extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
 
     private final Setting<Set<EntityType<?>>> entities = sgGeneral.add(new EntityTypeListSetting.Builder()
-        .name("entities")
-        .description("Entity blacklist")
+        .name("blacklisted-entities")
+        .description("Entities you will interact with as normal.")
         .defaultValue()
         .build()
     );
+
     private final Setting<Boolean> onlyWhenHoldingPickaxe = sgGeneral.add(new BoolSetting.Builder()
         .name("only-when-holding-a-pickaxe")
         .description("Whether or not to work only when holding a pickaxe.")
@@ -38,16 +38,10 @@ public class NoMiningTrace extends Module {
         super(Categories.Player, "no-mining-trace", "Allows you to mine blocks through entities.");
     }
 
-    public boolean canWork() {
+    public boolean canWork(Entity entity) {
         if (!isActive()) return false;
 
-        if (onlyWhenHoldingPickaxe.get()) {
-            return mc.player.getMainHandStack().getItem() instanceof PickaxeItem || mc.player.getOffHandStack().getItem() instanceof PickaxeItem;
-        }
-
-        Entity target = mc.targetedEntity;
-        if (target == null) return false;
-        if (entities.get().contains(target.getType())) return false;
-        return true;
+        return (!onlyWhenHoldingPickaxe.get() || mc.player.getMainHandStack().getItem() instanceof PickaxeItem || mc.player.getOffHandStack().getItem() instanceof PickaxeItem) &&
+            (entity == null || !entities.get().contains(entity.getType()));
     }
 }


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Adds a blacklist for the No Mining Trace module to allow users to select entities they still want to attack (Without my broken git branchs)

## Related issues

#4898 

# How Has This Been Tested?

Simple, it just works

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
