### PR TITLE
Fix the alt manager's limit of 3 Microsoft accounts.

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/WAccount.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/WAccount.java
@@ -58,7 +58,7 @@ public abstract class WAccount extends WHorizontalList {
             screen.locked = true;
 
             MeteorExecutor.execute(() -> {
-                if (account.login()) {
+                if (account.fetchInfo() && account.login()) {
                     name.set(account.getUsername());
 
                     Accounts.get().save();

--- a/src/main/java/meteordevelopment/meteorclient/systems/accounts/Accounts.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/accounts/Accounts.java
@@ -73,18 +73,14 @@ public class Accounts extends System<Accounts> implements Iterable<Account<?>> {
             AccountType type = AccountType.valueOf(t.getString("type"));
 
             try {
-                Account<?> account = switch (type) {
+                return switch (type) {
                     case Cracked ->     new CrackedAccount(null).fromTag(t);
                     case Microsoft ->   new MicrosoftAccount(null).fromTag(t);
                     case TheAltening -> new TheAlteningAccount(null).fromTag(t);
                 };
-
-                if (account.fetchInfo()) return account;
             } catch (NbtException e) {
                 return null;
             }
-
-            return null;
         }));
 
         return this;

--- a/src/main/java/meteordevelopment/meteorclient/systems/accounts/types/MicrosoftAccount.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/accounts/types/MicrosoftAccount.java
@@ -10,33 +10,34 @@ import meteordevelopment.meteorclient.systems.accounts.Account;
 import meteordevelopment.meteorclient.systems.accounts.AccountType;
 import meteordevelopment.meteorclient.systems.accounts.MicrosoftLogin;
 import net.minecraft.client.session.Session;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
 
 public class MicrosoftAccount extends Account<MicrosoftAccount> {
+    private @Nullable String token;
     public MicrosoftAccount(String refreshToken) {
         super(AccountType.Microsoft, refreshToken);
     }
 
     @Override
     public boolean fetchInfo() {
-        return auth() != null;
+        token = auth();
+        return token != null;
     }
 
     @Override
     public boolean login() {
-        super.login();
-
-        String token = auth();
         if (token == null) return false;
 
+        super.login();
         cache.loadHead();
 
         setSession(new Session(cache.username, UndashedUuid.fromStringLenient(cache.uuid), token, Optional.empty(), Optional.empty(), Session.AccountType.MSA));
         return true;
     }
 
-    private String auth() {
+    private @Nullable String auth() {
         MicrosoftLogin.LoginData data = MicrosoftLogin.login(name);
         if (!data.isGood()) return null;
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

This pr fixes the alt manager's incidental limit of 3 Microsoft accounts, which was occurring due to an API ratelimit during the process of loading accounts from disk. I accomplished this by moving usage of the fetchInfo() method out of Accounts#fromTag and relocating it to instead run when an account is actually logged into.

This prevents accounts beyond the 3rd from being thanos-snapped off the account list due to ratelimits on startup. You can still be ratelimited if you're switching between accounts too quickly, but if this happens just be patient, wait 30 seconds, try again and it will work.

## Related issues

Closes https://github.com/MeteorDevelopment/meteor-client/issues/4054

# How Has This Been Tested?

This was tested by adding more than 3 Microsoft accounts to the alt manager, closing and reopening the client, and then logging into and joining a server with each account in turn, to ensure the feature was working as expected. As a result of these changes, the alt manager can now support more than 3 accounts, which successfully persist through restarts.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
