### PR TITLE
Patch 2

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/commands/Commands.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/Commands.java
@@ -62,7 +62,8 @@ public class Commands {
         add(new InputCommand());
         add(new WaspCommand());
         add(new LocateCommand());
-
+        add(new SwapCommand());
+        
         COMMANDS.sort(Comparator.comparing(Command::getName));
     }
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/SwapCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/SwapCommand.java
@@ -11,8 +11,6 @@ import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.utils.player.InvUtils;
 import net.minecraft.command.CommandSource;
 
-import java.util.ArrayList;
-
 public class SwapCommand extends Command {
     public SwapCommand() {
         super("swap", "Swaps to a hotbar slot");

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/SwapCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/SwapCommand.java
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.commands.commands;
+
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import meteordevelopment.meteorclient.commands.Command;
+import meteordevelopment.meteorclient.utils.player.InvUtils;
+import net.minecraft.command.CommandSource;
+
+import java.util.ArrayList;
+
+public class SwapCommand extends Command {
+    public SwapCommand() {
+        super("swap", "Swaps to a hotbar slot");
+    }
+
+    @Override
+    public void build(LiteralArgumentBuilder<CommandSource> builder) {
+        builder.then(argument("slot", IntegerArgumentType.integer(1, 9)).executes(context -> {
+            int slot = IntegerArgumentType.getInteger(context, "slot") - 1;
+            InvUtils.swap(slot, false);
+            return SINGLE_SUCCESS;
+        }));
+
+    }
+}


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

New command: .swap. Takes integer argument from 1 to 9 and swaps to the corresponding slot.

## Related Issues
[#4236](https://github.com/MeteorDevelopment/meteor-client/issues/4236)

# How Has This Been Tested?

Tested in game, works perfectly fine.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
