### PR TITLE
Fixed alphabetical sorting of modules

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
@@ -573,7 +573,6 @@ public class Modules extends System<Modules> {
     }
 
     private void initMisc() {
-        add(new Swarm());
         add(new AntiPacketKick());
         add(new AutoLog());
         add(new AutoReconnect());
@@ -591,6 +590,7 @@ public class Modules extends System<Modules> {
         add(new ServerSpoof());
         add(new SoundBlocker());
         add(new Spam());
+        add(new Swarm());
     }
 
     public static class ModuleRegistry extends SimpleRegistry<Module> {


### PR DESCRIPTION
For some reason, swarm was at the top, I moved it down so everything is sorted nicely.

## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Moved swarm to the bottom.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
