### PR TITLE
If Baritone is paused, then InfinityMiner doesn't put the mending pickaxe in the player's hand

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/InfinityMiner.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/InfinityMiner.java
@@ -142,6 +142,10 @@ public class InfinityMiner extends Module {
             return;
         }
 
+        if (!isBaritoneNotPaused()) {
+            return;
+        }
+
         if (!findPickaxe()) {
             error("Could not find a usable mending pickaxe.");
             toggle();
@@ -172,7 +176,7 @@ public class InfinityMiner extends Module {
                 baritoneSettings.mineScanDroppedItems.value = false;
                 mineRepairBlocks();
                 return;
-            }
+            }   
 
             if (isBaritoneNotMining()) mineTargetBlocks();
         }
@@ -182,6 +186,10 @@ public class InfinityMiner extends Module {
         ItemStack itemStack = mc.player.getMainHandStack();
         double toolPercentage = ((itemStack.getMaxDamage() - itemStack.getDamage()) * 100f) / (float) itemStack.getMaxDamage();
         return !(toolPercentage > startMining.get() || (toolPercentage > startRepairing.get() && !repairing));
+    }
+
+    private boolean isBaritoneNotPaused() {
+        return baritone.getPathingControlManager().mostRecentInControl().isEmpty();
     }
 
     private boolean findPickaxe() {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/InfinityMiner.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/InfinityMiner.java
@@ -81,13 +81,6 @@ public class InfinityMiner extends Module {
         .build()
     );
 
-    public final Setting<Boolean> stopPrevMineScanDroppedItems = sgGeneral.add(new BoolSetting.Builder()
-        .name("stop-prev-mine-scan-dropped-items")
-        .description("Will stop the mine scan dropped items setting when reparining.")
-        .defaultValue(true)
-        .build()
-    );
-
     // When Full
 
     public final Setting<Boolean> walkHome = sgWhenFull.add(new BoolSetting.Builder()
@@ -165,9 +158,7 @@ public class InfinityMiner extends Module {
             if (!needsRepair()) {
                 warning("Finished repairing, going back to mining.");
                 repairing = false;
-                if (stopPrevMineScanDroppedItems.get()) {
-                    baritoneSettings.mineScanDroppedItems.value = false;
-                }
+                baritoneSettings.mineScanDroppedItems.value = true;
                 mineTargetBlocks();
                 return;
             }
@@ -178,9 +169,7 @@ public class InfinityMiner extends Module {
             if (needsRepair()) {
                 warning("Pickaxe needs repair, beginning repair process");
                 repairing = true;
-                if (stopPrevMineScanDroppedItems.get()) {
-                    baritoneSettings.mineScanDroppedItems.value = false;
-                }
+                baritoneSettings.mineScanDroppedItems.value = false;
                 mineRepairBlocks();
                 return;
             }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/InfinityMiner.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/InfinityMiner.java
@@ -37,6 +37,7 @@ import java.util.function.Predicate;
 public class InfinityMiner extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
     private final SettingGroup sgWhenFull = settings.createGroup("When Full");
+    private int tickCounter = 0; // Counter to track ticks
 
     // General
 
@@ -125,6 +126,7 @@ public class InfinityMiner extends Module {
 
     @EventHandler
     private void onTick(TickEvent.Post event) {
+        tickCounter++;
         if (isFull()) {
             if (walkHome.get()) {
                 if (isBaritoneNotWalking()) {
@@ -142,8 +144,11 @@ public class InfinityMiner extends Module {
             return;
         }
 
-        if (!isBaritoneNotPaused()) {
-            return;
+        if (tickCounter > 19) {
+            tickCounter = 0;
+                if (!isBaritoneNotPaused()) {
+                    return;
+            }
         }
 
         if (!findPickaxe()) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/InfinityMiner.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/InfinityMiner.java
@@ -38,6 +38,7 @@ public class InfinityMiner extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
     private final SettingGroup sgWhenFull = settings.createGroup("When Full");
     private int tickCounter = 0; // Counter to track ticks
+    private boolean isBaritonePaused = false; // Boolean to track if baritone is paused
 
     // General
 
@@ -147,8 +148,14 @@ public class InfinityMiner extends Module {
         if (tickCounter > 19) {
             tickCounter = 0;
                 if (!isBaritoneNotPaused()) {
-                    return;
+                    isBaritonePaused = true;
+            } else {
+                isBaritonePaused = false;
             }
+        }
+
+        if (isBaritonePaused) {
+            return;
         }
 
         if (!findPickaxe()) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/InfinityMiner.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/InfinityMiner.java
@@ -81,6 +81,13 @@ public class InfinityMiner extends Module {
         .build()
     );
 
+    public final Setting<Boolean> stopPrevMineScanDroppedItems = sgGeneral.add(new BoolSetting.Builder()
+        .name("stop-prev-mine-scan-dropped-items")
+        .description("Will stop the mine scan dropped items setting when reparining.")
+        .defaultValue(true)
+        .build()
+    );
+
     // When Full
 
     public final Setting<Boolean> walkHome = sgWhenFull.add(new BoolSetting.Builder()
@@ -158,6 +165,9 @@ public class InfinityMiner extends Module {
             if (!needsRepair()) {
                 warning("Finished repairing, going back to mining.");
                 repairing = false;
+                if (stopPrevMineScanDroppedItems.get()) {
+                    baritoneSettings.mineScanDroppedItems.value = false;
+                }
                 mineTargetBlocks();
                 return;
             }
@@ -168,6 +178,9 @@ public class InfinityMiner extends Module {
             if (needsRepair()) {
                 warning("Pickaxe needs repair, beginning repair process");
                 repairing = true;
+                if (stopPrevMineScanDroppedItems.get()) {
+                    baritoneSettings.mineScanDroppedItems.value = false;
+                }
                 mineRepairBlocks();
                 return;
             }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/InfinityMiner.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/InfinityMiner.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
- * Copyright (c) Meteor Development.
+ * Copyright (c) Meteor Development (https://github.com/MeteorDevelopment).
  */
 
 package meteordevelopment.meteorclient.systems.modules.world;
@@ -37,8 +37,8 @@ import java.util.function.Predicate;
 public class InfinityMiner extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
     private final SettingGroup sgWhenFull = settings.createGroup("When Full");
-    private int tickCounter = 0; // Counter to track ticks
-    private boolean isBaritonePaused = false; // Boolean to track if baritone is paused
+    private int tickCounter = 0;
+    private boolean isBaritonePaused = false;
 
     // General
 
@@ -128,6 +128,26 @@ public class InfinityMiner extends Module {
     @EventHandler
     private void onTick(TickEvent.Post event) {
         tickCounter++;
+
+        // Every 20 ticks, check if Baritone is paused
+        if (tickCounter >= 20) {
+            tickCounter = 0;
+
+            // Check if Baritone is paused
+            if (isBaritoneNotPaused()) {
+                isBaritonePaused = false; // Continue processing if Baritone is unpaused
+            } else {
+                isBaritonePaused = true; // Set flag to true if Baritone is paused
+                return; // Skip the rest of the method if Baritone is paused
+            }
+        }
+
+        // If Baritone is paused, return early to prevent further actions
+        if (isBaritonePaused) {
+            return;
+        }
+
+        // Rest of the logic continues if Baritone is not paused
         if (isFull()) {
             if (walkHome.get()) {
                 if (isBaritoneNotWalking()) {
@@ -142,19 +162,6 @@ public class InfinityMiner extends Module {
                 toggle();
             }
 
-            return;
-        }
-
-        if (tickCounter > 19) {
-            tickCounter = 0;
-                if (!isBaritoneNotPaused()) {
-                    isBaritonePaused = false;
-            } else {
-                isBaritonePaused = true;
-            }
-        }
-
-        if (isBaritonePaused) {
             return;
         }
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/InfinityMiner.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/InfinityMiner.java
@@ -148,9 +148,9 @@ public class InfinityMiner extends Module {
         if (tickCounter > 19) {
             tickCounter = 0;
                 if (!isBaritoneNotPaused()) {
-                    isBaritonePaused = true;
+                    isBaritonePaused = false;
             } else {
-                isBaritonePaused = false;
+                isBaritonePaused = true;
             }
         }
 
@@ -181,6 +181,7 @@ public class InfinityMiner extends Module {
 
             if (isBaritoneNotMining()) mineRepairBlocks();
         }
+        
         else {
             if (needsRepair()) {
                 warning("Pickaxe needs repair, beginning repair process");


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

When using InfinityMiner, if Baritone is paused by the user or by another module like AutoEat or AutoGap, InfinityMiner will, at each tick, put the mending pickaxe in the player's hand, which prevents the AutoEat or AutoGap module from functioning as intended while Baritone is paused.

It check every 20 tick because baritone dont seem to like being asked every tick if its paused or not.

## Related issues
None

# How Has This Been Tested?

By using InfinityMiner, AutoGap or AutoEat will be enabled to see if it eats correctly.

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
