### PR TITLE
Zoom Hide Hud Setting

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Zoom.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Zoom.java
@@ -116,12 +116,6 @@ public class Zoom extends Module {
         hudManualToggled = true;
     }
 
-    @EventHandler
-    public void onMouseButtonPressed(MouseButtonEvent event) {
-        if (event.button != GLFW.GLFW_KEY_F1) return;
-        hudManualToggled = true;
-    }
-
     public void onStop() {
         mc.options.smoothCameraEnabled = preCinematic;
         mc.options.getMouseSensitivity().setValue(preMouseSensitivity);

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Zoom.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Zoom.java
@@ -7,7 +7,6 @@ package meteordevelopment.meteorclient.systems.modules.render;
 
 import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.events.meteor.KeyEvent;
-import meteordevelopment.meteorclient.events.meteor.MouseButtonEvent;
 import meteordevelopment.meteorclient.events.meteor.MouseScrollEvent;
 import meteordevelopment.meteorclient.events.render.GetFovEvent;
 import meteordevelopment.meteorclient.events.render.Render3DEvent;
@@ -164,7 +163,7 @@ public class Zoom extends Module {
 
     @EventHandler
     private void onGetFov(GetFovEvent event) {
-        event.fov /= getScaling();
+        event.fov /= (float) getScaling();
 
         if (lastFov != event.fov) mc.worldRenderer.scheduleTerrainUpdate();
         lastFov = event.fov;

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Zoom.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Zoom.java
@@ -6,6 +6,8 @@
 package meteordevelopment.meteorclient.systems.modules.render;
 
 import meteordevelopment.meteorclient.MeteorClient;
+import meteordevelopment.meteorclient.events.meteor.KeyEvent;
+import meteordevelopment.meteorclient.events.meteor.MouseButtonEvent;
 import meteordevelopment.meteorclient.events.meteor.MouseScrollEvent;
 import meteordevelopment.meteorclient.events.render.GetFovEvent;
 import meteordevelopment.meteorclient.events.render.Render3DEvent;
@@ -18,6 +20,7 @@ import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.orbit.EventHandler;
 import net.minecraft.util.math.MathHelper;
+import org.lwjgl.glfw.GLFW;
 
 public class Zoom extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
@@ -52,10 +55,18 @@ public class Zoom extends Module {
         .build()
     );
 
+    private final Setting<Boolean> hideHud = sgGeneral.add(new BoolSetting.Builder()
+        .name("hide-HUD")
+        .description("Whether or not to hide the Minecraft HUD.")
+        .defaultValue(false)
+        .build()
+    );
+
     private final Setting<Boolean> renderHands = sgGeneral.add(new BoolSetting.Builder()
         .name("show-hands")
         .description("Whether or not to render your hands.")
         .defaultValue(false)
+        .visible(() -> !hideHud.get())
         .build()
     );
 
@@ -65,6 +76,8 @@ public class Zoom extends Module {
     private double value;
     private double lastFov;
     private double time;
+
+    private boolean hudManualToggled;
 
     public Zoom() {
         super(Categories.Render, "zoom", "Zooms your view.");
@@ -83,6 +96,30 @@ public class Zoom extends Module {
             MeteorClient.EVENT_BUS.subscribe(this);
             enabled = true;
         }
+
+        if (hideHud.get() && !mc.options.hudHidden) {
+            hudManualToggled = false;
+            mc.options.hudHidden = true;
+        }
+    }
+
+    @Override
+    public void onDeactivate() {
+        if (hideHud.get() && !hudManualToggled) {
+            mc.options.hudHidden = false;
+        }
+    }
+
+    @EventHandler
+    public void onKeyPressed(KeyEvent event) {
+        if (event.key != GLFW.GLFW_KEY_F1) return;
+        hudManualToggled = true;
+    }
+
+    @EventHandler
+    public void onMouseButtonPressed(MouseButtonEvent event) {
+        if (event.button != GLFW.GLFW_KEY_F1) return;
+        hudManualToggled = true;
     }
 
     public void onStop() {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Adds a setting to hide the hud while the module is active. Activating this hides the "show hands" setting since that logic is encapsulated in hud rendering. If the user manually turns the hud on/off while the module is active it will not try to retoggle the hud when deactivated.

## Related issues

N/A

# How Has This Been Tested?

https://github.com/user-attachments/assets/7f2ea8c0-e652-4f74-be5d-6543459d4712

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
