### PR TITLE
Hide Modules in ClickGUI

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/ModulesScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/ModulesScreen.java
@@ -53,7 +53,7 @@ public class ModulesScreen extends TabScreen {
 
     // Category
 
-    protected WWindow createCategory(WContainer c, Category category) {
+    protected WWindow createCategory(WContainer c, Category category, List<Module> moduleList) {
         WWindow w = theme.window(category.name);
         w.id = category.name;
         w.padding = 0;
@@ -68,8 +68,7 @@ public class ModulesScreen extends TabScreen {
         w.view.hasScrollBar = false;
         w.view.spacing = 0;
 
-        for (Module module : Modules.get().getGroup(category)) {
-            if (Config.get().hiddenModules.get().contains(module)) continue;
+        for (Module module : moduleList) {
             w.add(theme.module(module)).expandX();
         }
 
@@ -203,8 +202,19 @@ public class ModulesScreen extends TabScreen {
 
         @Override
         public void init() {
+            List<Module> moduleList = new ArrayList<>();
             for (Category category : Modules.loopCategories()) {
-                windows.add(createCategory(this, category));
+                for (Module module : Modules.get().getGroup(category)) {
+                    if (!Config.get().hiddenModules.get().contains(module)) {
+                        moduleList.add(module);
+                    }
+                }
+
+                // Ensure empty categories are not shown
+                if (!moduleList.isEmpty()) {
+                    windows.add(createCategory(this, category, moduleList));
+                    moduleList.clear();
+                }
             }
 
             windows.add(createSearch(this));

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/ModulesScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/ModulesScreen.java
@@ -69,6 +69,7 @@ public class ModulesScreen extends TabScreen {
         w.view.spacing = 0;
 
         for (Module module : Modules.get().getGroup(category)) {
+            if (Config.get().hiddenModules.get().contains(module)) continue;
             w.add(theme.module(module)).expandX();
         }
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/Systems.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/Systems.java
@@ -34,7 +34,7 @@ public class Systems {
     }
 
     public static void init() {
-        // Has to be loaded first so the the hidden modules list in config tab can load modules
+        // Has to be loaded first so the hidden modules list in config tab can load modules
         add(new Modules());
 
         Config config = new Config();

--- a/src/main/java/meteordevelopment/meteorclient/systems/Systems.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/Systems.java
@@ -34,6 +34,9 @@ public class Systems {
     }
 
     public static void init() {
+        // Has to be loaded first so the the hidden modules list in config tab can load modules
+        add(new Modules());
+
         Config config = new Config();
         System<?> configSystem = add(config);
         configSystem.init();
@@ -42,7 +45,6 @@ public class Systems {
         // Registers the colors from config tab. This allows rainbow colours to work for friends.
         config.settings.registerColorSettings(null);
 
-        add(new Modules());
         add(new Macros());
         add(new Friends());
         add(new Accounts());

--- a/src/main/java/meteordevelopment/meteorclient/systems/config/Config.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/config/Config.java
@@ -11,6 +11,8 @@ import meteordevelopment.meteorclient.renderer.text.FontFace;
 import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.System;
 import meteordevelopment.meteorclient.systems.Systems;
+import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.meteorclient.systems.modules.combat.BedAura;
 import meteordevelopment.meteorclient.utils.render.color.SettingColor;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;
@@ -26,6 +28,7 @@ public class Config extends System<Config> {
     public final Settings settings = new Settings();
 
     private final SettingGroup sgVisual = settings.createGroup("Visual");
+    private final SettingGroup sgModules = settings.createGroup("Modules");
     private final SettingGroup sgChat = settings.createGroup("Chat");
     private final SettingGroup sgMisc = settings.createGroup("Misc");
 
@@ -94,6 +97,29 @@ public class Config extends System<Config> {
         .build()
     );
 
+    // Modules
+
+    public final Setting<List<Module>> hiddenModules = sgModules.add(new ModuleListSetting.Builder()
+        .name("hidden-modules")
+        .description("Prevent these modules from being rendered as options in the clickgui.")
+        .build()
+    );
+
+    public final Setting<Integer> moduleSearchCount = sgModules.add(new IntSetting.Builder()
+        .name("module-search-count")
+        .description("Amount of modules and settings to be shown in the module search bar.")
+        .defaultValue(8)
+        .min(1).sliderMax(12)
+        .build()
+    );
+
+    public final Setting<Boolean> moduleAliases = sgModules.add(new BoolSetting.Builder()
+        .name("search-module-aliases")
+        .description("Whether or not module aliases will be used in the module search bar.")
+        .defaultValue(true)
+        .build()
+    );
+
     // Chat
 
     public final Setting<String> prefix = sgChat.add(new StringSetting.Builder()
@@ -130,21 +156,6 @@ public class Config extends System<Config> {
     public final Setting<Boolean> useTeamColor = sgMisc.add(new BoolSetting.Builder()
         .name("use-team-color")
         .description("Uses player's team color for rendering things like esp and tracers.")
-        .defaultValue(true)
-        .build()
-    );
-
-    public final Setting<Integer> moduleSearchCount = sgMisc.add(new IntSetting.Builder()
-        .name("module-search-count")
-        .description("Amount of modules and settings to be shown in the module search bar.")
-        .defaultValue(8)
-        .min(1).sliderMax(12)
-        .build()
-    );
-
-    public final Setting<Boolean> moduleAliases = sgMisc.add(new BoolSetting.Builder()
-        .name("search-module-aliases")
-        .description("Whether or not module aliases will be used in the module search bar.")
         .defaultValue(true)
         .build()
     );

--- a/src/main/java/meteordevelopment/meteorclient/systems/config/Config.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/config/Config.java
@@ -12,7 +12,6 @@ import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.System;
 import meteordevelopment.meteorclient.systems.Systems;
 import meteordevelopment.meteorclient.systems.modules.Module;
-import meteordevelopment.meteorclient.systems.modules.combat.BedAura;
 import meteordevelopment.meteorclient.utils.render.color.SettingColor;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
@@ -172,8 +172,6 @@ public class Modules extends System<Modules> {
         Map<Module, Integer> modules = new ValueComparableMap<>(Comparator.naturalOrder());
 
         for (Module module : this.moduleInstances.values()) {
-            if (Config.get().hiddenModules.get().contains(module)) continue;
-
             int score = Utils.searchLevenshteinDefault(module.title, text, false);
             if (Config.get().moduleAliases.get()) {
                 for (String alias : module.aliases) {
@@ -181,7 +179,6 @@ public class Modules extends System<Modules> {
                     if (aliasScore < score) score = aliasScore;
                 }
             }
-
             modules.put(module, modules.getOrDefault(module, 0) + score);
         }
 
@@ -192,8 +189,6 @@ public class Modules extends System<Modules> {
         Map<Module, Integer> modules = new ValueComparableMap<>(Comparator.naturalOrder());
 
         for (Module module : this.moduleInstances.values()) {
-            if (Config.get().hiddenModules.get().contains(module)) continue;
-
             int lowest = Integer.MAX_VALUE;
             for (SettingGroup sg : module.settings) {
                 for (Setting<?> setting : sg) {
@@ -201,7 +196,6 @@ public class Modules extends System<Modules> {
                     if (score < lowest) lowest = score;
                 }
             }
-
             modules.put(module, modules.getOrDefault(module, 0) + lowest);
         }
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
@@ -172,6 +172,8 @@ public class Modules extends System<Modules> {
         Map<Module, Integer> modules = new ValueComparableMap<>(Comparator.naturalOrder());
 
         for (Module module : this.moduleInstances.values()) {
+            if (Config.get().hiddenModules.get().contains(module)) continue;
+
             int score = Utils.searchLevenshteinDefault(module.title, text, false);
             if (Config.get().moduleAliases.get()) {
                 for (String alias : module.aliases) {
@@ -179,6 +181,7 @@ public class Modules extends System<Modules> {
                     if (aliasScore < score) score = aliasScore;
                 }
             }
+
             modules.put(module, modules.getOrDefault(module, 0) + score);
         }
 
@@ -189,6 +192,8 @@ public class Modules extends System<Modules> {
         Map<Module, Integer> modules = new ValueComparableMap<>(Comparator.naturalOrder());
 
         for (Module module : this.moduleInstances.values()) {
+            if (Config.get().hiddenModules.get().contains(module)) continue;
+
             int lowest = Integer.MAX_VALUE;
             for (SettingGroup sg : module.settings) {
                 for (Setting<?> setting : sg) {
@@ -196,6 +201,7 @@ public class Modules extends System<Modules> {
                     if (score < lowest) lowest = score;
                 }
             }
+
             modules.put(module, modules.getOrDefault(module, 0) + lowest);
         }
 


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Adds a new "modules" category in the config where module search settings were moved, along with a new "hidden modules" setting. You can add modules to this list and they will be excluded from the modules screen when entering the clickgui. They are not actually removed to keep compatability with mixins, addons etc, but are simply kept out of sight. Should be useful for hiding bloat in addons or modules you don't plan to use.

I don't think there needs to be any optimization here? Just wary of o(n^2) stuff but at least in this case it only happens once when the screen is created and there's a small enough amount of modules that I don't believe it makes a difference - at least it doesn't on my laptop. Maybe Crosby will prove me wrong in the future :3

## Related issues

#3454, #726

# How Has This Been Tested?

https://github.com/user-attachments/assets/986e865c-1485-4bf0-9133-9ccf90279b68

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
