### PR TITLE
Add keybind display option to Active Modules HUD (#5245)

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ActiveModulesHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ActiveModulesHud.java
@@ -45,6 +45,13 @@ public class ActiveModulesHud extends HudElement {
         .build()
     );
 
+    private final Setting<Boolean> showKeybind = sgGeneral.add(new BoolSetting.Builder()
+        .name("show-keybind")
+        .description("Shows the module's keybind next to its name.")
+        .defaultValue(false)
+        .build()
+    );
+
     private final Setting<Boolean> shadow = sgGeneral.add(new BoolSetting.Builder()
         .name("shadow")
         .description("Renders shadow behind text.")
@@ -273,16 +280,22 @@ public class ActiveModulesHud extends HudElement {
         double textHeight = renderer.textHeight(shadow.get(), getScale());
         double textLength = renderer.textWidth(module.title, shadow.get(), getScale());
 
-        double lineStartY = y;
-        double lineHeight = textHeight;
+        if (showKeybind.get() && module.keybind != null && module.keybind.isSet()) {
+            String keybindStr = " [" + module.keybind.toString() + "]";
+            renderer.text(keybindStr, x + textLength, y, moduleInfoColor.get(), shadow.get(), getScale());
+            textLength += renderer.textWidth(keybindStr, shadow.get(), getScale());
+        }
 
         if (activeInfo.get()) {
             String info = module.getInfoString();
             if (info != null) {
-                renderer.text(info, x + emptySpace + textLength, y, moduleInfoColor.get(), shadow.get(), getScale());
+                renderer.text(info, x + textLength + emptySpace, y, moduleInfoColor.get(), shadow.get(), getScale());
                 textLength += emptySpace + renderer.textWidth(info, shadow.get(), getScale());
             }
         }
+
+        double lineStartY = y;
+        double lineHeight = textHeight;
 
         if (outlines.get()) {
             if (index == 0) { // Render top quad for first item in list
@@ -329,6 +342,10 @@ public class ActiveModulesHud extends HudElement {
 
     private double getModuleWidth(HudRenderer renderer, Module module) {
         double width = renderer.textWidth(module.title, shadow.get(), getScale());
+
+        if (showKeybind.get() && module.keybind != null && module.keybind.isSet()) {
+            width += renderer.textWidth(" [" + module.keybind.toString() + "]", shadow.get(), getScale());
+        }
 
         if (activeInfo.get()) {
             String info = module.getInfoString();

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ActiveModulesHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ActiveModulesHud.java
@@ -280,8 +280,8 @@ public class ActiveModulesHud extends HudElement {
         double textHeight = renderer.textHeight(shadow.get(), getScale());
         double textLength = renderer.textWidth(module.title, shadow.get(), getScale());
 
-        if (showKeybind.get() && module.keybind != null && module.keybind.isSet()) {
-            String keybindStr = " [" + module.keybind.toString() + "]";
+        if (showKeybind.get() && module.keybind.isSet()) {
+            String keybindStr = " [" + module.keybind + "]";
             renderer.text(keybindStr, x + textLength, y, moduleInfoColor.get(), shadow.get(), getScale());
             textLength += renderer.textWidth(keybindStr, shadow.get(), getScale());
         }
@@ -305,14 +305,14 @@ public class ActiveModulesHud extends HudElement {
                 renderer.quad(x - 2 - outlineWidth.get(), lineStartY - outlineWidth.get(),
                     textLength + 4 + 2 * outlineWidth.get(),
                     outlineWidth.get(), prevColor, prevColor, color, color);
-            } else { // Inbetweens are rendered above the current line so don't need for the top
+            } else { // In-between quads are rendered above the current line so don't need for the top
                 renderer.quad(Math.min(prevX, x) - 2 - outlineWidth.get(), Math.max(prevX, x) == x ? y : y - outlineWidth.get(),
                     (Math.max(prevX, x) - 2) - (Math.min(prevX, x) - 2 - outlineWidth.get()), outlineWidth.get(),
-                    prevColor, prevColor, color, color); // Left inbetween quad
+                    prevColor, prevColor, color, color); // Left in-between quad
 
                 renderer.quad(Math.min(prevX + prevTextLength, x + textLength) + 2, Math.min(prevX + prevTextLength, x + textLength) == x + textLength ? y : y - outlineWidth.get(),
                     (Math.max(prevX + prevTextLength, x + textLength) + 2 + outlineWidth.get()) - (Math.min(prevX + prevTextLength, x + textLength) + 2), outlineWidth.get(),
-                    prevColor, prevColor, color, color); // Right inbetween quad
+                    prevColor, prevColor, color, color); // Right in-between quad
             }
 
             if (index == modules.size() - 1) { // Render bottom quad for last item in list
@@ -343,8 +343,8 @@ public class ActiveModulesHud extends HudElement {
     private double getModuleWidth(HudRenderer renderer, Module module) {
         double width = renderer.textWidth(module.title, shadow.get(), getScale());
 
-        if (showKeybind.get() && module.keybind != null && module.keybind.isSet()) {
-            width += renderer.textWidth(" [" + module.keybind.toString() + "]", shadow.get(), getScale());
+        if (showKeybind.get() && module.keybind.isSet()) {
+            width += renderer.textWidth(" [" + module.keybind + "]", shadow.get(), getScale());
         }
 
         if (activeInfo.get()) {


### PR DESCRIPTION
Closes #5245

Added a new "Show Keybind" option to the Active Modules HUD element that displays module keybinds in brackets next to module names.

Changes:
- Added a new boolean setting to control keybind display
- When enabled, shows keybinds in brackets next to module names (e.g., "Speed [R]")
- Maintains existing HUD functionality while adding this optional feature