### PR TITLE
Fix auto clicker not working while windows are open

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/MinecraftClientAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MinecraftClientAccessor.java
@@ -41,6 +41,12 @@ public interface MinecraftClientAccessor {
     @Accessor("resourceReloadLogger")
     ResourceReloadLogger getResourceReloadLogger();
 
+    @Accessor("attackCooldown")
+    int getAttackCooldown();
+
+    @Accessor("attackCooldown")
+    void setAttackCooldown(int attackCooldown);
+
     @Invoker("doAttack")
     boolean leftClick();
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoClicker.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoClicker.java
@@ -6,10 +6,7 @@
 package meteordevelopment.meteorclient.systems.modules.player;
 
 import meteordevelopment.meteorclient.events.world.TickEvent;
-import meteordevelopment.meteorclient.settings.EnumSetting;
-import meteordevelopment.meteorclient.settings.IntSetting;
-import meteordevelopment.meteorclient.settings.Setting;
-import meteordevelopment.meteorclient.settings.SettingGroup;
+import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.utils.Utils;
@@ -17,6 +14,13 @@ import meteordevelopment.orbit.EventHandler;
 
 public class AutoClicker extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
+
+    private final Setting<Boolean> inScreens = sgGeneral.add(new BoolSetting.Builder()
+        .name("while-in-screens")
+        .description("Whether to click while a screen is open.")
+        .defaultValue(true)
+        .build()
+    );
 
     private final Setting<Mode> leftClickMode = sgGeneral.add(new EnumSetting.Builder<Mode>()
         .name("mode-left")
@@ -74,6 +78,8 @@ public class AutoClicker extends Module {
 
     @EventHandler
     private void onTick(TickEvent.Post event) {
+        if (!inScreens.get() && mc.currentScreen != null) return;
+
         switch (leftClickMode.get()) {
             case Disabled -> {}
             case Hold -> mc.options.attackKey.setPressed(true);
@@ -85,6 +91,7 @@ public class AutoClicker extends Module {
                 }
             }
         }
+
         switch (rightClickMode.get()) {
             case Disabled -> {}
             case Hold -> mc.options.useKey.setPressed(true);

--- a/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
@@ -515,6 +515,8 @@ public class Utils {
 
     public static void leftClick() {
         // check if a screen is open
+        // see net.minecraft.client.Mouse.lockCursor
+        // see net.minecraft.client.MinecraftClient.tick
         int attackCooldown = ((MinecraftClientAccessor) mc).getAttackCooldown();
         if (attackCooldown == 10000) {
             ((MinecraftClientAccessor) mc).setAttackCooldown(0);

--- a/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
@@ -514,7 +514,7 @@ public class Utils {
     }
 
     public static void leftClick() {
-        // check if screens are open
+        // check if a screen is open
         int attackCooldown = ((MinecraftClientAccessor) mc).getAttackCooldown();
         if (attackCooldown == 10000) {
             ((MinecraftClientAccessor) mc).setAttackCooldown(0);

--- a/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
@@ -252,7 +252,8 @@ public class Utils {
             for (int i = 0; i < stacks.size(); i++) {
                 if (i >= 0 && i < items.length) items[i] = stacks.get(i);
             }
-        } else if (components.contains(DataComponentTypes.BLOCK_ENTITY_DATA)) {
+        }
+        else if (components.contains(DataComponentTypes.BLOCK_ENTITY_DATA)) {
             NbtComponent nbt2 = components.get(DataComponentTypes.BLOCK_ENTITY_DATA);
 
             if (nbt2.contains("Items")) {
@@ -261,8 +262,7 @@ public class Utils {
                 for (int i = 0; i < nbt3.size(); i++) {
                     int slot = nbt3.getCompound(i).getByte("Slot"); // Apparently shulker boxes can store more than 27 items, good job Mojang
                     // now NPEs when mc.world == null
-                    if (slot >= 0 && slot < items.length)
-                        items[slot] = ItemStack.fromNbtOrEmpty(mc.player.getRegistryManager(), nbt3.getCompound(i));
+                    if (slot >= 0 && slot < items.length) items[slot] = ItemStack.fromNbtOrEmpty(mc.player.getRegistryManager(), nbt3.getCompound(i));
                 }
             }
         }

--- a/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
@@ -252,8 +252,7 @@ public class Utils {
             for (int i = 0; i < stacks.size(); i++) {
                 if (i >= 0 && i < items.length) items[i] = stacks.get(i);
             }
-        }
-        else if (components.contains(DataComponentTypes.BLOCK_ENTITY_DATA)) {
+        } else if (components.contains(DataComponentTypes.BLOCK_ENTITY_DATA)) {
             NbtComponent nbt2 = components.get(DataComponentTypes.BLOCK_ENTITY_DATA);
 
             if (nbt2.contains("Items")) {
@@ -262,7 +261,8 @@ public class Utils {
                 for (int i = 0; i < nbt3.size(); i++) {
                     int slot = nbt3.getCompound(i).getByte("Slot"); // Apparently shulker boxes can store more than 27 items, good job Mojang
                     // now NPEs when mc.world == null
-                    if (slot >= 0 && slot < items.length) items[slot] = ItemStack.fromNbtOrEmpty(mc.player.getRegistryManager(), nbt3.getCompound(i));
+                    if (slot >= 0 && slot < items.length)
+                        items[slot] = ItemStack.fromNbtOrEmpty(mc.player.getRegistryManager(), nbt3.getCompound(i));
                 }
             }
         }
@@ -514,6 +514,12 @@ public class Utils {
     }
 
     public static void leftClick() {
+        // check if screens are open
+        int attackCooldown = ((MinecraftClientAccessor) mc).getAttackCooldown();
+        if (attackCooldown == 10000) {
+            ((MinecraftClientAccessor) mc).setAttackCooldown(0);
+        }
+
         mc.options.attackKey.setPressed(true);
         ((MinecraftClientAccessor) mc).leftClick();
         mc.options.attackKey.setPressed(false);


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

I fixed auto clicker not working while a screen (chat, containers, etc...) is open

## Related issues

[Auto Clicker stops when switching windows](https://github.com/MeteorDevelopment/meteor-client/issues/4855)

# How Has This Been Tested?

https://github.com/user-attachments/assets/aefa084a-db49-4250-b7a8-b7c671333474

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
