### PR TITLE
Use set values for text in AutoSign

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoSign.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoSign.java
@@ -6,8 +6,8 @@
 package meteordevelopment.meteorclient.systems.modules.world;
 
 import meteordevelopment.meteorclient.events.game.OpenScreenEvent;
-import meteordevelopment.meteorclient.events.packets.PacketEvent;
 import meteordevelopment.meteorclient.mixin.AbstractSignEditScreenAccessor;
+import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.orbit.EventHandler;
@@ -16,31 +16,54 @@ import net.minecraft.client.gui.screen.ingame.AbstractSignEditScreen;
 import net.minecraft.network.packet.c2s.play.UpdateSignC2SPacket;
 
 public class AutoSign extends Module {
-    private String[] text;
+    private final SettingGroup sgGeneral = settings.getDefaultGroup();
+
+    private final Setting<String> line1 = sgGeneral.add(new StringSetting.Builder()
+        .name("Line 1")
+        .description("Line 1")
+        .defaultValue("Meteor")
+        .build()
+    );
+
+    private final Setting<String> line2 = sgGeneral.add(new StringSetting.Builder()
+        .name("Line 2")
+        .description("Line 2")
+        .defaultValue("Client")
+        .build()
+    );
+
+    private final Setting<String> line3 = sgGeneral.add(new StringSetting.Builder()
+        .name("Line 3")
+        .description("Line 3")
+        .defaultValue("on")
+        .build()
+    );
+
+    private final Setting<String> line4 = sgGeneral.add(new StringSetting.Builder()
+        .name("Line 4")
+        .description("Line 4")
+        .defaultValue("Crack!")
+        .build()
+    );
+
+    private final Setting<Boolean> front = sgGeneral.add(new BoolSetting.Builder()
+        .name("Front")
+        .description("Place text on front or back of sign")
+        .defaultValue(true)
+        .build()
+    );
 
     public AutoSign() {
-        super(Categories.World, "auto-sign", "Automatically writes signs. The first sign's text will be used.");
-    }
-
-    @Override
-    public void onDeactivate() {
-        text = null;
-    }
-
-    @EventHandler
-    private void onSendPacket(PacketEvent.Send event) {
-        if (!(event.packet instanceof UpdateSignC2SPacket)) return;
-
-        text = ((UpdateSignC2SPacket) event.packet).getText();
+        super(Categories.World, "auto-sign", "Automatically writes signs.");
     }
 
     @EventHandler
     private void onOpenScreen(OpenScreenEvent event) {
-        if (!(event.screen instanceof AbstractSignEditScreen) || text == null) return;
+        if (!(event.screen instanceof AbstractSignEditScreen)) return;
 
         SignBlockEntity sign = ((AbstractSignEditScreenAccessor) event.screen).getSign();
 
-        mc.player.networkHandler.sendPacket(new UpdateSignC2SPacket(sign.getPos(), true, text[0], text[1], text[2], text[3]));
+        mc.player.networkHandler.sendPacket(new UpdateSignC2SPacket(sign.getPos(), front.get(), line1.get(), line2.get(), line3.get(), line4.get()));
 
         event.cancel();
     }


### PR DESCRIPTION
Changes AutoSign to use predefined values instead of text from the first placed sign, and add an option to place on the back of the sign instead of the front

## Type of change

- [ ] Bug fix
- [ ] New feature

## Description

Yes I actually tested it this time :tf:

## Related issues

There are no issues for this

# How Has This Been Tested?

Videos or screenshots of the changes if applicable.

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [ ] I have tested the code in both development and production environments.
