### PR TITLE
Add Quick trade module

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/MerchantScreenHandlerAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MerchantScreenHandlerAccessor.java
@@ -1,0 +1,19 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.mixin;
+
+import net.minecraft.screen.MerchantScreenHandler;
+import net.minecraft.village.Merchant;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(MerchantScreenHandler.class)
+public interface MerchantScreenHandlerAccessor {
+
+    @Accessor
+    Merchant getMerchant();
+
+}

--- a/src/main/java/meteordevelopment/meteorclient/mixin/MerchantScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MerchantScreenMixin.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.mixin;
+
+import meteordevelopment.meteorclient.systems.modules.Modules;
+import meteordevelopment.meteorclient.systems.modules.world.QuickTrade;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.client.gui.screen.ingame.MerchantScreen;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.screen.MerchantScreenHandler;
+import net.minecraft.text.Text;
+import net.minecraft.village.TradeOffer;
+import net.minecraft.village.TradeOfferList;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MerchantScreen.class)
+public abstract class MerchantScreenMixin extends HandledScreen<MerchantScreenHandler> {
+    @Shadow
+    private int selectedIndex;
+
+    public MerchantScreenMixin(MerchantScreenHandler handler, PlayerInventory inventory, Text title) {
+        super(handler, inventory, title);
+    }
+
+    @Inject(
+        method = "syncRecipeIndex",
+        at = @At("TAIL")
+    )
+    private void syncRecipeIndex(CallbackInfo ci) {
+        // Called when a new trade is selected, server is notified at end of call
+
+        QuickTrade module = Modules.get().get(QuickTrade.class);
+
+        if (!module.isActive()) {
+            return;
+        }
+
+        if (!module.modifier.get().isPressed()) {
+            return;
+        }
+
+
+        TradeOfferList tradeOfferList = this.handler.getRecipes();
+        if (tradeOfferList.size() < selectedIndex) return;
+
+        TradeOffer selectedOffer = tradeOfferList.get(selectedIndex);
+        MerchantScreenHandler handler = getScreenHandler();
+        module.tradeUntilDoneOrEmpty(selectedOffer, handler, this.selectedIndex);
+    }
+}
+

--- a/src/main/java/meteordevelopment/meteorclient/mixin/MerchantScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MerchantScreenMixin.java
@@ -8,7 +8,6 @@ package meteordevelopment.meteorclient.mixin;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.world.QuickTrade;
 import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.client.gui.screen.ingame.MerchantScreen;
 import net.minecraft.entity.player.PlayerInventory;
@@ -29,6 +28,30 @@ public abstract class MerchantScreenMixin extends HandledScreen<MerchantScreenHa
 
     public MerchantScreenMixin(MerchantScreenHandler handler, PlayerInventory inventory, Text title) {
         super(handler, inventory, title);
+    }
+
+    @Inject(
+        method = "render",
+        at = @At("TAIL")
+    )
+    private void render(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+
+        if (client == null) {
+            return;
+        }
+
+        QuickTrade module = Modules.get().get(QuickTrade.class);
+
+
+        if (!module.isActive()) {
+            return;
+        }
+
+        if (!module.modifier.get().isPressed()) {
+            return;
+        }
+
+        context.drawCenteredTextWithShadow(client.textRenderer, "Select a trade on the left to quick-trade", width / 2, height / 2 + 100, 0xFFFFFFFF);
     }
 
     @Inject(

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
@@ -565,6 +565,7 @@ public class Modules extends System<Modules> {
         add(new SpawnProofer());
         add(new Timer());
         add(new VeinMiner());
+        add(new QuickTrade());
 
         if (BaritoneUtils.IS_AVAILABLE) {
             add(new Excavator());

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/QuickTrade.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/QuickTrade.java
@@ -21,7 +21,6 @@ import net.minecraft.screen.MerchantScreenHandler;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.screen.slot.SlotActionType;
 import net.minecraft.village.TradeOffer;
-import org.lwjgl.glfw.GLFW;
 
 import java.util.Collections;
 import java.util.LinkedList;

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/QuickTrade.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/QuickTrade.java
@@ -35,7 +35,7 @@ public class QuickTrade extends Module {
     public final Setting<Keybind> modifier = sgGeneral.add(new KeybindSetting.Builder()
         .name("Activation key")
         .description("Key to press to perform trade until exhausted.")
-        .defaultValue(Keybind.fromButton(GLFW.GLFW_KEY_LEFT_CONTROL))
+        .defaultValue(Keybind.none())
         .build()
     );
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/QuickTrade.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/QuickTrade.java
@@ -1,0 +1,128 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.systems.modules.world;
+
+import meteordevelopment.meteorclient.events.world.TickEvent;
+import meteordevelopment.meteorclient.settings.KeybindSetting;
+import meteordevelopment.meteorclient.settings.Setting;
+import meteordevelopment.meteorclient.settings.SettingGroup;
+import meteordevelopment.meteorclient.systems.modules.Categories;
+import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.meteorclient.utils.misc.Keybind;
+import meteordevelopment.orbit.EventHandler;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.packet.c2s.play.SelectMerchantTradeC2SPacket;
+import net.minecraft.screen.MerchantScreenHandler;
+import net.minecraft.screen.slot.Slot;
+import net.minecraft.screen.slot.SlotActionType;
+import net.minecraft.village.TradeOffer;
+import org.lwjgl.glfw.GLFW;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class QuickTrade extends Module {
+    private final List<Supplier<Boolean>> tasks = Collections.synchronizedList(new LinkedList<>());
+    private final SettingGroup sgGeneral = settings.getDefaultGroup();
+
+    public final Setting<Keybind> modifier = sgGeneral.add(new KeybindSetting.Builder()
+        .name("Activation key")
+        .description("Key to press to perform trade until exhausted.")
+        .defaultValue(Keybind.fromButton(GLFW.GLFW_KEY_LEFT_CONTROL))
+        .build()
+    );
+
+    public QuickTrade() {
+        super(Categories.World, "quick-trade", "Quickly perform trades with villagers.");
+    }
+
+    @EventHandler
+    private void onTick(TickEvent.Pre event) {
+        synchronized (tasks) {
+            tasks.removeIf(task -> !task.get());
+        }
+    }
+
+    private void runUntilFalse(Supplier<Boolean> task) {
+        tasks.add(task);
+    }
+
+    public void tradeUntilDoneOrEmpty(TradeOffer selectedOffer, MerchantScreenHandler handler, int selectedIndex) {
+        final MinecraftClient client = MinecraftClient.getInstance();
+
+        if (client.interactionManager == null) {
+            error("Client interaction manager is null!");
+            return;
+        }
+
+        Slot inSlot0 = handler.getSlot(0);
+        Slot inSlot1 = handler.getSlot(1);
+        Slot outputSlot = handler.getSlot(2);
+        runUntilFalse(() -> {
+            // If player is null or they changed screen
+            if (client.player == null) {
+                error("Player is null, stopping trading.");
+                return false;
+            }
+
+            if (client.player.currentScreenHandler != handler) {
+                error("Screen is closed, stopping trading.");
+                return false;
+            }
+
+            if (client.getNetworkHandler() == null) {
+                error("Network handler is null, stopping trading.");
+                return false;
+            }
+
+            // If there is an item in the trade slot(s) already, then shift click or drop them
+            if (!inSlot0.getStack().isEmpty()) {
+                client.interactionManager.clickSlot(handler.syncId, inSlot0.id, 1, SlotActionType.QUICK_MOVE, client.player);
+                client.interactionManager.clickSlot(handler.syncId, inSlot0.id, 1, SlotActionType.THROW, client.player);
+            }
+
+            if (!inSlot1.getStack().isEmpty()) {
+                client.interactionManager.clickSlot(handler.syncId, inSlot1.id, 1, SlotActionType.QUICK_MOVE, client.player);
+                client.interactionManager.clickSlot(handler.syncId, inSlot1.id, 1, SlotActionType.THROW, client.player);
+            }
+
+            // Refresh items
+            handler.setRecipeIndex(selectedIndex);
+            handler.switchTo(selectedIndex);
+
+            client.getNetworkHandler().sendPacket(new SelectMerchantTradeC2SPacket(selectedIndex));
+
+            // Out of materials OR trade is out of stock
+
+            // todo auto-convert emerald blocks if we're out of them
+            // todo auto-trade without clicking a trade (preset trades?)
+            boolean shouldStopTrading = !selectedOffer.matchesBuyItems(
+                handler.slots.get(0).getStack(),
+                handler.slots.get(1).getStack())
+                || selectedOffer.isDisabled();
+
+            if (shouldStopTrading) {
+                return false;
+            }
+
+            if (hasSpace(client.player.getInventory(), selectedOffer.getSellItem())) {
+                client.interactionManager.clickSlot(handler.syncId, outputSlot.id, 0, SlotActionType.QUICK_MOVE, client.player);
+            } else {
+                client.interactionManager.clickSlot(handler.syncId, outputSlot.id, 0, SlotActionType.THROW, client.player);
+            }
+
+            return true;
+        });
+    }
+
+    public boolean hasSpace(PlayerInventory inv, ItemStack outStack) {
+        return outStack.isEmpty() || inv.getEmptySlot() >= 0 || inv.getOccupiedSlotWithRoomForStack(outStack) >= 0;
+    }
+}

--- a/src/main/resources/meteor-client.mixins.json
+++ b/src/main/resources/meteor-client.mixins.json
@@ -126,6 +126,8 @@
     "LivingEntityRendererMixin",
     "MapRendererMixin",
     "MapTextureManagerAccessor",
+    "MerchantScreenMixin",
+    "MerchantScreenHandlerAccessor",
     "MessageHandlerMixin",
     "MinecraftClientAccessor",
     "MinecraftClientMixin",


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

This change adds a new module to make trading in large quantites easier. By enabling the module and specifying a hotkey, you can trade with a villager until you run out of items. You may also disable the dropping of emeralds of those items if you wish to. (If your inventory is full, then items are dropped by default)

## Related issues

Have previously suggested this and had some support on it.

https://github.com/MeteorDevelopment/meteor-client/issues/4462

# How Has This Been Tested?

Yes - tested in production servers and in singleplayer. 
(Videos are too large to send here but can produce another if absolutely necessary)

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
