### PR TITLE
Refactor Sprint

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayerEntityMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayerEntityMixin.java
@@ -113,7 +113,9 @@ public abstract class ClientPlayerEntityMixin extends AbstractClientPlayerEntity
 
     @WrapWithCondition(method = "tickMovement", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerEntity;setSprinting(Z)V", ordinal = 3))
     private boolean wrapSetSprinting(ClientPlayerEntity instance, boolean b) {
-        return !Modules.get().get(Sprint.class).rageSprint();
+        Sprint s = Modules.get().get(Sprint.class);
+
+        return !s.rageSprint() || s.unsprintInWater() && isTouchingWater();
     }
 
     // Rotations

--- a/src/main/java/meteordevelopment/meteorclient/mixin/LivingEntityMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/LivingEntityMixin.java
@@ -124,7 +124,7 @@ public abstract class LivingEntityMixin extends Entity {
         if ((Object) this != mc.player) return original;
 
         Sprint s = Modules.get().get(Sprint.class);
-        if (!s.rageSprint() || !s.jumpFix.get()) return original;
+        if (!s.rageSprint()) return original;
 
         float forward = Math.signum(mc.player.input.movementForward);
         float strafe = 90 * Math.signum(mc.player.input.movementSideways);

--- a/src/main/java/meteordevelopment/meteorclient/mixin/LivingEntityMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/LivingEntityMixin.java
@@ -69,15 +69,19 @@ public abstract class LivingEntityMixin extends Entity {
 
     @Inject(method = "onEquipStack", at = @At("HEAD"), cancellable = true)
     private void onEquipStack(EquipmentSlot slot, ItemStack oldStack, ItemStack newStack, CallbackInfo info) {
-        if ((Object) this == mc.player && Modules.get().get(OffhandCrash.class).isAntiCrash()) {
+        if ((Object) this != mc.player) return;
+
+        if (Modules.get().get(OffhandCrash.class).isAntiCrash()) {
             info.cancel();
         }
     }
 
     @ModifyArg(method = "swingHand(Lnet/minecraft/util/Hand;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/LivingEntity;swingHand(Lnet/minecraft/util/Hand;Z)V"))
     private Hand setHand(Hand hand) {
+        if ((Object) this != mc.player) return hand;
+
         HandView handView = Modules.get().get(HandView.class);
-        if ((Object) this == mc.player && handView.isActive()) {
+        if (handView.isActive()) {
             if (handView.swingMode.get() == HandView.SwingMode.None) return hand;
             return handView.swingMode.get() == HandView.SwingMode.Offhand ? Hand.OFF_HAND : Hand.MAIN_HAND;
         }
@@ -87,12 +91,15 @@ public abstract class LivingEntityMixin extends Entity {
     @ModifyConstant(method = "getHandSwingDuration", constant = @Constant(intValue = 6))
     private int getHandSwingDuration(int constant) {
         if ((Object) this != mc.player) return constant;
+
         return Modules.get().get(HandView.class).isActive() && mc.options.getPerspective().isFirstPerson() ? Modules.get().get(HandView.class).swingSpeed.get() : constant;
     }
 
     @ModifyReturnValue(method = "isGliding", at = @At("RETURN"))
     private boolean isGlidingHook(boolean original) {
-        if ((Object) this == mc.player && Modules.get().get(ElytraFly.class).canPacketEfly()) {
+        if ((Object) this != mc.player) return original;
+
+        if (Modules.get().get(ElytraFly.class).canPacketEfly()) {
             return true;
         }
 
@@ -122,9 +129,7 @@ public abstract class LivingEntityMixin extends Entity {
     @ModifyExpressionValue(method = "jump", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/LivingEntity;getYaw()F"))
     private float modifyGetYaw(float original) {
         if ((Object) this != mc.player) return original;
-
-        Sprint s = Modules.get().get(Sprint.class);
-        if (!s.rageSprint()) return original;
+        if (!Modules.get().get(Sprint.class).rageSprint()) return original;
 
         float forward = Math.signum(mc.player.input.movementForward);
         float strafe = 90 * Math.signum(mc.player.input.movementSideways);
@@ -138,7 +143,8 @@ public abstract class LivingEntityMixin extends Entity {
 
     @ModifyExpressionValue(method = "jump", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/LivingEntity;isSprinting()Z"))
     private boolean modifyIsSprinting(boolean original) {
-        if ((Object) this != mc.player || !Modules.get().get(Sprint.class).rageSprint()) return original;
+        if ((Object) this != mc.player) return original;
+        if (!Modules.get().get(Sprint.class).rageSprint()) return original;
 
         // only add the extra velocity if you're actually moving, otherwise you'll jump in place and move forward
         return original && (Math.abs(mc.player.input.movementForward) > 1.0E-5F || Math.abs(mc.player.input.movementSideways) > 1.0E-5F);

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Sprint.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Sprint.java
@@ -81,21 +81,28 @@ public class Sprint extends Module {
 
     @EventHandler(priority = EventPriority.HIGH)
     private void onPacketSend(PacketEvent.Send event) {
-        if (!unsprintOnHit.get() || !(event.packet instanceof IPlayerInteractEntityC2SPacket packet) || packet.meteor$getType() != PlayerInteractEntityC2SPacket.InteractType.ATTACK) return;
+        if (!unsprintOnHit.get()) return;
+        if (!(event.packet instanceof IPlayerInteractEntityC2SPacket packet)
+            || packet.meteor$getType() != PlayerInteractEntityC2SPacket.InteractType.ATTACK) return;
 
-        mc.getNetworkHandler().sendPacket(new ClientCommandC2SPacket(mc.player, ClientCommandC2SPacket.Mode.STOP_SPRINTING));
+        mc.getNetworkHandler().sendPacket(new ClientCommandC2SPacket(
+            mc.player, ClientCommandC2SPacket.Mode.STOP_SPRINTING
+        ));
         mc.player.setSprinting(false);
     }
 
     @EventHandler
     private void onPacketSent(PacketEvent.Sent event) {
         if (!unsprintOnHit.get() || !keepSprint.get()) return;
-        if (!(event.packet instanceof IPlayerInteractEntityC2SPacket packet) || packet.meteor$getType() != PlayerInteractEntityC2SPacket.InteractType.ATTACK) return;
+        if (!(event.packet instanceof IPlayerInteractEntityC2SPacket packet)
+            || packet.meteor$getType() != PlayerInteractEntityC2SPacket.InteractType.ATTACK) return;
 
-        if (shouldSprint() && !mc.player.isSprinting()) {
-            mc.getNetworkHandler().sendPacket(new ClientCommandC2SPacket(mc.player, ClientCommandC2SPacket.Mode.START_SPRINTING));
-            mc.player.setSprinting(true);
-        }
+        if (!shouldSprint() || mc.player.isSprinting()) return;
+
+        mc.getNetworkHandler().sendPacket(new ClientCommandC2SPacket(
+            mc.player, ClientCommandC2SPacket.Mode.START_SPRINTING
+        ));
+        mc.player.setSprinting(true);
     }
 
     public boolean shouldSprint() {
@@ -106,7 +113,9 @@ public class Sprint extends Module {
             && (!mc.player.horizontalCollision || mc.player.collidedSoftly)
             && !(mc.player.isTouchingWater() && !mc.player.isSubmergedInWater());
 
-        return isActive() && (mode.get() == Mode.Rage || strictSprint) && (mc.currentScreen == null || Modules.get().get(GUIMove.class).sprint.get());
+        return isActive()
+            && (mode.get() == Mode.Rage || strictSprint)
+            && (mc.currentScreen == null || Modules.get().get(GUIMove.class).sprint.get());
     }
 
     public boolean rageSprint() {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Sprint.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Sprint.java
@@ -58,6 +58,14 @@ public class Sprint extends Module {
         .build()
     );
 
+    private final Setting<Boolean> permaSprint = sgGeneral.add(new BoolSetting.Builder()
+        .name("sprint-while-stationary")
+        .description("Sprint even when not moving.")
+        .defaultValue(false)
+        .visible(() -> mode.get() == Mode.Rage)
+        .build()
+    );
+
     public Sprint() {
         super(Categories.Movement, "sprint", "Automatically sprints.");
     }
@@ -98,7 +106,9 @@ public class Sprint extends Module {
             ? (Math.abs(mc.player.input.movementForward) + Math.abs(mc.player.input.movementSideways))
             : mc.player.input.movementForward;
 
-        if (movement <= (mc.player.isSubmergedInWater() ? 1.0E-5F : 0.8)) return false;
+        if (movement <= (mc.player.isSubmergedInWater() ? 1.0E-5F : 0.8)) {
+            if (mode.get() == Mode.Strict || !permaSprint.get()) return false;
+        }
 
         boolean strictSprint = !(mc.player.isTouchingWater() && !mc.player.isSubmergedInWater())
             && ((ClientPlayerEntityAccessor) mc.player).invokeCanSprint()

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Sprint.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Sprint.java
@@ -44,16 +44,16 @@ public class Sprint extends Module {
         .build()
     );
 
-    private final Setting<Boolean> keepSprint = sgGeneral.add(new BoolSetting.Builder()
-        .name("keep-sprint")
-        .description("Whether to keep sprinting after attacking an entity.")
+    private final Setting<Boolean> unsprintOnHit = sgGeneral.add(new BoolSetting.Builder()
+        .name("unsprint-on-hit")
+        .description("Whether to stop sprinting before attacking, to ensure you get crits and sweep attacks.")
         .defaultValue(false)
         .build()
     );
 
-    private final Setting<Boolean> unsprintOnHit = sgGeneral.add(new BoolSetting.Builder()
-        .name("unsprint-on-hit")
-        .description("Whether to stop sprinting when attacking, to ensure you get crits and sweep attacks.")
+    private final Setting<Boolean> keepAfterHit = sgGeneral.add(new BoolSetting.Builder()
+        .name("keep-after-hit")
+        .description("Whether to keep sprinting after attacking.")
         .defaultValue(false)
         .build()
     );
@@ -74,7 +74,7 @@ public class Sprint extends Module {
         mc.player.setSprinting(false);
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGH)
     private void onTickMovement(TickEvent.Post event) {
         if (shouldSprint()) mc.player.setSprinting(true);
     }
@@ -93,7 +93,7 @@ public class Sprint extends Module {
 
     @EventHandler
     private void onPacketSent(PacketEvent.Sent event) {
-        if (!unsprintOnHit.get() || !keepSprint.get()) return;
+        if (!unsprintOnHit.get() || !keepAfterHit.get()) return;
         if (!(event.packet instanceof IPlayerInteractEntityC2SPacket packet)
             || packet.meteor$getType() != PlayerInteractEntityC2SPacket.InteractType.ATTACK) return;
 
@@ -123,6 +123,6 @@ public class Sprint extends Module {
     }
 
     public boolean stopSprinting() {
-        return !isActive() || !keepSprint.get();
+        return !isActive() || !keepAfterHit.get();
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Sprint.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Sprint.java
@@ -30,7 +30,7 @@ public class Sprint extends Module {
     }
 
     public final Setting<Mode> mode = sgGeneral.add(new EnumSetting.Builder<Mode>()
-        .name("speed-mode")
+        .name("sprint-mode")
         .description("What mode of sprinting.")
         .defaultValue(Mode.Strict)
         .build()

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Sprint.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Sprint.java
@@ -36,14 +36,6 @@ public class Sprint extends Module {
         .build()
     );
 
-    public final Setting<Boolean> jumpFix = sgGeneral.add(new BoolSetting.Builder()
-        .name("jump-fix")
-        .description("Whether to correct jumping directions.")
-        .defaultValue(true)
-        .visible(() -> mode.get() == Mode.Rage)
-        .build()
-    );
-
     private final Setting<Boolean> unsprintOnHit = sgGeneral.add(new BoolSetting.Builder()
         .name("unsprint-on-hit")
         .description("Whether to stop sprinting before attacking, to ensure you get crits and sweep attacks.")

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Sprint.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Sprint.java
@@ -9,10 +9,7 @@ import meteordevelopment.meteorclient.events.packets.PacketEvent;
 import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.mixin.ClientPlayerEntityAccessor;
 import meteordevelopment.meteorclient.mixininterface.IPlayerInteractEntityC2SPacket;
-import meteordevelopment.meteorclient.settings.BoolSetting;
-import meteordevelopment.meteorclient.settings.EnumSetting;
-import meteordevelopment.meteorclient.settings.Setting;
-import meteordevelopment.meteorclient.settings.SettingGroup;
+import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.systems.modules.Modules;
@@ -68,7 +65,7 @@ public class Sprint extends Module {
 
     @EventHandler(priority = EventPriority.HIGH)
     private void onTickMovement(TickEvent.Post event) {
-        if (shouldSprint()) mc.player.setSprinting(true);
+        mc.player.setSprinting(shouldSprint());
     }
 
     @EventHandler(priority = EventPriority.HIGH)
@@ -103,10 +100,16 @@ public class Sprint extends Module {
         boolean isTouchingWater = mc.player.isTouchingWater() || mc.player.isSubmergedInWater();
         if (unsprintInWater.get() && isTouchingWater) return false;
 
-        boolean strictSprint = mc.player.forwardSpeed > 1.0E-5F
+        float speed = mc.player.forwardSpeed;
+        if (mode.get() == Mode.Rage) {
+            speed = Math.abs(speed);
+            speed += Math.abs(mc.player.sidewaysSpeed);
+        }
+        if (speed < 1.0E-5F) return false;
+
+        boolean strictSprint = isTouchingWater
             && ((ClientPlayerEntityAccessor) mc.player).invokeCanSprint()
-            && (!mc.player.horizontalCollision || mc.player.collidedSoftly)
-            && !isTouchingWater;
+            && (!mc.player.horizontalCollision || mc.player.collidedSoftly);
 
         return isActive() && (mode.get() == Mode.Rage || strictSprint);
     }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Sprint.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Sprint.java
@@ -98,16 +98,17 @@ public class Sprint extends Module {
     }
 
     public boolean shouldSprint() {
-        if (unsprintInWater.get() && (mc.player.isTouchingWater() || mc.player.isSubmergedInWater())) return false;
+        if (mc.currentScreen != null && !Modules.get().get(GUIMove.class).sprint.get()) return false;
+
+        boolean isTouchingWater = mc.player.isTouchingWater() || mc.player.isSubmergedInWater();
+        if (unsprintInWater.get() && isTouchingWater) return false;
 
         boolean strictSprint = mc.player.forwardSpeed > 1.0E-5F
             && ((ClientPlayerEntityAccessor) mc.player).invokeCanSprint()
             && (!mc.player.horizontalCollision || mc.player.collidedSoftly)
-            && !(mc.player.isTouchingWater() && !mc.player.isSubmergedInWater());
+            && !isTouchingWater;
 
-        return isActive()
-            && (mode.get() == Mode.Rage || strictSprint)
-            && (mc.currentScreen == null || Modules.get().get(GUIMove.class).sprint.get());
+        return isActive() && (mode.get() == Mode.Rage || strictSprint);
     }
 
     public boolean rageSprint() {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Make the jump fix a part of rage and remove the "always sprinting" logic. Evidently the logic behind "Rage" is to be sprinting at any time possible, it's unlikely for a server's AC to be configured in such a way that it ignores backwards jumping but just lets you keep sprinting after you hit a block.

As for always sprinting, it's really just a useless feature that makes sprint flag more on most anticheats. Functionally it makes no difference if this is removed so I figure it's all upsides. 

## Related issues

N/A

# How Has This Been Tested?

Joining minehut through both IDE and a Prism instance and running around a bit, running into walls, testing omnidirectional movement, etc.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
