### PR TITLE
Adding config settings to hide meteor buttons and text on multiplayer screen.

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/MultiplayerScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MultiplayerScreenMixin.java
@@ -10,6 +10,7 @@ import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.misc.NameProtect;
 import meteordevelopment.meteorclient.systems.proxies.Proxies;
 import meteordevelopment.meteorclient.systems.proxies.Proxy;
+import meteordevelopment.meteorclient.systems.config.Config;
 import meteordevelopment.meteorclient.utils.render.color.Color;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
@@ -81,7 +82,7 @@ public abstract class MultiplayerScreenMixin extends Screen {
         }
         
         // Proxy
-        if (Config.get().ProxyStatus.get()) {
+        if (Config.get().proxyStatus.get()) {
         Proxy proxy = Proxies.get().getEnabled();
 
         String left = proxy != null ? "Using proxy " : "Not using a proxy";

--- a/src/main/java/meteordevelopment/meteorclient/mixin/MultiplayerScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MultiplayerScreenMixin.java
@@ -48,19 +48,23 @@ public abstract class MultiplayerScreenMixin extends Screen {
         loggedInAs = "Logged in as ";
         loggedInAsLength = textRenderer.getWidth(loggedInAs);
 
-        addDrawableChild(
-            new ButtonWidget.Builder(Text.literal("Accounts"), button -> client.setScreen(GuiThemes.get().accountsScreen()))
-                .position(this.width - 75 - 3, 3)
-                .size(75, 20)
-                .build()
-        );
+        if (Config.get().accountsButton.get()) {
+            addDrawableChild(
+                new ButtonWidget.Builder(Text.literal("Accounts"), button -> client.setScreen(GuiThemes.get().accountsScreen()))
+                    .position(this.width - 75 - 3, 3)
+                    .size(75, 20)
+                    .build()
+            );
+        }
 
-        addDrawableChild(
-            new ButtonWidget.Builder(Text.literal("Proxies"), button -> client.setScreen(GuiThemes.get().proxiesScreen()))
-                .position(this.width - 75 - 3 - 75 - 2, 3)
-                .size(75, 20)
-                .build()
-        );
+        if (Config.get().proxiesButton.get()) {
+            addDrawableChild(
+                new ButtonWidget.Builder(Text.literal("Proxies"), button -> client.setScreen(GuiThemes.get().proxiesScreen()))
+                    .position(this.width - 75 - 3 - (Config.get().accountsButton.get() ? 75 : 0) - 2, 3)
+                    .size(75, 20)
+                    .build()
+            );
+        }
     }
 
     @Inject(method = "render", at = @At("TAIL"))
@@ -69,12 +73,15 @@ public abstract class MultiplayerScreenMixin extends Screen {
         int y = 3;
 
         // Logged in as
+        if (Config.get().accountStatus.get()) {
         context.drawTextWithShadow(mc.textRenderer, loggedInAs, x, y, textColor1);
         context.drawTextWithShadow(mc.textRenderer, Modules.get().get(NameProtect.class).getName(client.getSession().getUsername()), x + loggedInAsLength, y, textColor2);
 
         y += textRenderer.fontHeight + 2;
-
+        }
+        
         // Proxy
+        if (Config.get().ProxyStatus.get()) {
         Proxy proxy = Proxies.get().getEnabled();
 
         String left = proxy != null ? "Using proxy " : "Not using a proxy";
@@ -83,5 +90,6 @@ public abstract class MultiplayerScreenMixin extends Screen {
         context.drawTextWithShadow(mc.textRenderer, left, x, y, textColor1);
         if (right != null)
             context.drawTextWithShadow(mc.textRenderer, right, x + textRenderer.getWidth(left), y, textColor2);
+        }
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/config/Config.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/config/Config.java
@@ -70,6 +70,34 @@ public class Config extends System<Config> {
         .defaultValue(true)
         .build()
     );
+    
+    public final Setting<Boolean> proxiesButton = sgVisual.add(new BoolSetting.Builder()
+        .name("proxies-button")
+        .description("Show proxies button on multiplayer screen")
+        .defaultValue(true)
+        .build()
+    );
+
+    public final Setting<Boolean> accountsButton = sgVisual.add(new BoolSetting.Builder()
+        .name("accounts-button")
+        .description("Show accounts button on multiplayer screen")
+        .defaultValue(true)
+        .build()
+    );
+
+    public final Setting<Boolean> accountStatus = sgVisual.add(new BoolSetting.Builder()
+        .name("account-status")
+        .description("Show account status on multiplayer screen")
+        .defaultValue(true)
+        .build()
+    );
+
+    public final Setting<Boolean> proxyStatus = sgVisual.add(new BoolSetting.Builder()
+        .name("proxy-status")
+        .description("Show proxy status on multiplayer screen")
+        .defaultValue(true)
+        .build()
+    );
 
     public final Setting<Boolean> customWindowTitle = sgVisual.add(new BoolSetting.Builder()
         .name("custom-window-title")


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Proxy/account buttons can be disabled, as well as "the logged in as" and the proxy status.
Can be useful if other clients/mods add buttons/text to the multiplayer screen (similar to auto reconnect).

## Related issues

#5180, #3743

# How Has This Been Tested?
![image](https://github.com/user-attachments/assets/d3a3cfe6-3fc0-475a-88aa-b1890ba6a5f2)
![image](https://github.com/user-attachments/assets/f7b149b3-0381-4a4f-925a-40cbf6500d65)
![image](https://github.com/user-attachments/assets/ee7cf0c1-d53c-4f37-bbac-9664dd685c52)
![image](https://github.com/user-attachments/assets/8f73789b-57ad-4aed-9c9c-bf2720374cd1)
![image](https://github.com/user-attachments/assets/432eb5f5-cb73-4512-8a76-37d6048de335)
If only one button is enabled, it moves to the right. Same goes for the info text, it moves to the top.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
