### PR TITLE
Increase nametage scale when using Zoom

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/WaypointsModule.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/WaypointsModule.java
@@ -107,7 +107,7 @@ public class WaypointsModule extends Module {
 
             // Continue if this waypoint should not be rendered
             if (dist > waypoint.maxVisible.get()) continue;
-            if (!NametagUtils.to2D(pos, 1)) continue;
+            if (!NametagUtils.to2D(pos, waypoint.scale.get() - 0.2)) continue;
 
             // Calculate alpha and distance to center of the screen
             double distToCenter = pos.distance(center);
@@ -119,7 +119,6 @@ public class WaypointsModule extends Module {
             }
 
             // Render
-            NametagUtils.scale = waypoint.scale.get() - 0.2;
             NametagUtils.begin(pos);
 
             // Render icon
@@ -129,7 +128,7 @@ public class WaypointsModule extends Module {
             if (distToCenter <= textRenderDist) {
                 // Setup text rendering
                 int preTextA = TEXT.a;
-                TEXT.a *= a;
+                TEXT.a *= (int) a;
                 text.begin();
 
                 // Render name

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Zoom.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Zoom.java
@@ -97,7 +97,7 @@ public class Zoom extends Module {
         mc.options.smoothCameraEnabled = cinematic.get();
 
         if (!cinematic.get()) {
-            mc.options.getMouseSensitivity().setValue(preMouseSensitivity / Math.max(value() * 0.5, 1));
+            mc.options.getMouseSensitivity().setValue(preMouseSensitivity / Math.max(getScaling() * 0.5, 1));
         }
 
         if (time == 0) {
@@ -133,13 +133,13 @@ public class Zoom extends Module {
 
     @EventHandler
     private void onGetFov(GetFovEvent event) {
-        event.fov /= value();
+        event.fov /= getScaling();
 
         if (lastFov != event.fov) mc.worldRenderer.scheduleTerrainUpdate();
         lastFov = event.fov;
     }
 
-    private double value() {
+    public double getScaling() {
         double delta = time < 0.5 ? 4 * time * time * time : 1 - Math.pow(-2 * time + 2, 3) / 2; // Ease in out cubic
         return MathHelper.lerp(delta, 1, value);
     }

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/NametagUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/NametagUtils.java
@@ -6,6 +6,8 @@
 package meteordevelopment.meteorclient.utils.render;
 
 import com.mojang.blaze3d.systems.RenderSystem;
+import meteordevelopment.meteorclient.systems.modules.Modules;
+import meteordevelopment.meteorclient.systems.modules.render.Zoom;
 import meteordevelopment.meteorclient.utils.Utils;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.util.math.MatrixStack;
@@ -52,7 +54,8 @@ public class NametagUtils {
     }
 
     public static boolean to2D(Vector3d pos, double scale, boolean distanceScaling, boolean allowBehind) {
-        NametagUtils.scale = scale;
+        Zoom zoom = Modules.get().get(Zoom.class);
+        NametagUtils.scale = scale * zoom.getScaling();
         if (distanceScaling) {
             NametagUtils.scale *= getScale(pos);
         }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

When using the Zoom module before, Nametags stayed at the same size and were unreadable when looking at players in the distance without explicitly increasing Nametage scale. This also includes a renaming of the `Zoom::value` function to `getScaling` and exposes it as a public method.

## Related issues

None (maybe #1394)

# How Has This Been Tested?

Zoomed out:

![image](https://github.com/user-attachments/assets/9d7c0396-b39c-4947-9fe6-058cb07c2ff6)


Zoomed in:

![image](https://github.com/user-attachments/assets/2bc680b3-7eb1-4abf-bce9-60f6dabb5e07)


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
