### PR TITLE
allow prompt subclassing

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/utils/render/prompts/OkPrompt.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/prompts/OkPrompt.java
@@ -8,7 +8,6 @@ package meteordevelopment.meteorclient.utils.render.prompts;
 import meteordevelopment.meteorclient.gui.GuiTheme;
 import meteordevelopment.meteorclient.gui.GuiThemes;
 import meteordevelopment.meteorclient.gui.widgets.pressable.WButton;
-import meteordevelopment.meteorclient.systems.config.Config;
 import net.minecraft.client.gui.screen.Screen;
 
 import static meteordevelopment.meteorclient.MeteorClient.mc;
@@ -37,7 +36,7 @@ public class OkPrompt extends Prompt<OkPrompt> {
     protected void initialiseWidgets(PromptScreen screen) {
         WButton okButton = screen.list.add(theme.button("Ok")).expandX().widget();
         okButton.action = () -> {
-            if (screen.dontShowAgainCheckbox != null && screen.dontShowAgainCheckbox.checked) Config.get().dontShowAgainPrompts.add(id);
+            dontShowAgain(screen);
             onOk.run();
             screen.close();
         };

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/prompts/Prompt.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/prompts/Prompt.java
@@ -15,13 +15,13 @@ import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 @SuppressWarnings("unchecked") // cant instantiate a Prompt directly so this is fine
 public abstract class Prompt<T> {
-    final GuiTheme theme;
-    final Screen parent;
+    protected final GuiTheme theme;
+    protected final Screen parent;
 
-    String title = "";
-    final List<String> messages = new ArrayList<>();
-    boolean dontShowAgainCheckboxVisible = true;
-    String id = null;
+    protected String title = "";
+    protected final List<String> messages = new ArrayList<>();
+    protected boolean dontShowAgainCheckboxVisible = true;
+    protected String id = null;
 
     protected Prompt(GuiTheme theme, Screen parent) {
         this.theme = theme;
@@ -54,8 +54,7 @@ public abstract class Prompt<T> {
     }
 
     public boolean show() {
-        if (id == null) this.id(this.title);
-        if (Config.get().dontShowAgainPrompts.contains(id)) return false;
+        if (id != null && Config.get().dontShowAgainPrompts.contains(id)) return false;
 
         if (!RenderSystem.isOnRenderThread()) {
             RenderSystem.recordRenderCall(() -> mc.setScreen(new PromptScreen(theme)));
@@ -67,11 +66,11 @@ public abstract class Prompt<T> {
         return true;
     }
 
-    abstract void initialiseWidgets(PromptScreen screen);
+    protected abstract void initialiseWidgets(PromptScreen screen);
 
     protected class PromptScreen extends WindowScreen {
-        WCheckbox dontShowAgainCheckbox;
-        WHorizontalList list;
+        protected WCheckbox dontShowAgainCheckbox;
+        protected WHorizontalList list;
 
         public PromptScreen(GuiTheme theme) {
             super(theme, Prompt.this.title);

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/prompts/Prompt.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/prompts/Prompt.java
@@ -66,6 +66,12 @@ public abstract class Prompt<T> {
         return true;
     }
 
+    protected void dontShowAgain(PromptScreen screen) {
+        if (screen.dontShowAgainCheckbox != null && screen.dontShowAgainCheckbox.checked && id != null) {
+            Config.get().dontShowAgainPrompts.add(id);
+        }
+    }
+
     protected abstract void initialiseWidgets(PromptScreen screen);
 
     protected class PromptScreen extends WindowScreen {

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/prompts/YesNoPrompt.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/prompts/YesNoPrompt.java
@@ -8,7 +8,6 @@ package meteordevelopment.meteorclient.utils.render.prompts;
 import meteordevelopment.meteorclient.gui.GuiTheme;
 import meteordevelopment.meteorclient.gui.GuiThemes;
 import meteordevelopment.meteorclient.gui.widgets.pressable.WButton;
-import meteordevelopment.meteorclient.systems.config.Config;
 import net.minecraft.client.gui.screen.Screen;
 
 import static meteordevelopment.meteorclient.MeteorClient.mc;
@@ -43,14 +42,14 @@ public class YesNoPrompt extends Prompt<YesNoPrompt> {
     protected void initialiseWidgets(PromptScreen screen) {
         WButton yesButton = screen.list.add(theme.button("Yes")).expandX().widget();
         yesButton.action = () -> {
-            if (screen.dontShowAgainCheckbox != null && screen.dontShowAgainCheckbox.checked) Config.get().dontShowAgainPrompts.add(id);
+            dontShowAgain(screen);
             onYes.run();
             screen.close();
         };
 
         WButton noButton = screen.list.add(theme.button("No")).expandX().widget();
         noButton.action = () -> {
-            if (screen.dontShowAgainCheckbox != null && screen.dontShowAgainCheckbox.checked) Config.get().dontShowAgainPrompts.add(id);
+            dontShowAgain(screen);
             onNo.run();
             screen.close();
         };


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature

## Description

Allow subclassing `Prompt` class and creating prompts without ids

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
