### PR TITLE
replace blockesp meteorexecutor thread pool usage with single worker thread

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/BlockESP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/BlockESP.java
@@ -7,6 +7,7 @@ package meteordevelopment.meteorclient.systems.modules.render.blockesp;
 
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
 import meteordevelopment.meteorclient.events.render.Render3DEvent;
 import meteordevelopment.meteorclient.events.world.BlockUpdateEvent;
 import meteordevelopment.meteorclient.events.world.ChunkDataEvent;
@@ -16,8 +17,6 @@ import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.utils.Utils;
-import meteordevelopment.meteorclient.utils.misc.UnorderedArrayList;
-import meteordevelopment.meteorclient.utils.network.MeteorExecutor;
 import meteordevelopment.meteorclient.utils.player.PlayerUtils;
 import meteordevelopment.meteorclient.utils.render.color.RainbowColors;
 import meteordevelopment.meteorclient.utils.render.color.SettingColor;
@@ -31,6 +30,9 @@ import net.minecraft.world.chunk.Chunk;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class BlockESP extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
@@ -78,7 +80,8 @@ public class BlockESP extends Module {
     private final BlockPos.Mutable blockPos = new BlockPos.Mutable();
 
     private final Long2ObjectMap<ESPChunk> chunks = new Long2ObjectOpenHashMap<>();
-    private final List<ESPGroup> groups = new UnorderedArrayList<>();
+    private final Set<ESPGroup> groups = new ReferenceOpenHashSet<>();
+    private final ExecutorService workerThread = Executors.newSingleThreadExecutor();
 
     private Dimension lastDimension;
 
@@ -157,7 +160,7 @@ public class BlockESP extends Module {
     }
 
     private void searchChunk(Chunk chunk) {
-        MeteorExecutor.execute(() -> {
+        workerThread.submit(() -> {
             if (!isActive()) return;
             ESPChunk schunk = ESPChunk.searchChunk(chunk, blocks.get());
 
@@ -191,7 +194,7 @@ public class BlockESP extends Module {
         boolean removed = !added && !blocks.get().contains(event.newState.getBlock()) && blocks.get().contains(event.oldState.getBlock());
 
         if (added || removed) {
-            MeteorExecutor.execute(() -> {
+            workerThread.submit(() -> {
                 synchronized (chunks) {
                     ESPChunk chunk = chunks.get(key);
 
@@ -238,7 +241,7 @@ public class BlockESP extends Module {
                 ESPChunk chunk = it.next();
 
                 if (chunk.shouldBeDeleted()) {
-                    MeteorExecutor.execute(() -> {
+                    workerThread.submit(() -> {
                         for (ESPBlock block : chunk.blocks.values()) {
                             block.group.remove(block, false);
                             block.loaded = false;
@@ -251,13 +254,15 @@ public class BlockESP extends Module {
             }
 
             if (tracers.get()) {
-                for (Iterator<ESPGroup> it = groups.iterator(); it.hasNext();) {
-                    ESPGroup group = it.next();
-
-                    if (group.blocks.isEmpty()) it.remove();
-                    else group.render(event);
+                for (ESPGroup group : groups) {
+                    group.render(event);
                 }
             }
         }
+    }
+
+    @Override
+    public String getInfoString() {
+        return "%s groups".formatted(groups.size());
     }
 }


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

removes lag spike when enabling block esp

## Related issues

probably some of them

# How Has This Been Tested?

yerp

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
