### PR TITLE
Fix sneak slowdown being applied twice

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/utils/player/CustomPlayerInput.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/CustomPlayerInput.java
@@ -13,10 +13,6 @@ public class CustomPlayerInput extends Input {
     public void tick() {
         movementForward = this.playerInput.forward() == this.playerInput.backward() ? 0.0F : (this.playerInput.forward() ? 1.0F : -1.0F);
         movementSideways = this.playerInput.left() == this.playerInput.right() ? 0.0F : (this.playerInput.left() ? 1.0F : -1.0F);
-        if (this.playerInput.sneak()) {
-            movementForward *= 0.3f;
-            movementSideways *= 0.3f;
-        }
     }
 
     public void stop() {


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

Fixes the sneak slowdown being applied twice when using `CustomPlayerInput.sneak()`. The slowdown was applied in `CustomPlayerInput.tick()` and again in minecraft's `ClientPlayerEntity.tickMovement()`.

## Related issues

N/A

# How Has This Been Tested?

Can be tested by watching Highway Builder sneak aligning.

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
