### PR TITLE
Fix for void hole height checking

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/VoidESP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/VoidESP.java
@@ -139,7 +139,7 @@ public class VoidESP extends Module {
 
     private boolean isHole(BlockPos.Mutable blockPos, boolean nether) {
         for (int i = 0; i < holeHeight.get(); i++) {
-            blockPos.setY(nether ? 127 - i : mc.world.getBottomY());
+            blockPos.setY(nether ? 127 - i : mc.world.getBottomY() + i);
             if (isBlockWrong(blockPos)) return false;
         }
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

The Void ESP "hole height" option (which can be set from 1 to 5) appropriately checks the selected number of blocks for bedrock/air at the bedrock roof, but it doesn't do this for the normal bottom bedrock layer in the overworld/nether (it only checks the bottom-most layer), which I assume is unintended/a bug... if not, and the hole height option isn't supposed to do anything at these layers, then ig close this.

# How Has This Been Tested?

First screenshot is without fix, second screenshot is with fix. Both in overworld, both with a hole height of 5 blocks.

![2025-02-04_21 17 56](https://github.com/user-attachments/assets/9f3e76a2-d0fc-4d15-b6cf-5bd62e7385e8)
![2025-02-04_21 21 07](https://github.com/user-attachments/assets/518ad528-154e-44a7-8b55-779aebfaa025)

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
