### PR TITLE
Display in the module screen from which addon they come from.

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/MeteorClient.java
+++ b/src/main/java/meteordevelopment/meteorclient/MeteorClient.java
@@ -97,7 +97,6 @@ public class MeteorClient implements ClientModInitializer {
         AddonManager.init();
 
         // Register event handlers
-        EVENT_BUS.registerLambdaFactory(ADDON.getPackage() , (lookupInMethod, klass) -> (MethodHandles.Lookup) lookupInMethod.invoke(null, klass, MethodHandles.lookup()));
         AddonManager.ADDONS.forEach(addon -> {
             try {
                 EVENT_BUS.registerLambdaFactory(addon.getPackage(), (lookupInMethod, klass) -> (MethodHandles.Lookup) lookupInMethod.invoke(null, klass, MethodHandles.lookup()));
@@ -122,7 +121,7 @@ public class MeteorClient implements ClientModInitializer {
         EVENT_BUS.subscribe(this);
 
         // Initialise addons
-        AddonManager.initialiseAddons();
+        AddonManager.ADDONS.forEach(MeteorAddon::onInitialize);
 
         // Sort modules after addons have added their own
         Modules.get().sortModules();

--- a/src/main/java/meteordevelopment/meteorclient/MeteorClient.java
+++ b/src/main/java/meteordevelopment/meteorclient/MeteorClient.java
@@ -122,7 +122,7 @@ public class MeteorClient implements ClientModInitializer {
         EVENT_BUS.subscribe(this);
 
         // Initialise addons
-        AddonManager.ADDONS.forEach(MeteorAddon::onInitialize);
+        AddonManager.initialiseAddons();
 
         // Sort modules after addons have added their own
         Modules.get().sortModules();

--- a/src/main/java/meteordevelopment/meteorclient/addons/AddonManager.java
+++ b/src/main/java/meteordevelopment/meteorclient/addons/AddonManager.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 public class AddonManager {
     public static final List<MeteorAddon> ADDONS = new ArrayList<>();
+    public static MeteorAddon currentAddon;
 
     public static void init() {
         // Meteor pseudo addon
@@ -86,5 +87,20 @@ public class AddonManager {
 
             ADDONS.add(addon);
         }
+}
+
+    /**
+     *  currentAddon is used to allow us to track where any modules, commands, etc. being initialised are coming from.
+     *  Assumes everything the addon wants to initialise happens within {@link MeteorAddon#onInitialize()}, which should
+     *  really always be the case.
+     *  @see meteordevelopment.meteorclient.systems.modules.Modules#add(meteordevelopment.meteorclient.systems.modules.Module)
+     */
+    public static void initialiseAddons() {
+        ADDONS.forEach(meteorAddon -> {
+            currentAddon = meteorAddon;
+            currentAddon.onInitialize();
+        });
+
+        currentAddon = null;
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/addons/AddonManager.java
+++ b/src/main/java/meteordevelopment/meteorclient/addons/AddonManager.java
@@ -16,7 +16,6 @@ import java.util.List;
 
 public class AddonManager {
     public static final List<MeteorAddon> ADDONS = new ArrayList<>();
-    public static MeteorAddon currentAddon;
 
     public static void init() {
         // Meteor pseudo addon
@@ -59,6 +58,8 @@ public class AddonManager {
             for (Person author : metadata.getAuthors()) {
                 MeteorClient.ADDON.authors[i++] = author.getName();
             }
+
+            ADDONS.add(MeteorClient.ADDON);
         }
 
         // Addons
@@ -87,20 +88,5 @@ public class AddonManager {
 
             ADDONS.add(addon);
         }
-}
-
-    /**
-     *  currentAddon is used to allow us to track where any modules, commands, etc. being initialised are coming from.
-     *  Assumes everything the addon wants to initialise happens within {@link MeteorAddon#onInitialize()}, which should
-     *  really always be the case.
-     *  @see meteordevelopment.meteorclient.systems.modules.Modules#add(meteordevelopment.meteorclient.systems.modules.Module)
-     */
-    public static void initialiseAddons() {
-        ADDONS.forEach(meteorAddon -> {
-            currentAddon = meteorAddon;
-            currentAddon.onInitialize();
-        });
-
-        currentAddon = null;
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/ModuleScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/ModuleScreen.java
@@ -94,14 +94,17 @@ public class ModuleScreen extends WindowScreen {
         // Bottom
         WHorizontalList bottom = add(theme.horizontalList()).expandX().widget();
 
-        //   Active
+        // Active
         bottom.add(theme.label("Active: "));
         active = bottom.add(theme.checkbox(module.isActive())).expandCellX().widget();
         active.action = () -> {
             if (module.isActive() != active.checked) module.toggle();
         };
 
-        if (module.addon != MeteorClient.ADDON) bottom.add(theme.label("From: " + module.addon.name)).right().widget();
+        if (module.addon != null && module.addon != MeteorClient.ADDON) {
+            bottom.add(theme.label("From: ")).right().widget();
+            bottom.add(theme.label(module.addon.name).color(theme.textSecondaryColor())).right().widget();
+        }
     }
 
     @Override

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/ModuleScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/ModuleScreen.java
@@ -5,6 +5,7 @@
 
 package meteordevelopment.meteorclient.gui.screens;
 
+import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.events.meteor.ActiveModulesChangedEvent;
 import meteordevelopment.meteorclient.events.meteor.ModuleBindChangedEvent;
 import meteordevelopment.meteorclient.gui.GuiTheme;
@@ -99,6 +100,8 @@ public class ModuleScreen extends WindowScreen {
         active.action = () -> {
             if (module.isActive() != active.checked) module.toggle();
         };
+
+        if (module.addon != MeteorClient.ADDON) bottom.add(theme.label("From: " + module.addon.name)).right().widget();
     }
 
     @Override

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Module.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Module.java
@@ -6,6 +6,7 @@
 package meteordevelopment.meteorclient.systems.modules;
 
 import meteordevelopment.meteorclient.MeteorClient;
+import meteordevelopment.meteorclient.addons.AddonManager;
 import meteordevelopment.meteorclient.addons.MeteorAddon;
 import meteordevelopment.meteorclient.gui.GuiTheme;
 import meteordevelopment.meteorclient.gui.widgets.WWidget;
@@ -34,7 +35,7 @@ public abstract class Module implements ISerializable<Module>, Comparable<Module
     public final String description;
     public final Color color;
 
-    public MeteorAddon addon = MeteorClient.ADDON;
+    public final MeteorAddon addon;
     public final Settings settings = new Settings();
 
     private boolean active;
@@ -55,6 +56,16 @@ public abstract class Module implements ISerializable<Module>, Comparable<Module
         this.title = Utils.nameToTitle(name);
         this.description = description;
         this.color = Color.fromHsv(Utils.random(0.0, 360.0), 0.35, 1);
+
+        String classname = this.getClass().getName();
+        for (MeteorAddon addon : AddonManager.ADDONS) {
+            if (classname.startsWith(addon.getPackage())) {
+                this.addon = addon;
+                return;
+            }
+        }
+
+        this.addon = null;
     }
 
     public WWidget getWidget(GuiTheme theme) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Module.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Module.java
@@ -6,6 +6,7 @@
 package meteordevelopment.meteorclient.systems.modules;
 
 import meteordevelopment.meteorclient.MeteorClient;
+import meteordevelopment.meteorclient.addons.MeteorAddon;
 import meteordevelopment.meteorclient.gui.GuiTheme;
 import meteordevelopment.meteorclient.gui.widgets.WWidget;
 import meteordevelopment.meteorclient.settings.Settings;
@@ -33,6 +34,7 @@ public abstract class Module implements ISerializable<Module>, Comparable<Module
     public final String description;
     public final Color color;
 
+    public MeteorAddon addon = MeteorClient.ADDON;
     public final Settings settings = new Settings();
 
     private boolean active;

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
@@ -9,6 +9,7 @@ import com.mojang.datafixers.util.Pair;
 import com.mojang.serialization.Lifecycle;
 import it.unimi.dsi.fastutil.objects.Reference2ReferenceOpenHashMap;
 import meteordevelopment.meteorclient.MeteorClient;
+import meteordevelopment.meteorclient.addons.AddonManager;
 import meteordevelopment.meteorclient.events.game.GameJoinedEvent;
 import meteordevelopment.meteorclient.events.game.GameLeftEvent;
 import meteordevelopment.meteorclient.events.game.OpenScreenEvent;
@@ -395,6 +396,11 @@ public class Modules extends System<Modules> {
 
         // Register color settings for the module
         module.settings.registerColorSettings(module);
+
+        // set the addon if applicable
+        if (AddonManager.currentAddon != null) {
+            module.addon = AddonManager.currentAddon;
+        }
     }
 
     private void initCombat() {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
@@ -9,7 +9,6 @@ import com.mojang.datafixers.util.Pair;
 import com.mojang.serialization.Lifecycle;
 import it.unimi.dsi.fastutil.objects.Reference2ReferenceOpenHashMap;
 import meteordevelopment.meteorclient.MeteorClient;
-import meteordevelopment.meteorclient.addons.AddonManager;
 import meteordevelopment.meteorclient.events.game.GameJoinedEvent;
 import meteordevelopment.meteorclient.events.game.GameLeftEvent;
 import meteordevelopment.meteorclient.events.game.OpenScreenEvent;
@@ -396,11 +395,6 @@ public class Modules extends System<Modules> {
 
         // Register color settings for the module
         module.settings.registerColorSettings(module);
-
-        // set the addon if applicable
-        if (AddonManager.currentAddon != null) {
-            module.addon = AddonManager.currentAddon;
-        }
     }
 
     private void initCombat() {

--- a/src/main/java/meteordevelopment/meteorclient/utils/ReflectInit.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/ReflectInit.java
@@ -5,7 +5,6 @@
 
 package meteordevelopment.meteorclient.utils;
 
-import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.addons.AddonManager;
 import meteordevelopment.meteorclient.addons.MeteorAddon;
 import org.reflections.Reflections;
@@ -24,8 +23,6 @@ public class ReflectInit {
     }
 
     public static void registerPackages() {
-        add(MeteorClient.ADDON);
-
         for (MeteorAddon addon : AddonManager.ADDONS) {
             try {
                 add(addon);

--- a/src/main/java/meteordevelopment/meteorclient/utils/player/TitleScreenCredits.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/TitleScreenCredits.java
@@ -36,7 +36,6 @@ public class TitleScreenCredits {
 
     private static void init() {
         // Add addons
-        add(MeteorClient.ADDON);
         for (MeteorAddon addon : AddonManager.ADDONS) add(addon);
 
         // Sort by width (Meteor always first)


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Tracks per module which addon they come from, and displays it in the module screen if they do not come from meteor itself.

## Related issues

closes #4445

# How Has This Been Tested?

![java_BHa0RbA4KF](https://github.com/user-attachments/assets/6a00fa35-7ee7-4b12-8fd0-f67ab2569a96)

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
