### PR TITLE
Fix NPE for HUD text presets

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/Hud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/Hud.java
@@ -161,13 +161,13 @@ public class Hud extends System<Hud> implements Iterable<HudElement> {
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public void add(HudElementInfo.Preset preset, int x, int y, XAnchor xAnchor, YAnchor yAnchor) {
+    public void add(@NotNull HudElementInfo.Preset preset, int x, int y, XAnchor xAnchor, YAnchor yAnchor) {
         HudElement element = preset.info.create();
         preset.callback.accept(element);
         add(element, x, y, xAnchor, yAnchor);
     }
 
-    public void add(HudElementInfo<?>.Preset preset, int x, int y) {
+    public void add(@NotNull HudElementInfo<?>.Preset preset, int x, int y) {
         add(preset, x, y, null, null);
     }
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/screens/HudElementPresetsScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/screens/HudElementPresetsScreen.java
@@ -14,12 +14,14 @@ import meteordevelopment.meteorclient.systems.hud.Hud;
 import meteordevelopment.meteorclient.systems.hud.HudElementInfo;
 import meteordevelopment.meteorclient.utils.Utils;
 import net.minecraft.client.gui.DrawContext;
+import org.jetbrains.annotations.Nullable;
 
 public class HudElementPresetsScreen extends WindowScreen {
     private final HudElementInfo<?> info;
     private final int x, y;
 
     private final WTextBox searchBar;
+    @Nullable
     private HudElementInfo<?>.Preset firstPreset;
 
     public HudElementPresetsScreen(GuiTheme theme, HudElementInfo<?> info, int x, int y) {
@@ -36,6 +38,7 @@ public class HudElementPresetsScreen extends WindowScreen {
         };
 
         enterAction = () -> {
+            if (firstPreset == null) return;
             Hud.get().add(firstPreset, x, y);
             close();
         };


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

If the search bar didn't match any preset, pressing enter would crash due to a null preset trying to be instantiated.

## Related issues

Closes #5159 

# How Has This Been Tested?

HUD editing.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
