### PR TITLE
Small Hud Fix

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/Hud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/Hud.java
@@ -217,7 +217,7 @@ public class Hud extends System<Hud> implements Iterable<HudElement> {
         if (!(active || HudEditorScreen.isOpen())) return;
 
         for (HudElement element : elements) {
-            if (element.isActive()) element.tick(HudRenderer.INSTANCE);
+            element.tick(HudRenderer.INSTANCE);
         }
     }
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/Hud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/Hud.java
@@ -217,7 +217,9 @@ public class Hud extends System<Hud> implements Iterable<HudElement> {
         if (!(active || HudEditorScreen.isOpen())) return;
 
         for (HudElement element : elements) {
-            element.tick(HudRenderer.INSTANCE);
+            if (element.isActive() || element.isInEditor()) {
+                element.tick(HudRenderer.INSTANCE);
+            }
         }
     }
 
@@ -233,7 +235,9 @@ public class Hud extends System<Hud> implements Iterable<HudElement> {
         for (HudElement element : elements) {
             element.updatePos();
 
-            if (element.isActive()) element.render(HudRenderer.INSTANCE);
+            if (element.isActive() || element.isInEditor()) {
+                element.render(HudRenderer.INSTANCE);
+            }
         }
 
         HudRenderer.INSTANCE.end();


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Makes hud elements tick when they are in the editor as well as when active in-game to fix a bug with elements that set their size in the tick event. Previously if you disabled the element and restarted your game, the size of the element would be reduced to a 1x1 square and would not update unless you managed to click on it to re-enable it.

## Related issues

N/A

# How Has This Been Tested?

Tested via disabling potion hud, active modules hud and closing/reopening the game. Sizing updates correctly, no noticeable issues

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
