### PR TITLE
AntiAFK Look/Follow/Wander modes and general improvements

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AntiAFK.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AntiAFK.java
@@ -162,6 +162,7 @@ public class AntiAFK extends Module {
         .description("Where to look.")
         .defaultValue(LookMode.Random)
         .visible(look::get)
+        .onChanged(mode -> this.currentTarget = null)
         .build()
     );
     private final Setting<Boolean> wander = sgActions.add(new BoolSetting.Builder()

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AntiAFK.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AntiAFK.java
@@ -120,8 +120,8 @@ public class AntiAFK extends Module {
         .build()
     );
     private final Setting<Integer> spinSpeed = sgActions.add(new IntSetting.Builder()
-        .name("speed")
-        .description("The speed to spin you.")
+        .name("spin-speed")
+        .description("The speed to spin you (set to 0 for random).")
         .defaultValue(7)
         .visible(spin::get)
         .build()
@@ -378,7 +378,9 @@ public class AntiAFK extends Module {
 
         // Spin
         if (spin.get()) {
-            prevYaw += spinSpeed.get();
+            prevYaw += spinSpeed.get() <= 0
+                ? random.nextInt(42) : spinSpeed.get();
+
             if (!silentSpin.get()) mc.player.setYaw(prevYaw);
             else Rotations.rotate(prevYaw, spinPitch.get(), -15);
         }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AntiAFK.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AntiAFK.java
@@ -172,6 +172,11 @@ public class AntiAFK extends Module {
         .visible(() -> look.get() && lookMode.get().equals(LookMode.Random))
         .onChanged(value -> {
             if (value) silentLook.set(false);
+            else if (this.ticksWalking > 0) {
+                ticksWalking = 0;
+                mc.options.forwardKey.setPressed(false);
+                mc.options.getAutoJump().setValue(this.hadAutoJump);
+            }
         })
         .build()
     );
@@ -186,7 +191,7 @@ public class AntiAFK extends Module {
     private final Setting<Integer> wanderRate = sgActions.add(new IntSetting.Builder()
         .name("wander-rate")
         .description("How often to wander.")
-        .defaultValue(200).min(1).sliderRange(1, 420)
+        .defaultValue(20).min(1).sliderRange(1, 420)
         .visible(() -> wander.isVisible() && wander.get())
         .build()
     );
@@ -196,7 +201,13 @@ public class AntiAFK extends Module {
         .defaultValue(false)
         .visible(() -> look.get() && !lookMode.get().equals(LookMode.Random))
         .onChanged(value -> {
-            if (value) silentLook.set(false);
+            if (value) {
+                silentLook.set(false);
+                this.lookRate.set(0);
+            } else if (this.currentTarget != null) {
+                mc.options.forwardKey.setPressed(false);
+                mc.options.getAutoJump().setValue(this.hadAutoJump);
+            }
         })
         .build()
     );
@@ -219,7 +230,7 @@ public class AntiAFK extends Module {
     private final Setting<Integer> lookRate = sgActions.add(new IntSetting.Builder()
         .name("look-rate")
         .description("How many seconds before looking in a new direction (set to 0 for random/tracking).")
-        .defaultValue(1).min(0)
+        .defaultValue(10).min(0)
         .sliderRange(0, 60)
         .visible(look::get)
         .onChanged(value -> {
@@ -424,7 +435,7 @@ public class AntiAFK extends Module {
                         boolean shouldWander = random.nextInt(wanderRate.get()) == 0;
 
                         if (shouldWander) {
-                            ticksWalking = random.nextInt(600);
+                            ticksWalking = random.nextInt(69,1337);
                             mc.options.forwardKey.setPressed(true);
                             hadAutoJump = mc.options.getAutoJump().getValue();
                             mc.options.getAutoJump().setValue(true);

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AntiAFK.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AntiAFK.java
@@ -384,7 +384,7 @@ public class AntiAFK extends Module {
                       sneakTimer = 0;
                       ticksSneaked = 0;
                   }
-                } else if (random.nextInt(99) == 0) ticksSneaked = 0; // Sneak after ~5 seconds
+                } else if (random.nextInt(9) == 0) ticksSneaked = 0; // Twerk
             } else mc.options.sneakKey.setPressed(true);
         }
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AntiAFK.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AntiAFK.java
@@ -444,7 +444,7 @@ public class AntiAFK extends Module {
                             --ticksWalking;
                             if (ticksWalking >= -5) {
                                 mc.options.forwardKey.setPressed(false);
-                                mc.options.getAutoJump().setValue(false);
+                                mc.options.getAutoJump().setValue(hadAutoJump);
                             }
                         }
                     }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AntiAFK.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AntiAFK.java
@@ -105,6 +105,15 @@ public class AntiAFK extends Module {
         })
         .build()
     );
+    private final Setting<Integer> strafeRate = sgActions.add(new IntSetting.Builder()
+        .name("strafe-rate")
+        .description("How many seconds before changing strafe direction (set to 0 for random).")
+        .defaultValue(1)
+        .min(0)
+        .sliderRange(0, 60)
+        .visible(strafe::get)
+        .build()
+    );
 
     private final Setting<Boolean> spin = sgActions.add(new BoolSetting.Builder()
         .name("spin")
@@ -369,11 +378,20 @@ public class AntiAFK extends Module {
         }
 
         // Strafe
-        if (strafe.get() && strafeTimer-- <= 0) {
-            mc.options.leftKey.setPressed(!direction);
-            mc.options.rightKey.setPressed(direction);
-            direction = !direction;
-            strafeTimer = 20;
+        if (strafe.get()) {
+            if (strafeRate.get() > 0) {
+                ++strafeTimer;
+                if (strafeTimer >= strafeRate.get() * 20) {
+                    strafeTimer = 0;
+                    mc.options.leftKey.setPressed(!direction);
+                    mc.options.rightKey.setPressed(direction);
+                    direction = !direction;
+                }
+            } else if (random.nextInt(42) == 0) {
+                mc.options.leftKey.setPressed(!direction);
+                mc.options.rightKey.setPressed(direction);
+                direction = !direction;
+            }
         }
 
         // Spin

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AntiAFK.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AntiAFK.java
@@ -553,7 +553,9 @@ public class AntiAFK extends Module {
         for (Entity entity : mc.world.getEntities()) {
             if (entity.equals(mc.player)) continue;
             if (entity instanceof PlayerEntity player && targetPlayers.get().contains(player.getName().getString().toLowerCase())) {
-                validTargets.add(entity);
+                if (entity.getBlockPos().isWithinDistance(mc.player.getBlockPos(), maxDistance.get())) {
+                    validTargets.add(entity);
+                }
             }
         }
     }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AntiAFK.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AntiAFK.java
@@ -5,18 +5,27 @@
 
 package meteordevelopment.meteorclient.systems.modules.player;
 
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.utils.Utils;
-import meteordevelopment.meteorclient.utils.misc.input.Input;
 import meteordevelopment.meteorclient.utils.player.ChatUtils;
 import meteordevelopment.meteorclient.utils.player.Rotations;
 import meteordevelopment.orbit.EventHandler;
-
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.projectile.ProjectileUtil;
+import net.minecraft.predicate.entity.EntityPredicates;
+import net.minecraft.util.hit.EntityHitResult;
+import net.minecraft.util.math.Box;
+import net.minecraft.util.math.Vec3d;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 
 public class AntiAFK extends Module {
     private final SettingGroup sgActions = settings.createGroup("Actions");
@@ -30,7 +39,6 @@ public class AntiAFK extends Module {
         .defaultValue(true)
         .build()
     );
-
     private final Setting<Integer> jumpRate = sgActions.add(new IntSetting.Builder()
         .name("jump-rate")
         .description("How many seconds between jumps (set to 0 for random).")
@@ -47,7 +55,6 @@ public class AntiAFK extends Module {
         .defaultValue(false)
         .build()
     );
-
     private final Setting<Integer> swingRate = sgActions.add(new IntSetting.Builder()
         .name("swing-rate")
         .description("How many seconds between hand swings (set to 0 for random).")
@@ -64,7 +71,6 @@ public class AntiAFK extends Module {
         .defaultValue(false)
         .build()
     );
-
     private final Setting<Integer> sneakRate = sgActions.add(new IntSetting.Builder()
         .name("sneak-rate")
         .description("How many seconds between sneaks (set to 0 for random).")
@@ -74,7 +80,6 @@ public class AntiAFK extends Module {
         .visible(sneak::get)
         .build()
     );
-
     private final Setting<Integer> sneakTime = sgActions.add(new IntSetting.Builder()
         .name("sneak-time")
         .description("How many ticks to stay sneaked.")
@@ -107,15 +112,13 @@ public class AntiAFK extends Module {
         .defaultValue(true)
         .build()
     );
-
-    private final Setting<SpinMode> spinMode = sgActions.add(new EnumSetting.Builder<SpinMode>()
-        .name("spin-mode")
-        .description("The method of rotating.")
-        .defaultValue(SpinMode.Server)
+    private final Setting<Boolean> silentSpin = sgActions.add(new BoolSetting.Builder()
+        .name("silent-spin")
+        .description("Spins using silent (server-side) rotations.")
+        .defaultValue(true)
         .visible(spin::get)
         .build()
     );
-
     private final Setting<Integer> spinSpeed = sgActions.add(new IntSetting.Builder()
         .name("speed")
         .description("The speed to spin you.")
@@ -123,17 +126,114 @@ public class AntiAFK extends Module {
         .visible(spin::get)
         .build()
     );
-
-    private final Setting<Integer> pitch = sgActions.add(new IntSetting.Builder()
-        .name("pitch")
+    private final Setting<Integer> spinPitch = sgActions.add(new IntSetting.Builder()
+        .name("spin-pitch")
         .description("The pitch to send to the server.")
         .defaultValue(0)
         .range(-90, 90)
         .sliderRange(-90, 90)
-        .visible(() -> spin.get() && spinMode.get() == SpinMode.Server)
+        .visible(() -> spin.get() && silentSpin.get())
         .build()
     );
 
+    private final Setting<Boolean> look = sgActions.add(new BoolSetting.Builder()
+        .name("look")
+        .description("Periodically rotate to look in a random direction.")
+        .defaultValue(false)
+        .build()
+    );
+    private final Setting<Boolean> silentLook = sgActions.add(new BoolSetting.Builder()
+        .name("silent-look")
+        .description("Looks using silent (server-side) rotations.")
+        .defaultValue(true)
+        .visible(this::canSilentLook)
+        .build()
+    );
+    private final Setting<LookMode> lookMode = sgActions.add(new EnumSetting.Builder<LookMode>()
+        .name("look-mode")
+        .description("Where to look.")
+        .defaultValue(LookMode.Random)
+        .visible(look::get)
+        .build()
+    );
+    private final Setting<Boolean> wander = sgActions.add(new BoolSetting.Builder()
+        .name("wander")
+        .description("Wander around in random directions.")
+        .defaultValue(false)
+        .visible(() -> look.get() && lookMode.get().equals(LookMode.Random))
+        .onChanged(value -> {
+            if (value) silentLook.set(false);
+        })
+        .build()
+    );
+    private final Setting<Integer> wanderPitch = sgActions.add(new IntSetting.Builder()
+        .name("wander-pitch")
+        .description("How to set the player's pitch while wandering (set outside of slider range for random).")
+        .defaultValue(420)
+        .sliderRange(-90, 90)
+        .visible(() -> look.get() && wander.isVisible() && wander.get())
+        .build()
+    );
+    private final Setting<Integer> wanderRate = sgActions.add(new IntSetting.Builder()
+        .name("wander-rate")
+        .description("How often to wander.")
+        .defaultValue(200).min(1).sliderRange(1, 420)
+        .visible(() -> wander.isVisible() && wander.get())
+        .build()
+    );
+    private final Setting<Boolean> follow = sgActions.add(new BoolSetting.Builder()
+        .name("follow")
+        .description("Follow your target entity.")
+        .defaultValue(false)
+        .visible(() -> look.get() && !lookMode.get().equals(LookMode.Random))
+        .onChanged(value -> {
+            if (value) silentLook.set(false);
+        })
+        .build()
+    );
+    private final Setting<Set<EntityType<?>>> targetEntities = sgActions.add(new EntityTypeListSetting.Builder()
+        .name("target-entities")
+        .description("Which entities to look at.")
+        .defaultValue(EntityType.PLAYER, EntityType.VILLAGER,
+            EntityType.ALLAY, EntityType.CAT, EntityType.WOLF, EntityType.PARROT
+        )
+        .visible(() -> look.get() && lookMode.get().equals(LookMode.Entity))
+        .build()
+    );
+    private final Setting<List<String>> targetPlayers = sgActions.add(new StringListSetting.Builder()
+        .name("target-players")
+        .description("Which players to look at.")
+        .defaultValue(List.of())
+        .visible(() -> look.get() && lookMode.get().equals(LookMode.Player))
+        .build()
+    );
+    private final Setting<Integer> lookRate = sgActions.add(new IntSetting.Builder()
+        .name("look-rate")
+        .description("How many seconds before looking in a new direction (set to 0 for random/tracking).")
+        .defaultValue(1).min(0)
+        .sliderRange(0, 60)
+        .visible(look::get)
+        .onChanged(value -> {
+            if (value > 0) follow.set(false);
+        })
+        .build()
+    );
+    private final Setting<Integer> followDistance = sgActions.add(new IntSetting.Builder()
+        .name("follow-distance")
+        .description("What distance to follow entities at.")
+        .defaultValue(2)
+        .min(0).max(getMaxDistance()).sliderMax(getMaxDistance())
+        .visible(() -> follow.isVisible() && follow.get())
+        .build()
+    );
+    private final Setting<Integer> maxDistance = sgActions.add(new IntSetting.Builder()
+        .name("maximum-entity-distance")
+        .description("How far away can target entities be.")
+        .defaultValue(64).min(16)
+        .sliderRange(16, 256)
+        .visible(() -> look.get() && !lookMode.get().equals(LookMode.Random))
+        .build()
+    );
 
     // Messages
 
@@ -181,12 +281,17 @@ public class AntiAFK extends Module {
     private int messageTimer = 0;
     private int messageI = 0;
     private int jumpTimer = 0;
+    private int lookTimer = 0;
     private int swingTimer = 0;
     private int sneakTimer = 0;
     private int strafeTimer = 0;
     private int ticksSneaked = 0;
+    private int ticksWalking = 0;
     private boolean direction = false;
+    private boolean hadAutoJump = false;
     private float prevYaw;
+    private @Nullable Entity currentTarget;
+    private final List<Entity> validTargets = new ObjectArrayList<>();
 
     @Override
     public void onActivate() {
@@ -205,6 +310,16 @@ public class AntiAFK extends Module {
             mc.options.leftKey.setPressed(false);
             mc.options.rightKey.setPressed(false);
         }
+
+        if ((look.get() && follow.get() && currentTarget != null)
+            || (look.get() && wander.get() && ticksWalking > 0)) {
+            mc.options.forwardKey.setPressed(false);
+            mc.options.getAutoJump().setValue(hadAutoJump);
+        }
+
+        hadAutoJump = false;
+        validTargets.clear();
+        currentTarget = null;
     }
 
     @EventHandler
@@ -264,10 +379,8 @@ public class AntiAFK extends Module {
         // Spin
         if (spin.get()) {
             prevYaw += spinSpeed.get();
-            switch (spinMode.get()) {
-                case Client -> mc.player.setYaw(prevYaw);
-                case Server -> Rotations.rotate(prevYaw, pitch.get(), -15);
-            }
+            if (!silentSpin.get()) mc.player.setYaw(prevYaw);
+            else Rotations.rotate(prevYaw, spinPitch.get(), -15);
         }
 
         // Messages
@@ -278,10 +391,192 @@ public class AntiAFK extends Module {
             ChatUtils.sendPlayerMsg(messages.get().get(messageI));
             messageTimer = delay.get() * 20;
         }
+
+        // Look
+        ++lookTimer; // Guard syntax to reduce nesting
+        if (lookTimer < lookRate.get() * 20 || !look.get()) return;
+
+        lookTimer = 0;
+        switch (lookMode.get()) {
+            case Random -> {
+                if (wander.get()) {
+                    if (ticksWalking <= 0) {
+                        boolean shouldWander = random.nextInt(wanderRate.get()) == 0;
+
+                        if (shouldWander) {
+                            ticksWalking = random.nextInt(600);
+                            mc.options.forwardKey.setPressed(true);
+                            hadAutoJump = mc.options.getAutoJump().getValue();
+                            mc.options.getAutoJump().setValue(true);
+                        } else {
+                            --ticksWalking;
+                            if (ticksWalking >= -5) {
+                                mc.options.forwardKey.setPressed(false);
+                                mc.options.getAutoJump().setValue(false);
+                            }
+                        }
+
+                    } else --ticksWalking;
+
+                    if (wanderPitchOutOfBounds()) {
+                        if (lookRate.get() > 0) lookRandomly();
+                        else if (random.nextInt(99) == 0) lookRandomly();
+                    } else {
+                        if (lookRate.get() > 0) yawRandomly(wanderPitch.get());
+                        else if (random.nextInt(99) == 0) yawRandomly(wanderPitch.get());
+                    }
+
+                } else if (lookRate.get() > 0) lookRandomly();
+                else if (random.nextInt(99) == 0) lookRandomly();
+            }
+            case Entity, RandomEntity, Player -> {
+                boolean playerMode = lookMode.get().equals(LookMode.Player);
+
+                if (lookRate.get() > 0) {
+                    if (playerMode) {
+                        findValidPlayers();
+                    } else {
+                        findValidTargets(lookMode.get().equals(LookMode.RandomEntity));
+                    }
+                    if (validTargets.isEmpty()) lookRandomly();
+                    else {
+                        int luckyIndex = random.nextInt(validTargets.size());
+                        Entity entity = validTargets.get(luckyIndex);
+                        if (alreadyTargeting(entity)) {
+                            lookRandomly();
+                        } else {
+                            lookAtEntity(entity);
+                        }
+                    }
+                } else if (isCurrentTargetInvalid()) {
+                    if (playerMode) {
+                        findValidPlayers();
+                    } else {
+                        findValidTargets(lookMode.get().equals(LookMode.RandomEntity));
+                    }
+                    if (validTargets.isEmpty()) {
+                      if (random.nextInt(99) == 0) lookRandomly();
+                    } else {
+                        int luckyIndex = random.nextInt(validTargets.size());
+                        currentTarget = validTargets.get(luckyIndex);
+                        lookAtEntity(currentTarget);
+                    }
+                } else {
+                    if (follow.get() && !mc.player.getBlockPos().isWithinDistance(currentTarget.getBlockPos(), followDistance.get())) {
+                        mc.options.forwardKey.setPressed(true);
+                        hadAutoJump = mc.options.getAutoJump().getValue();
+                        mc.options.getAutoJump().setValue(true);
+                    } else if (follow.get()) {
+                        mc.options.forwardKey.setPressed(false);
+                    }
+                    lookAtEntity(currentTarget);
+                }
+            }
+        }
     }
 
-    public enum SpinMode {
-        Server,
-        Client
+    private void yawRandomly(float pitch) {
+        if (silentLook.get()) {
+            Rotations.rotate(random.nextFloat(360), pitch, -13);
+        } else {
+            mc.player.setYaw(random.nextFloat(360));
+            mc.player.setPitch(pitch);
+        }
+    }
+
+    private void lookRandomly() {
+        if (silentLook.get()) {
+            Rotations.rotate(
+                random.nextFloat(360),
+                random.nextFloat(-90, 90), -13
+            );
+        } else {
+            mc.player.setYaw(random.nextFloat(360));
+            mc.player.setPitch(random.nextFloat(-90, 90));
+        }
+    }
+
+    private void lookAtEntity(Entity entity) {
+        Vec3d targetPos = entity.getEyePos();
+
+        if (silentLook.get()) {
+            Rotations.rotate(
+                Rotations.getYaw(targetPos),
+                Rotations.getPitch(targetPos), -13
+            );
+        } else {
+            mc.player.setYaw((float) Rotations.getYaw(targetPos));
+            mc.player.setPitch((float) Rotations.getPitch(targetPos));
+        }
+    }
+
+    private void findValidTargets(boolean random) {
+        validTargets.clear();
+        for (Entity entity : mc.world.getEntities()) {
+            if (entity.equals(mc.player)) continue;
+            if (random || targetEntities.get().contains(entity.getType())) {
+                if (entity.getBlockPos().isWithinDistance(mc.player.getBlockPos(), maxDistance.get())) {
+                    validTargets.add(entity);
+                }
+            }
+        }
+    }
+
+    private void findValidPlayers() {
+        validTargets.clear();
+        for (Entity entity : mc.world.getEntities()) {
+            if (entity.equals(mc.player)) continue;
+            if (entity instanceof PlayerEntity player && targetPlayers.get().contains(player.getName().getString().toLowerCase())) {
+                validTargets.add(entity);
+            }
+        }
+    }
+
+    private boolean isCurrentTargetInvalid() {
+        return currentTarget == null
+            || currentTarget.isRemoved()
+            || (lookMode.get().equals(LookMode.Player) && !(currentTarget instanceof PlayerEntity))
+            || (lookMode.get().equals(LookMode.Entity) && !targetEntities.get().contains(currentTarget.getType()))
+            || !currentTarget.getBlockPos().isWithinDistance(mc.player.getBlockPos(), maxDistance.get())
+            || (lookMode.get().equals(LookMode.Player) && !targetPlayers.get().contains(currentTarget.getName().toString().toLowerCase()));
+    }
+
+    private boolean alreadyTargeting(Entity entity) {
+        int raycastDistance = maxDistance.get();
+
+        Vec3d eyes = mc.player.getEyePos();
+        Vec3d lookDirection = mc.player.getRotationVec(0f);
+        Vec3d lookingTowards = eyes.add(lookDirection.multiply(raycastDistance));
+        Box box = mc.player.getBoundingBox().stretch(lookDirection.multiply(raycastDistance)).expand(1.0, 1.0, 1.0);
+
+        EntityHitResult result = ProjectileUtil.raycast(
+            mc.player, eyes, lookingTowards, box,
+            EntityPredicates.VALID_ENTITY, raycastDistance * raycastDistance
+        );
+
+        return result != null && result.getEntity().equals(entity);
+    }
+
+    private boolean canSilentLook() {
+        return look.get()
+            && !(wander.isVisible() && wander.get())
+            && !(follow.isVisible() && follow.get());
+    }
+
+    private boolean wanderPitchOutOfBounds() {
+        return wanderPitch.get() > 90 || wanderPitch.get() < -90;
+    }
+
+    private int getMaxDistance() {
+        if (maxDistance == null) {
+            return 64;
+        } else return maxDistance.get();
+    }
+
+    public enum LookMode {
+        Random,
+        Player,
+        Entity,
+        RandomEntity
     }
 }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [x] New feature

## Description

**EDIT - Context:**
AntiAFK currently performs its actions on a random delay that is not configurable, which is unnecessarily restrictive and annoying.<br>
For example, on 2b2t you must only send a single hand swing packet every ~15 minutes to avoid being kicked for AFK. This means that with the ability to configure your swing delay, you could leave AntiAFK on 24/7 without having to notice or think about it, and still never get kicked for being afk. With the current version of Meteor's AntiAFK, however, your only option is to watch your player throw hands every few seconds at all times, or otherwise explicitly enable/disable the module when you "plan" on going AFK for a bit.

I do understand that some people might like/want/need the random delay so I have left it as the default behavior for most actions that already used it. I have also added a fun Look mode with some simple but satisfying-to-use follow/wander modes.

### Additions

- Look mode which rotates randomly or tracks an entity based on the sub-mode settings.
- Added random yaw speed setting to spin mode and strafe duration option to strafe mode.
- Follow & wander sub-settings which follow the targeted entity or wander in random directions.
- Added timer settings to jump/swing/sneak/strafe modes, while preserving random time capabilities.

### Fixes

- Changed module package to reflect its category (movement -> player).
- Made jump and sneak work properly while the their module modes are active (you could not jump when jump was enabled).

## Related issues

Probably #3944
Twerking for #2175 

# How Has This Been Tested?
In singleplayer and on 2b2t.


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
