### PR TITLE
Added setting to disable the buttons related to Auto Reconnect

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/DisconnectedScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/DisconnectedScreenMixin.java
@@ -42,7 +42,7 @@ public abstract class DisconnectedScreenMixin extends Screen {
 
         if (autoReconnect.lastServerConnection != null) {
             reconnectBtn = new ButtonWidget.Builder(Text.literal(getText()), button -> tryConnecting()).build();
-            if (Modules.get().get(AutoReconnect.class).button.get()) {
+            if (!Modules.get().get(AutoReconnect.class).button.get()) {
                 grid.add(reconnectBtn);
             }
             reconnectBtn = new ButtonWidget.Builder(Text.literal("Toggle Auto Reconnect"), button -> {
@@ -50,7 +50,7 @@ public abstract class DisconnectedScreenMixin extends Screen {
                     reconnectBtn.setMessage(Text.literal(getText()));
                     time = autoReconnect.time.get() * 20;
                 }).build();
-            if (Modules.get().get(AutoReconnect.class).button.get()) {
+            if (!Modules.get().get(AutoReconnect.class).button.get()) {
                 grid.add(reconnectBtn);
             }
         }

--- a/src/main/java/meteordevelopment/meteorclient/mixin/DisconnectedScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/DisconnectedScreenMixin.java
@@ -42,15 +42,17 @@ public abstract class DisconnectedScreenMixin extends Screen {
 
         if (autoReconnect.lastServerConnection != null) {
             reconnectBtn = new ButtonWidget.Builder(Text.literal(getText()), button -> tryConnecting()).build();
-            grid.add(reconnectBtn);
-
-            grid.add(
-                new ButtonWidget.Builder(Text.literal("Toggle Auto Reconnect"), button -> {
+            if (Modules.get().get(AutoReconnect.class).button.get()) {
+                grid.add(reconnectBtn);
+            }
+            reconnectBtn = new ButtonWidget.Builder(Text.literal("Toggle Auto Reconnect"), button -> {
                     autoReconnect.toggle();
                     reconnectBtn.setMessage(Text.literal(getText()));
                     time = autoReconnect.time.get() * 20;
-                }).build()
-            );
+                }).build();
+            if (Modules.get().get(AutoReconnect.class).button.get()) {
+                grid.add(reconnectBtn);
+            }
         }
     }
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/DisconnectedScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/DisconnectedScreenMixin.java
@@ -7,10 +7,10 @@ package meteordevelopment.meteorclient.mixin;
 
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.misc.AutoReconnect;
-import net.minecraft.client.gui.screen.multiplayer.ConnectScreen;
 import net.minecraft.client.gui.screen.DisconnectedScreen;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.TitleScreen;
+import net.minecraft.client.gui.screen.multiplayer.ConnectScreen;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.gui.widget.DirectionalLayoutWidget;
 import net.minecraft.text.Text;
@@ -40,19 +40,17 @@ public abstract class DisconnectedScreenMixin extends Screen {
     private void addButtons(CallbackInfo ci) {
         AutoReconnect autoReconnect = Modules.get().get(AutoReconnect.class);
 
-        if (autoReconnect.lastServerConnection != null) {
+        if (autoReconnect.lastServerConnection != null && !autoReconnect.button.get()) {
             reconnectBtn = new ButtonWidget.Builder(Text.literal(getText()), button -> tryConnecting()).build();
-            if (!Modules.get().get(AutoReconnect.class).button.get()) {
-                grid.add(reconnectBtn);
-            }
-            reconnectBtn = new ButtonWidget.Builder(Text.literal("Toggle Auto Reconnect"), button -> {
+            grid.add(reconnectBtn);
+
+            grid.add(
+                new ButtonWidget.Builder(Text.literal("Toggle Auto Reconnect"), button -> {
                     autoReconnect.toggle();
                     reconnectBtn.setMessage(Text.literal(getText()));
                     time = autoReconnect.time.get() * 20;
-                }).build();
-            if (!Modules.get().get(AutoReconnect.class).button.get()) {
-                grid.add(reconnectBtn);
-            }
+                }).build()
+            );
         }
     }
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/AutoReconnect.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/AutoReconnect.java
@@ -9,8 +9,8 @@ import it.unimi.dsi.fastutil.Pair;
 import it.unimi.dsi.fastutil.objects.ObjectObjectImmutablePair;
 import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.events.world.ServerConnectBeginEvent;
-import meteordevelopment.meteorclient.settings.DoubleSetting;
 import meteordevelopment.meteorclient.settings.BoolSetting;
+import meteordevelopment.meteorclient.settings.DoubleSetting;
 import meteordevelopment.meteorclient.settings.Setting;
 import meteordevelopment.meteorclient.settings.SettingGroup;
 import meteordevelopment.meteorclient.systems.modules.Categories;
@@ -32,7 +32,7 @@ public class AutoReconnect extends Module {
     );
 
     public final Setting<Boolean> button = sgGeneral.add(new BoolSetting.Builder()
-        .name("hide-button")
+        .name("hide-buttons")
         .description("Will hide the buttons related to Auto Reconnect.")
         .defaultValue(false)
         .build()

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/AutoReconnect.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/AutoReconnect.java
@@ -30,6 +30,13 @@ public class AutoReconnect extends Module {
         .build()
     );
 
+    public final Setting<Boolean> button = sgGeneral.add(new BoolSetting.Builder()
+        .name("hide-button")
+        .description("Will hide the buttons related to Auto Reconnect.")
+        .defaultValue(false)
+        .build()
+    );
+
     public Pair<ServerAddress, ServerInfo> lastServerConnection;
 
     public AutoReconnect() {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/AutoReconnect.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/AutoReconnect.java
@@ -10,6 +10,7 @@ import it.unimi.dsi.fastutil.objects.ObjectObjectImmutablePair;
 import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.events.world.ServerConnectBeginEvent;
 import meteordevelopment.meteorclient.settings.DoubleSetting;
+import meteordevelopment.meteorclient.settings.BoolSetting;
 import meteordevelopment.meteorclient.settings.Setting;
 import meteordevelopment.meteorclient.settings.SettingGroup;
 import meteordevelopment.meteorclient.systems.modules.Categories;


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Allows the user to toggle the buttons. Usefull when using meteor in combination with other clients to prevent the same buttons multiple times.


# How Has This Been Tested?

Tested it out, worked fine.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
