### PR TITLE
Allow for addons to add their systems

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/Systems.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/Systems.java
@@ -56,7 +56,7 @@ public class Systems {
         MeteorClient.EVENT_BUS.subscribe(Systems.class);
     }
 
-    private static System<?> add(System<?> system) {
+    public static System<?> add(System<?> system) {
         systems.put(system.getClass(), system);
         MeteorClient.EVENT_BUS.subscribe(system);
         system.init();


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Imagine an addon wanting to store some global info (like hashed seeds of dimensions that got discovered in runtime), adding system to store that kind of info that would be "managed" by meteor would be amazing.

## Related issues

Did not search

# How Has This Been Tested?

It builds

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas. (none)
- [ ] I have tested the code in both development and production environments.
