### PR TITLE
Update WireframeEntityRenderer.java Memory Leak Fix

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/utils/render/WireframeEntityRenderer.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/WireframeEntityRenderer.java
@@ -64,7 +64,7 @@ public class WireframeEntityRenderer {
         matrices.push();
         matrices.scale((float) scale, (float) scale, (float) scale);
         renderer.render(state, matrices, MyVertexConsumerProvider.INSTANCE, 15);
-        matrices.push();
+        matrices.pop();
     }
 
     private static class MyVertexConsumerProvider implements VertexConsumerProvider {


### PR DESCRIPTION
Possible fixes for the 1.21.3 Memory leak caused by ESP

## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Change the second `matrices.push();` line to `matrices.pop();`

## Related issues

Memory leak on 1.21.3 while using ESP: https://github.com/MeteorDevelopment/meteor-client/issues/5033

# How Has This Been Tested?

Played for 3 Hours straight and reached a max of 1GB Memory used compared to it previously reaching 8 out of 8GB used
![image](https://github.com/user-attachments/assets/68d7eedd-439b-48c6-9c8b-9dbd8ed309e3)

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
