### PR TITLE
Fix PotionSpoof flickering with night vision and add potion mode to Fullbright

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/PotionSpoof.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/PotionSpoof.java
@@ -50,6 +50,15 @@ public class PotionSpoof extends Module {
         .build()
     );
 
+    private final Setting<Integer> effectDuration = sgGeneral.add(new IntSetting.Builder()
+        .name("effect-duration")
+        .description("How many ticks to spoof the effect for.")
+        .range(1, 32767)
+        .sliderRange(20, 500)
+        .defaultValue(420)
+        .build()
+    );
+
     public PotionSpoof() {
         super(Categories.Player, "potion-spoof", "Spoofs potion statuses for you. SOME effects DO NOT work.");
     }
@@ -73,9 +82,9 @@ public class PotionSpoof extends Module {
             if (mc.player.hasStatusEffect(Registries.STATUS_EFFECT.getEntry(entry.getKey()))) {
                 StatusEffectInstance instance = mc.player.getStatusEffect(Registries.STATUS_EFFECT.getEntry(entry.getKey()));
                 ((StatusEffectInstanceAccessor) instance).setAmplifier(level - 1);
-                if (instance.getDuration() < 1000) ((StatusEffectInstanceAccessor) instance).setDuration(1000);
+                if (instance.getDuration() < effectDuration.get()) ((StatusEffectInstanceAccessor) instance).setDuration(effectDuration.get());
             } else {
-                mc.player.addStatusEffect(new StatusEffectInstance(Registries.STATUS_EFFECT.getEntry(entry.getKey()), 1000, level - 1));
+                mc.player.addStatusEffect(new StatusEffectInstance(Registries.STATUS_EFFECT.getEntry(entry.getKey()), effectDuration.get(), level - 1));
             }
         }
     }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/PotionSpoof.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/PotionSpoof.java
@@ -73,9 +73,9 @@ public class PotionSpoof extends Module {
             if (mc.player.hasStatusEffect(Registries.STATUS_EFFECT.getEntry(entry.getKey()))) {
                 StatusEffectInstance instance = mc.player.getStatusEffect(Registries.STATUS_EFFECT.getEntry(entry.getKey()));
                 ((StatusEffectInstanceAccessor) instance).setAmplifier(level - 1);
-                if (instance.getDuration() < 20) ((StatusEffectInstanceAccessor) instance).setDuration(20);
+                if (instance.getDuration() < 1000) ((StatusEffectInstanceAccessor) instance).setDuration(1000);
             } else {
-                mc.player.addStatusEffect(new StatusEffectInstance(Registries.STATUS_EFFECT.getEntry(entry.getKey()), 20, level - 1));
+                mc.player.addStatusEffect(new StatusEffectInstance(Registries.STATUS_EFFECT.getEntry(entry.getKey()), 1000, level - 1));
             }
         }
     }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Fullbright.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Fullbright.java
@@ -5,12 +5,18 @@
 
 package meteordevelopment.meteorclient.systems.modules.render;
 
+import meteordevelopment.meteorclient.events.world.TickEvent;
+import meteordevelopment.meteorclient.mixin.StatusEffectInstanceAccessor;
 import meteordevelopment.meteorclient.settings.EnumSetting;
 import meteordevelopment.meteorclient.settings.IntSetting;
 import meteordevelopment.meteorclient.settings.Setting;
 import meteordevelopment.meteorclient.settings.SettingGroup;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.orbit.EventHandler;
+import net.minecraft.entity.effect.StatusEffectInstance;
+import net.minecraft.entity.effect.StatusEffects;
+import net.minecraft.registry.Registries;
 import net.minecraft.world.LightType;
 
 public class Fullbright extends Module {
@@ -62,6 +68,9 @@ public class Fullbright extends Module {
     @Override
     public void onDeactivate() {
         if (mode.get() == Mode.Luminance) mc.worldRenderer.reload();
+        else if (mode.get() == Mode.Potion && mc.player.hasStatusEffect(Registries.STATUS_EFFECT.getEntry(StatusEffects.NIGHT_VISION.value()))) {
+            mc.player.removeStatusEffect(Registries.STATUS_EFFECT.getEntry(StatusEffects.NIGHT_VISION.value()));
+        }
     }
 
     public int getLuminance(LightType type) {
@@ -73,8 +82,20 @@ public class Fullbright extends Module {
         return isActive() && mode.get() == Mode.Gamma;
     }
 
+    @EventHandler
+    private void onTick(TickEvent.Post event) {
+        if (mc.player == null) return;
+        if (mc.player.hasStatusEffect(Registries.STATUS_EFFECT.getEntry(StatusEffects.NIGHT_VISION.value()))) {
+            StatusEffectInstance instance = mc.player.getStatusEffect(Registries.STATUS_EFFECT.getEntry(StatusEffects.NIGHT_VISION.value()));
+            if (instance != null && instance.getDuration() < 1000) ((StatusEffectInstanceAccessor) instance).setDuration(1000);
+        } else {
+            mc.player.addStatusEffect(new StatusEffectInstance(Registries.STATUS_EFFECT.getEntry(StatusEffects.NIGHT_VISION.value()), 1000, 0));
+        }
+    }
+
     public enum Mode {
         Gamma,
+        Potion,
         Luminance
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Fullbright.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Fullbright.java
@@ -27,7 +27,10 @@ public class Fullbright extends Module {
         .description("The mode to use for Fullbright.")
         .defaultValue(Mode.Gamma)
         .onChanged(mode -> {
-            if (mc.worldRenderer != null && isActive()) mc.worldRenderer.reload();
+            if (isActive()) {
+                if (mode != Mode.Potion) disableNightVision();
+                if (mc.worldRenderer != null) mc.worldRenderer.reload();
+            }
         })
         .build()
     );
@@ -68,9 +71,7 @@ public class Fullbright extends Module {
     @Override
     public void onDeactivate() {
         if (mode.get() == Mode.Luminance) mc.worldRenderer.reload();
-        else if (mode.get() == Mode.Potion && mc.player.hasStatusEffect(Registries.STATUS_EFFECT.getEntry(StatusEffects.NIGHT_VISION.value()))) {
-            mc.player.removeStatusEffect(Registries.STATUS_EFFECT.getEntry(StatusEffects.NIGHT_VISION.value()));
-        }
+        else if (mode.get() == Mode.Potion) disableNightVision();
     }
 
     public int getLuminance(LightType type) {
@@ -84,12 +85,19 @@ public class Fullbright extends Module {
 
     @EventHandler
     private void onTick(TickEvent.Post event) {
-        if (mc.player == null) return;
+        if (mc.player == null || !mode.get().equals(Mode.Potion)) return;
         if (mc.player.hasStatusEffect(Registries.STATUS_EFFECT.getEntry(StatusEffects.NIGHT_VISION.value()))) {
             StatusEffectInstance instance = mc.player.getStatusEffect(Registries.STATUS_EFFECT.getEntry(StatusEffects.NIGHT_VISION.value()));
-            if (instance != null && instance.getDuration() < 1000) ((StatusEffectInstanceAccessor) instance).setDuration(1000);
+            if (instance != null && instance.getDuration() < 420) ((StatusEffectInstanceAccessor) instance).setDuration(420);
         } else {
-            mc.player.addStatusEffect(new StatusEffectInstance(Registries.STATUS_EFFECT.getEntry(StatusEffects.NIGHT_VISION.value()), 1000, 0));
+            mc.player.addStatusEffect(new StatusEffectInstance(Registries.STATUS_EFFECT.getEntry(StatusEffects.NIGHT_VISION.value()), 420, 0));
+        }
+    }
+
+    private void disableNightVision() {
+        if (mc.player == null) return;
+        if (mc.player.hasStatusEffect(Registries.STATUS_EFFECT.getEntry(StatusEffects.NIGHT_VISION.value()))) {
+            mc.player.removeStatusEffect(Registries.STATUS_EFFECT.getEntry(StatusEffects.NIGHT_VISION.value()));
         }
     }
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [x] New feature

## Description

This pr fixes the annoying flicker that occurs when using PotionSpoof to spoof the night vision effect. This was happening because the duration of the effect was hardcoded to 20 ticks, which in night vision's case causes the effect to render dimly, and with a subtle yet annoying visual flicker. I remedied this by adding an effect duration setting which defaults to a higher duration, allowing PotionSpoof to spoof the night vision effect in all its glory.

Incidentally, it also makes the 'Clear Effects' setting actually have a practical use, since previously, even if you had it disabled, the effect would always expire in just 20 ticks (1 second) after disabling the module.

Additionally, I've added a potion mode to the Fullbright module which effectively does the same thing. My reasoning for this is mainly one of user-friendliness: it isn't nearly as intuitive to notice, configure, and use PotionSpoof as it is to just use Fullbright in potion mode when running shaderpacks that don't work well with the gamma or luminance modes, which is most of them.

# How Has This Been Tested?

[potion-fullbright.webm](https://github.com/user-attachments/assets/7303e647-f8b2-480f-83c9-7c6f6abb87f9)

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
