### PR TITLE
Fix AutoLog toggle off setting

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/AutoLog.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/AutoLog.java
@@ -142,13 +142,14 @@ public class AutoLog extends Module {
             if (smartToggle.get()) {
                 if (isActive()) this.toggle();
                 enableHealthListener();
-                return;
-            }
+            } else if (toggleOff.get()) this.toggle();
+            return;
         }
 
         if (smart.get() && playerHealth + mc.player.getAbsorptionAmount() - PlayerUtils.possibleHealthReductions() < health.get()) {
             disconnect("Health was going to be lower than " + health.get() + ".");
             if (toggleOff.get()) this.toggle();
+            return;
         }
 
         if (!onlyTrusted.get() && !instantDeath.get() && entities.get().isEmpty())


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

The toggle off setting in AutoLog isn't being considered when performing a basic health-based disconnect. There is a branch for the smart toggle setting there, but nothing for the regular toggle off. I fixed this by adding it.

# How Has This Been Tested?

On a local Paper server.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
