### PR TITLE
disable update checking on unofficial build

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/TitleScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/TitleScreenMixin.java
@@ -38,7 +38,7 @@ public abstract class TitleScreenMixin extends Screen {
         if (Utils.firstTimeTitleScreen) {
             Utils.firstTimeTitleScreen = false;
 
-            if (!MeteorClient.VERSION.isZero()) {
+            if (!MeteorClient.VERSION.isZero() && !MeteorClient.BUILD_NUMBER.isEmpty()) {
                 MeteorClient.LOG.info("Checking latest version of Meteor Client");
 
                 MeteorExecutor.execute(() -> {


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

Disable update checking on unofficial builds

"unofficial builds" meaning those where the `build_number` property is unset when compiling, making the `MeteorClient#BUILD_NUMBER` variable contain an empty string

disabling update checking also suppresses this stacktrace that appears in the logs when `MeteorClient#BUILD_NUMBER` cannot be parsed to an int

```
[22:09:19] [Render thread/INFO] (Meteor Client) Checking latest version of Meteor Client
[22:09:19] [Meteor-Executor-1/ERROR] (FabricLoader) Uncaught exception in thread "Meteor-Executor-1"
java.lang.NumberFormatException: For input string: ""
	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:67) ~[?:?]
	at java.base/java.lang.Integer.parseInt(Integer.java:671) ~[?:?]
	at java.base/java.lang.Integer.parseInt(Integer.java:777) ~[?:?]
	at knot/net.minecraft.client.gui.screen.TitleScreen.mddc5b07$meteor-client$lambda$onRenderIdkDude$3$0(TitleScreen.java:557) ~[minecraft-merged-e95e5615d8-1.21.4-net.fabricmc.yarn.1_21_4.1.21.4+build.7-v2.jar:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
	at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
```

# How Has This Been Tested?

Videos or screenshots of the changes if testicable.

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
