### PR TITLE
Fixed flight abilities toggling when receiving an abilities packet

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Flight.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Flight.java
@@ -17,6 +17,7 @@ import meteordevelopment.orbit.EventHandler;
 import net.minecraft.block.AbstractBlock;
 import net.minecraft.entity.Entity;
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket;
+import net.minecraft.network.packet.s2c.play.PlayerAbilitiesS2CPacket;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.util.math.Vec3d;
 
@@ -225,6 +226,16 @@ public class Flight extends Module {
             antiKickPacket(fullPacket, mc.player.getY());
             mc.getNetworkHandler().sendPacket(fullPacket);
         }
+    }
+
+    @EventHandler
+    private void onReceivePacket(PacketEvent.Receive event) {
+        if (!(event.packet instanceof PlayerAbilitiesS2CPacket packet) || mode.get() != Mode.Abilities) return;
+        event.setCancelled(true); // Cancel packet, so fly won't be toggled
+        mc.player.getAbilities().flying = true;
+        mc.player.getAbilities().allowFlying = true;
+        mc.player.getAbilities().invulnerable = packet.isInvulnerable();
+        mc.player.getAbilities().creativeMode = packet.isCreativeMode();
     }
 
     private boolean shouldFlyDown(double currentY, double lastY) {


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

Receiving an abilities packet from the server will toggle your flight for a tick (which if the server spams this packet, it will annoyingly pull you down).

# How Has This Been Tested?

Sorry for the low quality, but left shows flight without the patch (gets spammed with abilities off by the server), and right shows it with the abilities packet cancelled.

https://github.com/user-attachments/assets/f0a65b41-0d8e-43ab-9954-5c18a31d8125

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
