### PR TITLE
Infinity miner ignore full inventory option

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/InfinityMiner.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/InfinityMiner.java
@@ -83,6 +83,13 @@ public class InfinityMiner extends Module {
 
     // When Full
 
+    public final Setting<Boolean> ignoreFull = sgWhenFull.add(new BoolSetting.Builder()
+        .name("ignore-full-inventory")
+        .description("Continues mining even if your inventory is full. Makes both options below redundant if enabled.")
+        .defaultValue(false)
+        .build()
+    );
+
     public final Setting<Boolean> walkHome = sgWhenFull.add(new BoolSetting.Builder()
         .name("walk-home")
         .description("Will walk 'home' when your inventory is full.")
@@ -243,6 +250,6 @@ public class InfinityMiner extends Module {
             }
         }
 
-        return true;
+        return !ignoreFull.get();
     }
 }


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Adds a toggle in Infinity Miner to continue mining even if the inventory is full.

## Related issues

Infinity miner has no option to continue even when full.

# How Has This Been Tested?

Tested on multiplayer and singleplayer.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [NA] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
