### PR TITLE
Update Pitch40 to more efficient angles

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFly.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFly.java
@@ -183,9 +183,9 @@ public class ElytraFly extends Module {
     public final Setting<Double> pitch40rotationSpeed = sgGeneral.add(new DoubleSetting.Builder()
         .name("pitch40-rotate-speed")
         .description("The speed for pitch rotation (degrees per tick)")
-        .defaultValue(4)
+        .defaultValue(15)
         .min(1)
-        .sliderMax(6)
+        .sliderMax(20)
         .visible(() -> flightMode.get() == ElytraFlightModes.Pitch40)
         .build()
     );

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/modes/Pitch40.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/modes/Pitch40.java
@@ -11,7 +11,7 @@ import meteordevelopment.meteorclient.systems.modules.movement.elytrafly.ElytraF
 
 public class Pitch40 extends ElytraFlightMode {
     private boolean pitchingDown = true;
-    private int pitch;
+    private float pitch;
 
     public Pitch40() {
         super(ElytraFlightModes.Pitch40);
@@ -22,17 +22,35 @@ public class Pitch40 extends ElytraFlightMode {
         if (mc.player.getY() < elytraFly.pitch40upperBounds.get()) {
             elytraFly.error("Player must be above upper bounds!");
             elytraFly.toggle();
+        } else if (mc.player.getY() - 40 > elytraFly.pitch40lowerBounds.get()) {
+            elytraFly.error("Player must be at least 40 blocks above the lower bounds!");
+            elytraFly.toggle();
         }
 
-        pitch = 40;
+        pitch = 32.0F;
     }
 
     @Override
     public void onDeactivate() {}
 
+    /**
+     * Create a random pitch around `pitch` that is within +/- bound/2
+     * @param pitch the input pitch
+     * @param bound the amount of variance
+     * @return the changed pitch
+     */
+    private float randPitch(float pitch, float bound) {
+        return (float) (pitch + (bound * (Math.random() - 0.5)));
+    }
+
     @Override
     public void onTick() {
         super.onTick();
+
+        /*
+        When descending, look at 32-33 deg
+        When ascending, look up at -49 at 10*pitch speed, then lower at 0.5 deg/tick until at 32-33
+         */
 
         if (pitchingDown && mc.player.getY() <= elytraFly.pitch40lowerBounds.get()) {
             pitchingDown = false;
@@ -42,15 +60,16 @@ public class Pitch40 extends ElytraFlightMode {
         }
 
         // Pitch upwards
-        if (!pitchingDown && mc.player.getPitch() > -40) {
-            pitch -= elytraFly.pitch40rotationSpeed.get();
+        if (!pitchingDown) {
+            pitch -= randPitch(elytraFly.pitch40rotationSpeed.get().floatValue(), 3.0F);
 
-            if (pitch < -40) pitch = -40;
+            if (pitch < -49.0) {
+                pitch = -49.0F;
+                pitchingDown = true;
+            }
         // Pitch downwards
-        } else if (pitchingDown && mc.player.getPitch() < 40) {
-            pitch += elytraFly.pitch40rotationSpeed.get();
-
-            if (pitch > 40) pitch = 40;
+        } else if (pitch < 32.0) {
+            pitch += randPitch(0.5F, 0.125F);
         }
 
         mc.player.setPitch(pitch);

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/modes/Pitch40.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/modes/Pitch40.java
@@ -22,16 +22,13 @@ public class Pitch40 extends ElytraFlightMode {
         if (mc.player.getY() < elytraFly.pitch40upperBounds.get()) {
             elytraFly.error("Player must be above upper bounds!");
             elytraFly.toggle();
-        } else if (mc.player.getY() - 40 > elytraFly.pitch40lowerBounds.get()) {
+        } else if (mc.player.getY() - 40 < elytraFly.pitch40lowerBounds.get()) {
             elytraFly.error("Player must be at least 40 blocks above the lower bounds!");
             elytraFly.toggle();
         }
 
         pitch = 32.0F;
     }
-
-    @Override
-    public void onDeactivate() {}
 
     /**
      * Create a random pitch around `pitch` that is within +/- bound/2


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature

## Description

When Pitch40 mode is selected in ElytraFly, the player will now pitch down to 32-33 deg then after hitting the lower bound, will pitch at the supplied rate to -49 deg. Finally they will pitch down at roughly 0.5 deg/tick until looking at 32-33 deg. These angles come from the findings of [this video](https://www.youtube.com/watch?v=F69K1-cMaf8&t=187s) where said angles are much more optimal than the standard 40/40 profile. Ideally this will net ~3 block of max altitude gain per cycle until ~90 block above the lower bound.

# How Has This Been Tested?

In testing in a default superflat single-player world, where the player starts on a tower to y=13, pitch rate of 13, lower bound of -40 and upper bound of 0, the maximum height I achieved was roughly y=51.

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
