### PR TITLE
Add toggle to disable prevMineScanDroppedItems during tool repairs in…

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/InfinityMiner.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/InfinityMiner.java
@@ -81,13 +81,6 @@ public class InfinityMiner extends Module {
         .build()
     );
 
-    public final Setting<Boolean> stopPrevMineScanDroppedItems = sgGeneral.add(new BoolSetting.Builder()
-        .name("stop-prev-mine-scan-dropped-items")
-        .description("Will stop the mine scan dropped items setting when reparining.")
-        .defaultValue(true)
-        .build()
-    );
-
     // When Full
 
     public final Setting<Boolean> walkHome = sgWhenFull.add(new BoolSetting.Builder()
@@ -165,9 +158,7 @@ public class InfinityMiner extends Module {
             if (!needsRepair()) {
                 warning("Finished repairing, going back to mining.");
                 repairing = false;
-                if (stopPrevMineScanDroppedItems.get()) {
-                    baritoneSettings.mineScanDroppedItems.value = false;
-                }
+                baritoneSettings.mineScanDroppedItems.value = true;
                 mineTargetBlocks();
                 return;
             }
@@ -178,9 +169,7 @@ public class InfinityMiner extends Module {
             if (needsRepair()) {
                 warning("Pickaxe needs repair, beginning repair process");
                 repairing = true;
-                if (stopPrevMineScanDroppedItems.get()) {
-                    baritoneSettings.mineScanDroppedItems.value = false;
-                }
+                baritoneSettings.mineScanDroppedItems.value = false;
                 mineRepairBlocks();
                 return;
             }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/InfinityMiner.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/InfinityMiner.java
@@ -81,6 +81,13 @@ public class InfinityMiner extends Module {
         .build()
     );
 
+    public final Setting<Boolean> stopPrevMineScanDroppedItems = sgGeneral.add(new BoolSetting.Builder()
+        .name("stop-prev-mine-scan-dropped-items")
+        .description("Will stop the mine scan dropped items setting when reparining.")
+        .defaultValue(true)
+        .build()
+    );
+
     // When Full
 
     public final Setting<Boolean> walkHome = sgWhenFull.add(new BoolSetting.Builder()
@@ -158,6 +165,9 @@ public class InfinityMiner extends Module {
             if (!needsRepair()) {
                 warning("Finished repairing, going back to mining.");
                 repairing = false;
+                if (stopPrevMineScanDroppedItems.get()) {
+                    baritoneSettings.mineScanDroppedItems.value = false;
+                }
                 mineTargetBlocks();
                 return;
             }
@@ -168,6 +178,9 @@ public class InfinityMiner extends Module {
             if (needsRepair()) {
                 warning("Pickaxe needs repair, beginning repair process");
                 repairing = true;
+                if (stopPrevMineScanDroppedItems.get()) {
+                    baritoneSettings.mineScanDroppedItems.value = false;
+                }
                 mineRepairBlocks();
                 return;
             }


### PR DESCRIPTION
… InfinityMiner

## Type of change

- [ ] Bug Fixes
- [X] New feature

## Description

Add toggle to disable prevMineScanDroppedItems from baritone settings during tool repairs process in InfinityMiner because if cant pickup item then player get stuck

# How Has This Been Tested?

I have mined for a whole night and with my change when i woke up player was not stuff on repairs process like any other night.

![image](https://github.com/user-attachments/assets/97337097-d2ec-4bd6-8d99-cd792a61c242)

# Checklist:

- [ ] My code follows the style guidelines of this project
- Sadly im not good at naming stuff so idk how to name stuff user see.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
