### PR TITLE
Allow hoes and Fortune tools for nether warts (#5243)

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ActiveModulesHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ActiveModulesHud.java
@@ -45,6 +45,13 @@ public class ActiveModulesHud extends HudElement {
         .build()
     );
 
+    private final Setting<Boolean> showKeybind = sgGeneral.add(new BoolSetting.Builder()
+        .name("show-keybind")
+        .description("Shows the module's keybind next to its name.")
+        .defaultValue(false)
+        .build()
+    );
+
     private final Setting<Boolean> shadow = sgGeneral.add(new BoolSetting.Builder()
         .name("shadow")
         .description("Renders shadow behind text.")
@@ -273,16 +280,22 @@ public class ActiveModulesHud extends HudElement {
         double textHeight = renderer.textHeight(shadow.get(), getScale());
         double textLength = renderer.textWidth(module.title, shadow.get(), getScale());
 
-        double lineStartY = y;
-        double lineHeight = textHeight;
+        if (showKeybind.get() && module.keybind != null && module.keybind.isSet()) {
+            String keybindStr = " [" + module.keybind.toString() + "]";
+            renderer.text(keybindStr, x + textLength, y, moduleInfoColor.get(), shadow.get(), getScale());
+            textLength += renderer.textWidth(keybindStr, shadow.get(), getScale());
+        }
 
         if (activeInfo.get()) {
             String info = module.getInfoString();
             if (info != null) {
-                renderer.text(info, x + emptySpace + textLength, y, moduleInfoColor.get(), shadow.get(), getScale());
+                renderer.text(info, x + textLength + emptySpace, y, moduleInfoColor.get(), shadow.get(), getScale());
                 textLength += emptySpace + renderer.textWidth(info, shadow.get(), getScale());
             }
         }
+
+        double lineStartY = y;
+        double lineHeight = textHeight;
 
         if (outlines.get()) {
             if (index == 0) { // Render top quad for first item in list
@@ -329,6 +342,10 @@ public class ActiveModulesHud extends HudElement {
 
     private double getModuleWidth(HudRenderer renderer, Module module) {
         double width = renderer.textWidth(module.title, shadow.get(), getScale());
+
+        if (showKeybind.get() && module.keybind != null && module.keybind.isSet()) {
+            width += renderer.textWidth(" [" + module.keybind.toString() + "]", shadow.get(), getScale());
+        }
 
         if (activeInfo.get()) {
             String info = module.getInfoString();

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoTool.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoTool.java
@@ -191,7 +191,10 @@ public class AutoTool extends Module {
 
     public static double getScore(ItemStack itemStack, BlockState state, boolean silkTouchEnderChest, boolean fortuneOre, EnchantPreference enchantPreference, Predicate<ItemStack> good) {
         if (!good.test(itemStack) || !isTool(itemStack)) return -1;
-        if (!itemStack.isSuitableFor(state) && !(itemStack.getItem() instanceof SwordItem && (state.getBlock() instanceof BambooBlock || state.getBlock() instanceof BambooShootBlock)) && !(itemStack.getItem() instanceof ShearsItem && state.getBlock() instanceof LeavesBlock || state.isIn(BlockTags.WOOL))) return -1;
+        if (!itemStack.isSuitableFor(state) && 
+            !(itemStack.getItem() instanceof SwordItem && (state.getBlock() instanceof BambooBlock || state.getBlock() instanceof BambooShootBlock)) && 
+            !(itemStack.getItem() instanceof ShearsItem && state.getBlock() instanceof LeavesBlock || state.isIn(BlockTags.WOOL)) &&
+            !(itemStack.getItem() instanceof HoeItem && state.getBlock() == Blocks.NETHER_WART)) return -1;
 
         if (silkTouchEnderChest
             && state.getBlock() == Blocks.ENDER_CHEST
@@ -218,11 +221,14 @@ public class AutoTool extends Module {
         if (itemStack.getItem() instanceof SwordItem item && (state.getBlock() instanceof BambooBlock || state.getBlock() instanceof BambooShootBlock))
             score += 9000 + (item.getComponents().get(DataComponentTypes.TOOL).getSpeed(state) * 1000);
 
+        if (itemStack.getItem() instanceof HoeItem && state.getBlock() == Blocks.NETHER_WART)
+            score += 9000;
+
         return score;
     }
 
     public static boolean isTool(Item item) {
-        return item instanceof MiningToolItem || item instanceof ShearsItem;
+        return item instanceof MiningToolItem || item instanceof ShearsItem || item instanceof HoeItem;
     }
     public static boolean isTool(ItemStack itemStack) {
         return isTool(itemStack.getItem());
@@ -231,7 +237,7 @@ public class AutoTool extends Module {
 
     private static boolean isFortunable(Block block) {
         if (block == Blocks.ANCIENT_DEBRIS) return false;
-        return Xray.ORES.contains(block) || block instanceof CropBlock;
+        return Xray.ORES.contains(block) || block instanceof CropBlock || block == Blocks.NETHER_WART;
     }
 
     public enum EnchantPreference {


### PR DESCRIPTION
     Fixes #5243
     
     - Added support for hoes to be used on nether warts
     - Added nether warts to the list of fortunable blocks
     - Added bonus score for hoes when mining nether warts