### PR TITLE
Added option to only show activated spawners (Spawner-Based Stash Detection)

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/MobSpawnerLogicAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MobSpawnerLogicAccessor.java
@@ -1,0 +1,16 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.mixin;
+
+import net.minecraft.block.spawner.MobSpawnerLogic;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(MobSpawnerLogic.class)
+public interface MobSpawnerLogicAccessor {
+    @Accessor("spawnDelay")
+    int meteor$getSpawnDelay();
+}

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/BlockESP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/BlockESP.java
@@ -77,6 +77,14 @@ public class BlockESP extends Module {
         .build()
     );
 
+    private final Setting<Boolean> onlyActivatedSpawners = sgGeneral.add(new BoolSetting.Builder()
+        .name("only-activated-spawners")
+        .description("Only show activated spawners.")
+        .defaultValue(false)
+        .visible(() -> blocks.get().stream().anyMatch(block -> block.getTranslationKey().equals("block.minecraft.spawner")))
+        .build()
+    );
+
     private final BlockPos.Mutable blockPos = new BlockPos.Mutable();
 
     private final Long2ObjectMap<ESPChunk> chunks = new Long2ObjectOpenHashMap<>();
@@ -264,5 +272,9 @@ public class BlockESP extends Module {
     @Override
     public String getInfoString() {
         return "%s groups".formatted(groups.size());
+    }
+
+    public boolean isOnlyActivatedSpawners() {
+        return onlyActivatedSpawners.get();
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPBlock.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPBlock.java
@@ -281,6 +281,9 @@ public class ESPBlock {
         }
     }
 
+    public BlockState getState() {
+        return state;
+    }
 
     public static long getKey(int x, int y, int z) {
         return ((long) y << 16) | ((long) (z & 15) << 8) | ((long) (x & 15));

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPGroup.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPGroup.java
@@ -7,14 +7,21 @@ package meteordevelopment.meteorclient.systems.modules.render.blockesp;
 
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import meteordevelopment.meteorclient.events.render.Render3DEvent;
+import meteordevelopment.meteorclient.mixin.MobSpawnerLogicAccessor;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.utils.misc.UnorderedArrayList;
 import meteordevelopment.meteorclient.utils.render.RenderUtils;
 import net.minecraft.block.Block;
+import net.minecraft.block.SpawnerBlock;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.block.entity.MobSpawnerBlockEntity;
+import net.minecraft.util.math.BlockPos;
 
 import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.Set;
+
+import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class ESPGroup {
     private static final BlockESP blockEsp = Modules.get().get(BlockESP.class);
@@ -142,7 +149,20 @@ public class ESPGroup {
         ESPBlockData blockData = blockEsp.getBlockData(block);
 
         if (blockData.tracer) {
-            event.renderer.line(RenderUtils.center.x, RenderUtils.center.y, RenderUtils.center.z, sumX / blocks.size() + 0.5, sumY / blocks.size() + 0.5, sumZ / blocks.size() + 0.5, blockData.tracerColor);
+            int x = (int) (sumX / blocks.size());
+            int y = (int) (sumY / blocks.size());
+            int z = (int) (sumZ / blocks.size());
+            if (mc.world != null && block instanceof SpawnerBlock && blockEsp.isOnlyActivatedSpawners()) {
+                BlockEntity blockEntity = mc.world.getBlockEntity(new BlockPos(x, y, z));
+                if (blockEntity instanceof MobSpawnerBlockEntity spawner) {
+                    MobSpawnerLogicAccessor logic = (MobSpawnerLogicAccessor) spawner.getLogic();
+                    if (logic.meteor$getSpawnDelay() != 20) {
+                        event.renderer.line(RenderUtils.center.x, RenderUtils.center.y, RenderUtils.center.z, sumX / blocks.size() + 0.5, sumY / blocks.size() + 0.5, sumZ / blocks.size() + 0.5, blockData.tracerColor);
+                    }
+                }
+            } else {
+                event.renderer.line(RenderUtils.center.x, RenderUtils.center.y, RenderUtils.center.z, sumX / blocks.size() + 0.5, sumY / blocks.size() + 0.5, sumZ / blocks.size() + 0.5, blockData.tracerColor);
+            }
         }
     }
 }

--- a/src/main/resources/meteor-client.mixins.json
+++ b/src/main/resources/meteor-client.mixins.json
@@ -190,7 +190,8 @@
     "WorldChunkMixin",
     "WorldRendererAccessor",
     "WorldRendererMixin",
-    "YggdrasilMinecraftSessionServiceAccessor"
+    "YggdrasilMinecraftSessionServiceAccessor",
+    "MobSpawnerLogicAccessor"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

This feature leverages a recently discovered exploit to enhance stash searching capabilities on anarchy servers like 2b2t. Inspired by [FitMC’s video](https://www.youtube.com/watch?v=Ak8ph0SYbmM), the method addresses a common practice where players hide stashes in naturally generated chests, such as those found near spawners. These stashes typically remain undetected since they do not alter the surrounding terrain.

A week ago, a player named ETIANL revealed a technique to identify player activity near spawners by analyzing the spawner's **spawn delay**. If the delay has been reset or altered, it indicates that player was nearby. This discovery significantly improves stash detection by pinpointing spawners that might have been triggered by players hiding their loot.

This new setting in BlockESP implements this technique, allowing players to identify and locate activated spawners as potential stash locations.

*NOTE: In theory, this method does not detect all activated spawners. A player could leave the spawner radius at the exact tick the spawn delay reaches its default value (20), making it undetectable in such cases. Additionally, spawners in the Nether can sometimes have their spawn delay set to 0 instead of 20, leading to potential false positives.*

## Related issues

None.

# How Has This Been Tested?

Tested the new feature in the development environment to ensure that the added setting works and only activated spawners are rendered. No issues were found during testing.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.