### PR TITLE
Add player join/leave messages to Notifier

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notifier.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notifier.java
@@ -221,10 +221,8 @@ public class Notifier extends Module {
             }
         }
 
-        if (pearl.get()) {
-            if (event.entity instanceof EnderPearlEntity pearlEntity) {
-                pearlStartPosMap.put(pearlEntity.getId(), new Vec3d(pearlEntity.getX(), pearlEntity.getY(), pearlEntity.getZ()));
-            }
+        if (pearl.get() && event.entity instanceof EnderPearlEntity pearlEntity) {
+            pearlStartPosMap.put(pearlEntity.getId(), new Vec3d(pearlEntity.getX(), pearlEntity.getY(), pearlEntity.getZ()));
         }
     }
 
@@ -379,7 +377,6 @@ public class Notifier extends Module {
                         + Formatting.GRAY + " joined."
                 ));
             }
-
         }
     }
 


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

This pr adds options to display player join/leave messages in the Notifier module. Includes two different formatting styles, a configurable notification delay, and the option to show only joins, only leaves, neither, or both.

## Related issues

Closes https://github.com/MeteorDevelopment/meteor-client/issues/4929

# How Has This Been Tested?

A screenshot demonstrating both notification styles:
![image](https://github.com/user-attachments/assets/f3fa5901-8c7a-4877-85f1-497c048657dc)


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
