### PR TITLE
More Hud Settings

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ActiveModulesHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ActiveModulesHud.java
@@ -150,7 +150,7 @@ public class ActiveModulesHud extends HudElement {
 
     private final Setting<Boolean> customScale = sgScale.add(new BoolSetting.Builder()
         .name("custom-scale")
-        .description("Applies custom text scale rather than the global one.")
+        .description("Applies a custom scale to this hud element.")
         .defaultValue(false)
         .build()
     );

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ArmorHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ArmorHud.java
@@ -200,7 +200,7 @@ public class ArmorHud extends HudElement {
     }
 
     private float getScale() {
-        return customScale.get() ? scale.get().floatValue() : 2.0f;
+        return customScale.get() ? scale.get().floatValue() : scale.getDefaultValue().floatValue();
     }
 
     public enum Durability {

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ArmorHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ArmorHud.java
@@ -22,6 +22,7 @@ public class ArmorHud extends HudElement {
 
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
     private final SettingGroup sgDurability = settings.createGroup("Durability");
+    private final SettingGroup sgScale = settings.createGroup("Scale");
     private final SettingGroup sgBackground = settings.createGroup("Background");
 
     // General
@@ -38,16 +39,6 @@ public class ArmorHud extends HudElement {
         .name("flip-order")
         .description("Flips the order of armor items.")
         .defaultValue(true)
-        .build()
-    );
-
-    private final Setting<Double> scale = sgGeneral.add(new DoubleSetting.Builder()
-        .name("scale")
-        .description("The scale.")
-        .defaultValue(2)
-        .onChanged(aDouble -> calculateSize())
-        .min(0.5)
-        .sliderRange(0.5, 5)
         .build()
     );
 
@@ -84,6 +75,26 @@ public class ArmorHud extends HudElement {
         .build()
     );
 
+    // Scale
+
+    private final Setting<Boolean> customScale = sgScale.add(new BoolSetting.Builder()
+        .name("custom-scale")
+        .description("Applies custom text scale rather than the global one.")
+        .defaultValue(false)
+        .build()
+    );
+
+    private final Setting<Double> scale = sgScale.add(new DoubleSetting.Builder()
+        .name("scale")
+        .description("Custom scale.")
+        .visible(customScale::get)
+        .defaultValue(2)
+        .onChanged(aDouble -> calculateSize())
+        .min(0.5)
+        .sliderRange(0.5, 3)
+        .build()
+    );
+
     // Background
 
     private final Setting<Boolean> background = sgBackground.add(new BoolSetting.Builder()
@@ -109,8 +120,9 @@ public class ArmorHud extends HudElement {
 
     private void calculateSize() {
         switch (orientation.get()) {
-            case Horizontal -> setSize(16 * scale.get() * 4 + 2 * 4 * scale.get(), 16 * scale.get());
-            case Vertical -> setSize(16 * scale.get(), 16 * scale.get() * 4 + 2 * 4 * scale.get());
+            // Four item stacks plus
+            case Horizontal -> setSize((16 * 4 + 2 * 4) * getScale(), 16 * getScale());
+            case Vertical -> setSize(16 * getScale(), (16 * 4 + 2 * 4) * getScale());
         }
     }
 
@@ -142,13 +154,13 @@ public class ArmorHud extends HudElement {
 
                 if (orientation.get() == Orientation.Vertical) {
                     armorX = x;
-                    armorY = y + position * 18 * scale.get();
+                    armorY = y + position * 18 * getScale();
                 } else {
-                    armorX = x + position * 18 * scale.get();
+                    armorX = x + position * 18 * getScale();
                     armorY = y;
                 }
 
-                renderer.item(itemStack, (int) armorX, (int) armorY, scale.get().floatValue(), (itemStack.isDamageable() && durability.get() == Durability.Bar));
+                renderer.item(itemStack, (int) armorX, (int) armorY, getScale(), (itemStack.isDamageable() && durability.get() == Durability.Bar));
 
                 if (itemStack.isDamageable() && durability.get() != Durability.Bar && durability.get() != Durability.None) {
                     String message = switch (durability.get()) {
@@ -160,10 +172,10 @@ public class ArmorHud extends HudElement {
                     double messageWidth = renderer.textWidth(message);
 
                     if (orientation.get() == Orientation.Vertical) {
-                        armorX = x + 8 * scale.get() - messageWidth / 2.0;
-                        armorY = y + (18 * position * scale.get()) + (18 * scale.get() - renderer.textHeight());
+                        armorX = x + 8 * getScale() - messageWidth / 2.0;
+                        armorY = y + (18 * position * getScale()) + (18 * getScale() - renderer.textHeight());
                     } else {
-                        armorX = x + 18 * position * scale.get() + 8 * scale.get() - messageWidth / 2.0;
+                        armorX = x + 18 * position * getScale() + 8 * getScale() - messageWidth / 2.0;
                         armorY = y + (getHeight() - renderer.textHeight());
                     }
 
@@ -185,6 +197,10 @@ public class ArmorHud extends HudElement {
 
         ItemStack stack = mc.player.getInventory().getArmorStack(i);
         return stack.isEmpty() && showEmpty.get() ? Items.BARRIER.getDefaultStack() : stack;
+    }
+
+    private float getScale() {
+        return customScale.get() ? scale.get().floatValue() : 2.0f;
     }
 
     public enum Durability {

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ArmorHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ArmorHud.java
@@ -79,8 +79,9 @@ public class ArmorHud extends HudElement {
 
     private final Setting<Boolean> customScale = sgScale.add(new BoolSetting.Builder()
         .name("custom-scale")
-        .description("Applies custom text scale rather than the global one.")
+        .description("Applies a custom scale to this hud element.")
         .defaultValue(false)
+        .onChanged(aBoolean -> calculateSize())
         .build()
     );
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CombatHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CombatHud.java
@@ -53,16 +53,12 @@ public class CombatHud extends HudElement {
     public static final HudElementInfo<CombatHud> INFO = new HudElementInfo<>(Hud.GROUP, "combat", "Displays information about your combat target.", CombatHud::new);
 
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
-
-    private final Setting<Double> scale = sgGeneral.add(new DoubleSetting.Builder()
-        .name("scale")
-        .description("The scale.")
-        .defaultValue(2)
-        .min(1)
-        .sliderRange(1, 5)
-        .onChanged(aDouble -> calculateSize())
-        .build()
-    );
+    private final SettingGroup sgEnchantments = settings.createGroup("Enchantments");
+    private final SettingGroup sgHealth = settings.createGroup("Health");
+    private final SettingGroup sgDistance = settings.createGroup("Distance");
+    private final SettingGroup sgPing = settings.createGroup("Ping");
+    private final SettingGroup sgScale = settings.createGroup("Scale");
+    private final SettingGroup sgBackground = settings.createGroup("Background");
 
     private final Setting<Double> range = sgGeneral.add(new DoubleSetting.Builder()
         .name("range")
@@ -73,42 +69,55 @@ public class CombatHud extends HudElement {
         .build()
     );
 
-    private final Setting<Boolean> displayPing = sgGeneral.add(new BoolSetting.Builder()
-        .name("ping")
-        .description("Shows the player's ping.")
-        .defaultValue(true)
+    // Health
+
+    private final Setting<SettingColor> healthColor1 = sgHealth.add(new ColorSetting.Builder()
+        .name("health-stage-1")
+        .description("The color on the left of the health gradient.")
+        .defaultValue(new SettingColor(255, 15, 15))
         .build()
     );
 
-    private final Setting<Boolean> displayDistance = sgGeneral.add(new BoolSetting.Builder()
-        .name("distance")
-        .description("Shows the distance between you and the player.")
-        .defaultValue(true)
+    private final Setting<SettingColor> healthColor2 = sgHealth.add(new ColorSetting.Builder()
+        .name("health-stage-2")
+        .description("The color in the middle of the health gradient.")
+        .defaultValue(new SettingColor(255, 150, 15))
         .build()
     );
 
-    private final Setting<Set<RegistryKey<Enchantment>>> displayedEnchantments = sgGeneral.add(new EnchantmentListSetting.Builder()
+    private final Setting<SettingColor> healthColor3 = sgHealth.add(new ColorSetting.Builder()
+        .name("health-stage-3")
+        .description("The color on the right of the health gradient.")
+        .defaultValue(new SettingColor(15, 255, 15))
+        .build()
+    );
+
+    // Enchantments
+
+    private final Setting<Set<RegistryKey<Enchantment>>> displayedEnchantments = sgEnchantments.add(new EnchantmentListSetting.Builder()
         .name("displayed-enchantments")
         .description("The enchantments that are shown on nametags.")
         .vanillaDefaults()
         .build()
     );
 
-    private final Setting<SettingColor> backgroundColor = sgGeneral.add(new ColorSetting.Builder()
-        .name("background-color")
-        .description("Color of background.")
-        .defaultValue(new SettingColor(0, 0, 0, 64))
-        .build()
-    );
-
-    private final Setting<SettingColor> enchantmentTextColor = sgGeneral.add(new ColorSetting.Builder()
+    private final Setting<SettingColor> enchantmentTextColor = sgEnchantments.add(new ColorSetting.Builder()
         .name("enchantment-color")
         .description("Color of enchantment text.")
         .defaultValue(new SettingColor(255, 255, 255))
         .build()
     );
 
-    private final Setting<SettingColor> pingColor1 = sgGeneral.add(new ColorSetting.Builder()
+    // Ping
+
+    private final Setting<Boolean> displayPing = sgPing.add(new BoolSetting.Builder()
+        .name("ping")
+        .description("Shows the player's ping.")
+        .defaultValue(true)
+        .build()
+    );
+
+    private final Setting<SettingColor> pingColor1 = sgPing.add(new ColorSetting.Builder()
         .name("ping-stage-1")
         .description("Color of ping text when under 75.")
         .defaultValue(new SettingColor(15, 255, 15))
@@ -116,7 +125,7 @@ public class CombatHud extends HudElement {
         .build()
     );
 
-    private final Setting<SettingColor> pingColor2 = sgGeneral.add(new ColorSetting.Builder()
+    private final Setting<SettingColor> pingColor2 = sgPing.add(new ColorSetting.Builder()
         .name("ping-stage-2")
         .description("Color of ping text when between 75 and 200.")
         .defaultValue(new SettingColor(255, 150, 15))
@@ -124,7 +133,7 @@ public class CombatHud extends HudElement {
         .build()
     );
 
-    private final Setting<SettingColor> pingColor3 = sgGeneral.add(new ColorSetting.Builder()
+    private final Setting<SettingColor> pingColor3 = sgPing.add(new ColorSetting.Builder()
         .name("ping-stage-3")
         .description("Color of ping text when over 200.")
         .defaultValue(new SettingColor(255, 15, 15))
@@ -132,7 +141,16 @@ public class CombatHud extends HudElement {
         .build()
     );
 
-    private final Setting<SettingColor> distColor1 = sgGeneral.add(new ColorSetting.Builder()
+    // Distance
+
+    private final Setting<Boolean> displayDistance = sgDistance.add(new BoolSetting.Builder()
+        .name("distance")
+        .description("Shows the distance between you and the player.")
+        .defaultValue(true)
+        .build()
+    );
+
+    private final Setting<SettingColor> distColor1 = sgDistance.add(new ColorSetting.Builder()
         .name("distance-stage-1")
         .description("The color when a player is within 10 blocks of you.")
         .defaultValue(new SettingColor(255, 15, 15))
@@ -140,7 +158,7 @@ public class CombatHud extends HudElement {
         .build()
     );
 
-    private final Setting<SettingColor> distColor2 = sgGeneral.add(new ColorSetting.Builder()
+    private final Setting<SettingColor> distColor2 = sgDistance.add(new ColorSetting.Builder()
         .name("distance-stage-2")
         .description("The color when a player is within 50 blocks of you.")
         .defaultValue(new SettingColor(255, 150, 15))
@@ -148,7 +166,7 @@ public class CombatHud extends HudElement {
         .build()
     );
 
-    private final Setting<SettingColor> distColor3 = sgGeneral.add(new ColorSetting.Builder()
+    private final Setting<SettingColor> distColor3 = sgDistance.add(new ColorSetting.Builder()
         .name("distance-stage-3")
         .description("The color when a player is greater then 50 blocks away from you.")
         .defaultValue(new SettingColor(15, 255, 15))
@@ -156,24 +174,41 @@ public class CombatHud extends HudElement {
         .build()
     );
 
-    private final Setting<SettingColor> healthColor1 = sgGeneral.add(new ColorSetting.Builder()
-        .name("health-stage-1")
-        .description("The color on the left of the health gradient.")
-        .defaultValue(new SettingColor(255, 15, 15))
+    // Scale
+
+    public final Setting<Boolean> customScale = sgScale.add(new BoolSetting.Builder()
+        .name("custom-scale")
+        .description("Applies custom text scale rather than the global one.")
+        .defaultValue(false)
+        .onChanged(integer -> calculateSize())
         .build()
     );
 
-    private final Setting<SettingColor> healthColor2 = sgGeneral.add(new ColorSetting.Builder()
-        .name("health-stage-2")
-        .description("The color in the middle of the health gradient.")
-        .defaultValue(new SettingColor(255, 150, 15))
+    public final Setting<Double> scale = sgScale.add(new DoubleSetting.Builder()
+        .name("scale")
+        .description("Custom scale.")
+        .visible(customScale::get)
+        .defaultValue(1)
+        .onChanged(integer -> calculateSize())
+        .min(0.5)
+        .sliderRange(0.5, 3)
         .build()
     );
 
-    private final Setting<SettingColor> healthColor3 = sgGeneral.add(new ColorSetting.Builder()
-        .name("health-stage-3")
-        .description("The color on the right of the health gradient.")
-        .defaultValue(new SettingColor(15, 255, 15))
+    // Background
+
+    public final Setting<Boolean> background = sgBackground.add(new BoolSetting.Builder()
+        .name("background")
+        .description("Displays background.")
+        .defaultValue(false)
+        .build()
+    );
+
+    public final Setting<SettingColor> backgroundColor = sgBackground.add(new ColorSetting.Builder()
+        .name("background-color")
+        .description("Color used for the background.")
+        .visible(background::get)
+        .defaultValue(new SettingColor(25, 25, 25, 50))
         .build()
     );
 
@@ -186,7 +221,7 @@ public class CombatHud extends HudElement {
     }
 
     private void calculateSize() {
-        setSize(175 * scale.get(), 95 * scale.get());
+        setSize(175 * getScale(), 95 * getScale());
     }
 
     @Override
@@ -212,7 +247,7 @@ public class CombatHud extends HudElement {
                 if (isInEditor()) {
                     renderer.line(x, y, x + getWidth(), y + getHeight(), Color.GRAY);
                     renderer.line(x + getWidth(), y, x, y + getHeight(), Color.GRAY);
-                    Renderer2D.COLOR.render(null); // i know, ill fix it soon
+                    Renderer2D.COLOR.render(null); // I know, ill fix it soon
                 }
                 return;
             }
@@ -223,9 +258,9 @@ public class CombatHud extends HudElement {
                 renderer.drawContext,
                 (int) x,
                 (int) y,
-                (int) (x + (25 * scale.get())),
-                (int) (y + (66 * scale.get())),
-                (int) (30 * scale.get()),
+                (int) (x + (25 * getScale())),
+                (int) (y + (66 * getScale())),
+                (int) (30 * getScale()),
                 0,
                 -MathHelper.wrapDegrees(playerEntity.prevYaw + (playerEntity.getYaw() - playerEntity.prevYaw) * mc.getRenderTickCounter().getTickDelta(true)),
                 -playerEntity.getPitch(),
@@ -233,8 +268,8 @@ public class CombatHud extends HudElement {
             );
 
             // Moving pos to past player model
-            x += 50 * scale.get();
-            y += 5 * scale.get();
+            x += 50 * getScale();
+            y += 5 * getScale();
 
             // Setting up texts
             String breakText = " | ";
@@ -301,7 +336,7 @@ public class CombatHud extends HudElement {
                 }
             }
 
-            TextRenderer.get().begin(0.45 * scale.get(), false, true);
+            TextRenderer.get().begin(0.45 * getScale(), false, true);
 
             double breakWidth = TextRenderer.get().getWidth(breakText);
             double pingWidth = TextRenderer.get().getWidth(pingText);
@@ -329,7 +364,7 @@ public class CombatHud extends HudElement {
             TextRenderer.get().end();
 
             // Moving pos down for armor
-            y += 10 * scale.get();
+            y += 10 * getScale();
 
             double armorX;
             double armorY;
@@ -339,10 +374,10 @@ public class CombatHud extends HudElement {
             Matrix4fStack matrices = RenderSystem.getModelViewStack();
 
             matrices.pushMatrix();
-            matrices.scale(scale.get().floatValue(), scale.get().floatValue(), 1);
+            matrices.scale((float) getScale(), (float) getScale(), 1);
 
-            x /= scale.get();
-            y /= scale.get();
+            x /= getScale();
+            y /= getScale();
 
             TextRenderer.get().begin(0.35, false, true);
 
@@ -377,13 +412,13 @@ public class CombatHud extends HudElement {
 
             TextRenderer.get().end();
 
-            y = (int) (this.y + 75 * scale.get());
+            y = (int) (this.y + 75 * getScale());
             x = this.x;
 
             // Health bar
 
-            x /= scale.get();
-            y /= scale.get();
+            x /= getScale();
+            y /= getScale();
 
             x += 5;
             y += 5;
@@ -440,5 +475,9 @@ public class CombatHud extends HudElement {
             case 5 -> playerEntity.getMainHandStack();
             default -> playerEntity.getInventory().getArmorStack(i);
         };
+    }
+
+    private double getScale() {
+        return customScale.get() ? scale.get() : Hud.get().getTextScale();
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CombatHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CombatHud.java
@@ -188,7 +188,7 @@ public class CombatHud extends HudElement {
         .name("scale")
         .description("Custom scale.")
         .visible(customScale::get)
-        .defaultValue(1)
+        .defaultValue(2)
         .onChanged(integer -> calculateSize())
         .min(0.5)
         .sliderRange(0.5, 3)

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CombatHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CombatHud.java
@@ -178,9 +178,9 @@ public class CombatHud extends HudElement {
 
     public final Setting<Boolean> customScale = sgScale.add(new BoolSetting.Builder()
         .name("custom-scale")
-        .description("Applies custom text scale rather than the global one.")
+        .description("Applies a custom scale to this hud element.")
         .defaultValue(false)
-        .onChanged(integer -> calculateSize())
+        .onChanged(aBoolean -> calculateSize())
         .build()
     );
 
@@ -189,7 +189,7 @@ public class CombatHud extends HudElement {
         .description("Custom scale.")
         .visible(customScale::get)
         .defaultValue(2)
-        .onChanged(integer -> calculateSize())
+        .onChanged(aDouble -> calculateSize())
         .min(0.5)
         .sliderRange(0.5, 3)
         .build()

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CombatHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CombatHud.java
@@ -239,9 +239,10 @@ public class CombatHud extends HudElement {
 
             if (playerEntity == null && !isInEditor()) return;
 
-            // Background
-            Renderer2D.COLOR.begin();
-            Renderer2D.COLOR.quad(x, y, getWidth(), getHeight(), backgroundColor.get());
+            if (background.get()) {
+                Renderer2D.COLOR.begin();
+                Renderer2D.COLOR.quad(x, y, getWidth(), getHeight(), backgroundColor.get());
+            }
 
             if (playerEntity == null) {
                 if (isInEditor()) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CompassHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CompassHud.java
@@ -66,7 +66,7 @@ public class CompassHud extends HudElement {
 
     private final Setting<Boolean> customScale = sgScale.add(new BoolSetting.Builder()
         .name("custom-scale")
-        .description("Applies custom scales rather than the global ones.")
+        .description("Apply custom scales to this hud element.")
         .defaultValue(false)
         .onChanged(aBoolean -> calculateSize())
         .build()
@@ -74,7 +74,7 @@ public class CompassHud extends HudElement {
 
     private final Setting<Double> textScale = sgScale.add(new DoubleSetting.Builder()
         .name("text-scale")
-        .description("Custom text scale.")
+        .description("Scale to use for the letters.")
         .visible(customScale::get)
         .defaultValue(1)
         .min(0.5)

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CompassHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CompassHud.java
@@ -19,7 +19,7 @@ public class CompassHud extends HudElement {
     public static final HudElementInfo<CompassHud> INFO = new HudElementInfo<>(Hud.GROUP, "compass", "Displays a compass.", CompassHud::new);
 
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
-    private final SettingGroup sgTextScale = settings.createGroup("Text Scale");
+    private final SettingGroup sgScale = settings.createGroup("Scale");
     private final SettingGroup sgBackground = settings.createGroup("Background");
 
     // General
@@ -62,30 +62,34 @@ public class CompassHud extends HudElement {
         .build()
     );
 
-    private final Setting<Integer> border = sgGeneral.add(new IntSetting.Builder()
-        .name("border")
-        .description("How much space to add around the element.")
-        .defaultValue(0)
-        .onChanged(integer -> calculateSize())
-        .build()
-    );
-
     // Scale
 
-    private final Setting<Boolean> customTextScale = sgTextScale.add(new BoolSetting.Builder()
-        .name("custom-text-scale")
-        .description("Applies custom text scale rather than the global one.")
+    private final Setting<Boolean> customScale = sgScale.add(new BoolSetting.Builder()
+        .name("custom-scale")
+        .description("Applies custom scales rather than the global ones.")
         .defaultValue(false)
+        .onChanged(aBoolean -> calculateSize())
         .build()
     );
 
-    private final Setting<Double> textScale = sgTextScale.add(new DoubleSetting.Builder()
+    private final Setting<Double> textScale = sgScale.add(new DoubleSetting.Builder()
         .name("text-scale")
         .description("Custom text scale.")
-        .visible(customTextScale::get)
+        .visible(customScale::get)
         .defaultValue(1)
         .min(0.5)
         .sliderRange(0.5, 3)
+        .build()
+    );
+
+    private final Setting<Double> compassScale = sgScale.add(new DoubleSetting.Builder()
+        .name("compass-scale")
+        .description("Scale of the whole HUD element.")
+        .visible(customScale::get)
+        .defaultValue(1)
+        .min(0.5)
+        .sliderRange(0.5, 3)
+        .onChanged(aDouble -> calculateSize())
         .build()
     );
 
@@ -112,13 +116,8 @@ public class CompassHud extends HudElement {
         calculateSize();
     }
 
-    @Override
-    public void setSize(double width, double height) {
-        super.setSize(width + border.get() * 2, height + border.get() * 2);
-    }
-
     private void calculateSize() {
-        setSize(100 * scale.get(), 100 * scale.get());
+        setSize(100 * getCompassScale(), 100 * getCompassScale());
     }
 
     @Override
@@ -151,11 +150,11 @@ public class CompassHud extends HudElement {
     }
 
     private double getX(Direction direction, double yaw) {
-        return Math.sin(getPos(direction, yaw)) * scale.get() * 40;
+        return Math.sin(getPos(direction, yaw)) * getCompassScale() * 40;
     }
 
     private double getY(Direction direction, double yaw, double pitch) {
-        return Math.cos(getPos(direction, yaw)) * Math.sin(pitch) * scale.get() * 40;
+        return Math.cos(getPos(direction, yaw)) * Math.sin(pitch) * getCompassScale() * 40;
     }
 
     private double getPos(Direction direction, double yaw) {
@@ -163,7 +162,11 @@ public class CompassHud extends HudElement {
     }
 
     private double getTextScale() {
-        return customTextScale.get() ? textScale.get() : -1;
+        return customScale.get() ? textScale.get() : Hud.get().getTextScale();
+    }
+
+    private double getCompassScale() {
+        return customScale.get() ? compassScale.get() : Hud.get().getTextScale();
     }
 
     private enum Direction {

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/HoleHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/HoleHud.java
@@ -112,7 +112,7 @@ public class HoleHud extends HudElement {
         Block block = dir == Direction.DOWN ? Blocks.OBSIDIAN : mc.world.getBlockState(mc.player.getBlockPos().offset(dir)).getBlock();
         if (!safe.get().contains(block)) return;
 
-        renderer.item(block.asItem().getDefaultStack(), (int) x, (int) y, (float) getScale(), false);
+        renderer.item(block.asItem().getDefaultStack(), (int) x, (int) y, getScale(), false);
 
         if (dir == Direction.DOWN) return;
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/HoleHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/HoleHud.java
@@ -132,7 +132,7 @@ public class HoleHud extends HudElement {
     }
 
     private double getScale() {
-        return customScale.get() ? scale.get() : Hud.get().getTextScale();
+        return customScale.get() ? scale.get() : scale.getDefaultValue();
     }
 
     private enum Facing {

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/HoleHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/HoleHud.java
@@ -52,7 +52,7 @@ public class HoleHud extends HudElement {
         .name("scale")
         .description("Custom scale.")
         .visible(customScale::get)
-        .defaultValue(1)
+        .defaultValue(2.5)
         .onChanged(anInteger -> calculateSize())
         .min(0.5)
         .sliderRange(0.5, 3)

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/HoleHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/HoleHud.java
@@ -86,16 +86,16 @@ public class HoleHud extends HudElement {
     }
 
     private void calculateSize() {
-        setSize(16 * 3 * scale.get(), 16 * 3 * scale.get());
+        setSize(16 * 3 * getScale(), 16 * 3 * getScale());
     }
 
     @Override
     public void render(HudRenderer renderer) {
         renderer.post(() -> {
-            drawBlock(renderer, get(Facing.Left), x, y + 16 * scale.get()); // Left
-            drawBlock(renderer, get(Facing.Front), x + 16 * scale.get(), y); // Front
-            drawBlock(renderer, get(Facing.Right), x + 32 * scale.get(), y + 16 * scale.get()); // Right
-            drawBlock(renderer, get(Facing.Back), x + 16 * scale.get(), y + 32 * scale.get()); // Back
+            drawBlock(renderer, get(Facing.Left), x, y + 16 * getScale()); // Left
+            drawBlock(renderer, get(Facing.Front), x + 16 * getScale(), y); // Front
+            drawBlock(renderer, get(Facing.Right), x + 32 * getScale(), y + 16 * getScale()); // Right
+            drawBlock(renderer, get(Facing.Back), x + 16 * getScale(), y + 32 * getScale()); // Back
         });
 
         if (background.get()) {
@@ -112,7 +112,7 @@ public class HoleHud extends HudElement {
         Block block = dir == Direction.DOWN ? Blocks.OBSIDIAN : mc.world.getBlockState(mc.player.getBlockPos().offset(dir)).getBlock();
         if (!safe.get().contains(block)) return;
 
-        renderer.item(block.asItem().getDefaultStack(), (int) x, (int) y, scale.get().floatValue(), false);
+        renderer.item(block.asItem().getDefaultStack(), (int) x, (int) y, (float) getScale(), false);
 
         if (dir == Direction.DOWN) return;
 
@@ -124,11 +124,15 @@ public class HoleHud extends HudElement {
     }
 
     private void renderBreaking(HudRenderer renderer, double x, double y, double percent) {
-        renderer.quad(x, y, (16 * percent) * scale.get(), 16 * scale.get(), BG_COLOR);
-        renderer.quad(x, y, 16 * scale.get(), 1 * scale.get(), OL_COLOR);
-        renderer.quad(x, y + 15 * scale.get(), 16 * scale.get(), 1 * scale.get(), OL_COLOR);
-        renderer.quad(x, y, 1 * scale.get(), 16 * scale.get(), OL_COLOR);
-        renderer.quad(x + 15 * scale.get(), y, 1 * scale.get(), 16 * scale.get(), OL_COLOR);
+        renderer.quad(x, y, (16 * percent) * getScale(), 16 * getScale(), BG_COLOR);
+        renderer.quad(x, y, 16 * getScale(), 1 * getScale(), OL_COLOR);
+        renderer.quad(x, y + 15 * getScale(), 16 * getScale(), 1 * getScale(), OL_COLOR);
+        renderer.quad(x, y, 1 * getScale(), 16 * getScale(), OL_COLOR);
+        renderer.quad(x + 15 * getScale(), y, 1 * getScale(), 16 * getScale(), OL_COLOR);
+    }
+
+    private double getScale() {
+        return customScale.get() ? scale.get() : Hud.get().getTextScale();
     }
 
     private enum Facing {

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/HoleHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/HoleHud.java
@@ -42,9 +42,9 @@ public class HoleHud extends HudElement {
 
     public final Setting<Boolean> customScale = sgScale.add(new BoolSetting.Builder()
         .name("custom-scale")
-        .description("Applies custom text scale rather than the global one.")
+        .description("Applies a custom scale to this hud element.")
         .defaultValue(false)
-        .onChanged(anInteger -> calculateSize())
+        .onChanged(aBoolean -> calculateSize())
         .build()
     );
 
@@ -53,7 +53,7 @@ public class HoleHud extends HudElement {
         .description("Custom scale.")
         .visible(customScale::get)
         .defaultValue(2.5)
-        .onChanged(anInteger -> calculateSize())
+        .onChanged(aDouble -> calculateSize())
         .min(0.5)
         .sliderRange(0.5, 3)
         .build()

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/HoleHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/HoleHud.java
@@ -26,6 +26,7 @@ public class HoleHud extends HudElement {
     public static final HudElementInfo<HoleHud> INFO = new HudElementInfo<>(Hud.GROUP, "hole", "Displays information about the hole you are standing in.", HoleHud::new);
 
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
+    private final SettingGroup sgScale = settings.createGroup("Scale");
     private final SettingGroup sgBackground = settings.createGroup("Background");
 
     // General
@@ -37,34 +38,37 @@ public class HoleHud extends HudElement {
         .build()
     );
 
-    private final Setting<Double> scale = sgGeneral.add(new DoubleSetting.Builder()
-        .name("scale")
-        .description("The scale.")
-        .defaultValue(2)
-        .onChanged(aDouble -> calculateSize())
-        .min(1)
-        .sliderRange(1, 5)
+    // Scale
+
+    public final Setting<Boolean> customScale = sgScale.add(new BoolSetting.Builder()
+        .name("custom-scale")
+        .description("Applies custom text scale rather than the global one.")
+        .defaultValue(false)
+        .onChanged(anInteger -> calculateSize())
         .build()
     );
 
-    private final Setting<Integer> border = sgGeneral.add(new IntSetting.Builder()
-        .name("border")
-        .description("How much space to add around the element.")
-        .defaultValue(0)
-        .onChanged(integer -> calculateSize())
+    public final Setting<Double> scale = sgScale.add(new DoubleSetting.Builder()
+        .name("scale")
+        .description("Custom scale.")
+        .visible(customScale::get)
+        .defaultValue(1)
+        .onChanged(anInteger -> calculateSize())
+        .min(0.5)
+        .sliderRange(0.5, 3)
         .build()
     );
 
     // Background
 
-    private final Setting<Boolean> background = sgBackground.add(new BoolSetting.Builder()
+    public final Setting<Boolean> background = sgBackground.add(new BoolSetting.Builder()
         .name("background")
         .description("Displays background.")
         .defaultValue(false)
         .build()
     );
 
-    private final Setting<SettingColor> backgroundColor = sgBackground.add(new ColorSetting.Builder()
+    public final Setting<SettingColor> backgroundColor = sgBackground.add(new ColorSetting.Builder()
         .name("background-color")
         .description("Color used for the background.")
         .visible(background::get)
@@ -81,11 +85,6 @@ public class HoleHud extends HudElement {
         calculateSize();
     }
 
-    @Override
-    public void setSize(double width, double height) {
-        super.setSize(width + border.get() * 2, height + border.get() * 2);
-    }
-
     private void calculateSize() {
         setSize(16 * 3 * scale.get(), 16 * 3 * scale.get());
     }
@@ -93,9 +92,6 @@ public class HoleHud extends HudElement {
     @Override
     public void render(HudRenderer renderer) {
         renderer.post(() -> {
-            double x = this.x + border.get();
-            double y = this.y + border.get();
-
             drawBlock(renderer, get(Facing.Left), x, y + 16 * scale.get()); // Left
             drawBlock(renderer, get(Facing.Front), x + 16 * scale.get(), y); // Front
             drawBlock(renderer, get(Facing.Right), x + 32 * scale.get(), y + 16 * scale.get()); // Right

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/HoleHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/HoleHud.java
@@ -52,7 +52,7 @@ public class HoleHud extends HudElement {
         .name("scale")
         .description("Custom scale.")
         .visible(customScale::get)
-        .defaultValue(2.5)
+        .defaultValue(2)
         .onChanged(aDouble -> calculateSize())
         .min(0.5)
         .sliderRange(0.5, 3)

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/HoleHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/HoleHud.java
@@ -131,8 +131,8 @@ public class HoleHud extends HudElement {
         renderer.quad(x + 15 * getScale(), y, 1 * getScale(), 16 * getScale(), OL_COLOR);
     }
 
-    private double getScale() {
-        return customScale.get() ? scale.get() : scale.getDefaultValue();
+    private float getScale() {
+        return customScale.get() ? scale.get().floatValue() : scale.getDefaultValue().floatValue();
     }
 
     private enum Facing {

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/InventoryHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/InventoryHud.java
@@ -51,7 +51,7 @@ public class InventoryHud extends HudElement {
         .name("scale")
         .description("Custom scale.")
         .visible(customScale::get)
-        .defaultValue(2.5)
+        .defaultValue(2)
         .onChanged(integer -> calculateSize())
         .min(0.5)
         .sliderRange(0.5, 3)

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/InventoryHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/InventoryHud.java
@@ -144,7 +144,7 @@ public class InventoryHud extends HudElement {
     }
 
     private double getScale() {
-        return customScale.get() ? scale.get() : Hud.get().getTextScale();
+        return customScale.get() ? scale.get() : scale.getDefaultValue();
     }
 
     public enum Background {

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/InventoryHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/InventoryHud.java
@@ -41,9 +41,9 @@ public class InventoryHud extends HudElement {
 
     public final Setting<Boolean> customScale = sgScale.add(new BoolSetting.Builder()
         .name("custom-scale")
-        .description("Applies custom text scale rather than the global one.")
+        .description("Applies a custom scale to this hud element.")
         .defaultValue(false)
-        .onChanged(integer -> calculateSize())
+        .onChanged(aBoolean -> calculateSize())
         .build()
     );
 
@@ -52,7 +52,7 @@ public class InventoryHud extends HudElement {
         .description("Custom scale.")
         .visible(customScale::get)
         .defaultValue(2)
-        .onChanged(integer -> calculateSize())
+        .onChanged(aDouble -> calculateSize())
         .min(0.5)
         .sliderRange(0.5, 3)
         .build()

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/InventoryHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/InventoryHud.java
@@ -108,17 +108,17 @@ public class InventoryHud extends HudElement {
                     ItemStack stack = hasContainer ? containerItems[index] : mc.player.getInventory().getStack(index + 9);
                     if (stack == null) continue;
 
-                    int itemX = background.get() == Background.Texture ? (int) (x + (8 + i * 18) * scale.get()) : (int) (x + (1 + i * 18) * scale.get());
-                    int itemY = background.get() == Background.Texture ? (int) (y + (7 + row * 18) * scale.get()) : (int) (y + (1 + row * 18) * scale.get());
+                    int itemX = background.get() == Background.Texture ? (int) (x + (8 + i * 18) * getScale()) : (int) (x + (1 + i * 18) * getScale());
+                    int itemY = background.get() == Background.Texture ? (int) (y + (7 + row * 18) * getScale()) : (int) (y + (1 + row * 18) * getScale());
 
-                    renderer.item(stack, itemX, itemY, scale.get().floatValue(), true);
+                    renderer.item(stack, itemX, itemY, (float) getScale(), true);
                 }
             }
         });
     }
 
     private void calculateSize() {
-        setSize(background.get().width * scale.get(), background.get().height * scale.get());
+        setSize(background.get().width * getScale(), background.get().height * getScale());
     }
 
     private void drawBackground(HudRenderer renderer, int x, int y, Color color) {
@@ -141,6 +141,10 @@ public class InventoryHud extends HudElement {
         if (Utils.hasItems(stack) || stack.getItem() == Items.ENDER_CHEST) return stack;
 
         return null;
+    }
+
+    private double getScale() {
+        return customScale.get() ? scale.get() : Hud.get().getTextScale();
     }
 
     public enum Background {

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/InventoryHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/InventoryHud.java
@@ -51,7 +51,7 @@ public class InventoryHud extends HudElement {
         .name("scale")
         .description("Custom scale.")
         .visible(customScale::get)
-        .defaultValue(1)
+        .defaultValue(2.5)
         .onChanged(integer -> calculateSize())
         .min(0.5)
         .sliderRange(0.5, 3)

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ItemHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ItemHud.java
@@ -54,7 +54,7 @@ public class ItemHud extends HudElement {
         .name("scale")
         .description("Custom scale.")
         .visible(customScale::get)
-        .defaultValue(1)
+        .defaultValue(2.5)
         .onChanged(aDouble -> calculateSize())
         .min(0.5)
         .sliderRange(0.5, 3)

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ItemHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ItemHud.java
@@ -54,7 +54,7 @@ public class ItemHud extends HudElement {
         .name("scale")
         .description("Custom scale.")
         .visible(customScale::get)
-        .defaultValue(2.5)
+        .defaultValue(2)
         .onChanged(aDouble -> calculateSize())
         .min(0.5)
         .sliderRange(0.5, 3)

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ItemHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ItemHud.java
@@ -85,7 +85,7 @@ public class ItemHud extends HudElement {
     }
 
     private void calculateSize() {
-        setSize(17 * scale.get(), 17 * scale.get());
+        setSize(17 * getScale(), 17 * getScale());
     }
 
     @Override
@@ -106,7 +106,7 @@ public class ItemHud extends HudElement {
 
     private void render(HudRenderer renderer, ItemStack itemStack, int x, int y) {
         if (noneMode.get() == NoneMode.HideItem) {
-            renderer.item(itemStack, x, y, scale.get().floatValue(), true);
+            renderer.item(itemStack, x, y, getScale(), true);
             return;
         }
 
@@ -121,14 +121,14 @@ public class ItemHud extends HudElement {
             resetToZero = true;
         }
 
-        renderer.item(itemStack, x, y, scale.get().floatValue(), true, countOverride);
+        renderer.item(itemStack, x, y, getScale(), true, countOverride);
 
         if (resetToZero)
             itemStack.setCount(0);
     }
 
-    private double getScale() {
-        return customScale.get() ? scale.get() : Hud.get().getTextScale();
+    private float getScale() {
+        return customScale.get() ? scale.get().floatValue() : scale.getDefaultValue().floatValue();
     }
 
     public enum NoneMode {

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ItemHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ItemHud.java
@@ -44,9 +44,9 @@ public class ItemHud extends HudElement {
 
     public final Setting<Boolean> customScale = sgScale.add(new BoolSetting.Builder()
         .name("custom-scale")
-        .description("Applies custom text scale rather than the global one.")
+        .description("Applies a custom scale to this hud element.")
         .defaultValue(false)
-        .onChanged(anInteger -> calculateSize())
+        .onChanged(aBoolean -> calculateSize())
         .build()
     );
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/LagNotifierHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/LagNotifierHud.java
@@ -123,6 +123,6 @@ public class LagNotifierHud extends HudElement {
     }
 
     private double getScale() {
-        return customScale.get() ? scale.get() : -1;
+        return customScale.get() ? scale.get() : Hud.get().getTextScale();
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/LagNotifierHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/LagNotifierHud.java
@@ -13,6 +13,7 @@ import meteordevelopment.meteorclient.systems.hud.HudRenderer;
 import meteordevelopment.meteorclient.utils.render.color.Color;
 import meteordevelopment.meteorclient.utils.render.color.SettingColor;
 import meteordevelopment.meteorclient.utils.world.TickRate;
+import net.minecraft.world.tick.Tick;
 
 public class LagNotifierHud extends HudElement {
     public static final HudElementInfo<LagNotifierHud> INFO = new HudElementInfo<>(Hud.GROUP, "lag-notifier", "Displays if the server is lagging in ticks.", LagNotifierHud::new);
@@ -112,24 +113,17 @@ public class LagNotifierHud extends HudElement {
 
     @Override
     public void render(HudRenderer renderer) {
-        if (isInEditor()) {
-            render(renderer, "4.3", color3.get());
-            return;
-        }
-
         float timeSinceLastTick = TickRate.INSTANCE.getTimeSinceLastTick();
+        if (timeSinceLastTick < 1.1f && !isInEditor()) return;
 
-        if (timeSinceLastTick >= 1.1f) {
-            Color color;
+        Color color = isInEditor() || timeSinceLastTick > 10f ? color3.get()
+            : timeSinceLastTick > 3f ? color2.get()
+            : color1.get();
 
-            if (timeSinceLastTick > 10) color = color3.get();
-            else if (timeSinceLastTick > 3) color = color2.get();
-            else color = color1.get();
+        String info = isInEditor() ? "10.2" : String.format("%.1f", timeSinceLastTick);
 
-            render(renderer, String.format("%.1f", timeSinceLastTick), color);
-        }
-
-        if (background.get() && (timeSinceLastTick >= 1.1f || isInEditor())) {
+        render(renderer, info, color);
+        if (background.get()) {
             renderer.quad(this.x, this.y, getWidth(), getHeight(), backgroundColor.get());
         }
     }

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/LagNotifierHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/LagNotifierHud.java
@@ -112,10 +112,6 @@ public class LagNotifierHud extends HudElement {
 
     @Override
     public void render(HudRenderer renderer) {
-        if (background.get()) {
-            renderer.quad(this.x, this.y, getWidth(), getHeight(), backgroundColor.get());
-        }
-
         if (isInEditor()) {
             render(renderer, "4.3", color3.get());
             return;
@@ -123,7 +119,7 @@ public class LagNotifierHud extends HudElement {
 
         float timeSinceLastTick = TickRate.INSTANCE.getTimeSinceLastTick();
 
-        if (timeSinceLastTick >= 1f) {
+        if (timeSinceLastTick >= 1.1f) {
             Color color;
 
             if (timeSinceLastTick > 10) color = color3.get();
@@ -131,6 +127,10 @@ public class LagNotifierHud extends HudElement {
             else color = color1.get();
 
             render(renderer, String.format("%.1f", timeSinceLastTick), color);
+        }
+
+        if (background.get() && (timeSinceLastTick >= 1.1f || isInEditor())) {
+            renderer.quad(this.x, this.y, getWidth(), getHeight(), backgroundColor.get());
         }
     }
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/LagNotifierHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/LagNotifierHud.java
@@ -62,7 +62,7 @@ public class LagNotifierHud extends HudElement {
 
     private final Setting<Boolean> customScale = sgScale.add(new BoolSetting.Builder()
         .name("custom-scale")
-        .description("Applies custom text scale rather than the global one.")
+        .description("Applies a custom scale to this hud element.")
         .defaultValue(false)
         .build()
     );

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/LagNotifierHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/LagNotifierHud.java
@@ -13,7 +13,6 @@ import meteordevelopment.meteorclient.systems.hud.HudRenderer;
 import meteordevelopment.meteorclient.utils.render.color.Color;
 import meteordevelopment.meteorclient.utils.render.color.SettingColor;
 import meteordevelopment.meteorclient.utils.world.TickRate;
-import net.minecraft.world.tick.Tick;
 
 public class LagNotifierHud extends HudElement {
     public static final HudElementInfo<LagNotifierHud> INFO = new HudElementInfo<>(Hud.GROUP, "lag-notifier", "Displays if the server is lagging in ticks.", LagNotifierHud::new);
@@ -59,13 +58,6 @@ public class LagNotifierHud extends HudElement {
         .build()
     );
 
-    private final Setting<Integer> border = sgGeneral.add(new IntSetting.Builder()
-        .name("border")
-        .description("How much space to add around the element.")
-        .defaultValue(0)
-        .build()
-    );
-
     // Scale
 
     private final Setting<Boolean> customScale = sgScale.add(new BoolSetting.Builder()
@@ -107,11 +99,6 @@ public class LagNotifierHud extends HudElement {
     }
 
     @Override
-    public void setSize(double width, double height) {
-        super.setSize(width + border.get() * 2, height + border.get() * 2);
-    }
-
-    @Override
     public void render(HudRenderer renderer) {
         float timeSinceLastTick = TickRate.INSTANCE.getTimeSinceLastTick();
         if (timeSinceLastTick < 1.1f && !isInEditor()) return;
@@ -129,9 +116,6 @@ public class LagNotifierHud extends HudElement {
     }
 
     private void render(HudRenderer renderer, String right, Color rightColor) {
-        double x = this.x + border.get();
-        double y = this.y + border.get();
-
         double x2 = renderer.text("Time since last tick ", x, y, textColor.get(), shadow.get(), getScale());
         x2 = renderer.text(right, x2, y, rightColor, shadow.get(), getScale());
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PlayerModelHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PlayerModelHud.java
@@ -75,9 +75,9 @@ public class PlayerModelHud extends HudElement {
 
     public final Setting<Boolean> customScale = sgScale.add(new BoolSetting.Builder()
         .name("custom-scale")
-        .description("Applies custom text scale rather than the global one.")
+        .description("Applies a custom scale to this hud element.")
         .defaultValue(false)
-        .onChanged(integer -> calculateSize())
+        .onChanged(aBoolean -> calculateSize())
         .build()
     );
 
@@ -86,7 +86,7 @@ public class PlayerModelHud extends HudElement {
         .description("Custom scale.")
         .visible(customScale::get)
         .defaultValue(2)
-        .onChanged(integer -> calculateSize())
+        .onChanged(aDouble -> calculateSize())
         .min(0.5)
         .sliderRange(0.5, 3)
         .build()

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PlayerModelHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PlayerModelHud.java
@@ -194,7 +194,7 @@ public class PlayerModelHud extends HudElement {
     }
 
     private double getScale() {
-        return customScale.get() ? scale.get() : Hud.get().getTextScale();
+        return customScale.get() ? scale.get() : scale.getDefaultValue();
     }
 
     private enum CenterOrientation {

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PlayerModelHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PlayerModelHud.java
@@ -25,19 +25,10 @@ import static meteordevelopment.meteorclient.MeteorClient.mc;
 public class PlayerModelHud extends HudElement {
     public static final HudElementInfo<PlayerModelHud> INFO = new HudElementInfo<>(Hud.GROUP, "player-model", "Displays a model of your player.", PlayerModelHud::new);
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
+    private final SettingGroup sgScale = settings.createGroup("Scale");
     private final SettingGroup sgBackground = settings.createGroup("Background");
 
     // General
-
-    private final Setting<Double> scale = sgGeneral.add(new DoubleSetting.Builder()
-        .name("scale")
-        .description("The scale.")
-        .defaultValue(2)
-        .min(1)
-        .sliderRange(1, 5)
-        .onChanged(aDouble -> calculateSize())
-        .build()
-    );
 
     private final Setting<Boolean> copyYaw = sgGeneral.add(new BoolSetting.Builder()
         .name("copy-yaw")
@@ -80,6 +71,27 @@ public class PlayerModelHud extends HudElement {
         .build()
     );
 
+    // Scale
+
+    public final Setting<Boolean> customScale = sgScale.add(new BoolSetting.Builder()
+        .name("custom-scale")
+        .description("Applies custom text scale rather than the global one.")
+        .defaultValue(false)
+        .onChanged(integer -> calculateSize())
+        .build()
+    );
+
+    public final Setting<Double> scale = sgScale.add(new DoubleSetting.Builder()
+        .name("scale")
+        .description("Custom scale.")
+        .visible(customScale::get)
+        .defaultValue(2)
+        .onChanged(integer -> calculateSize())
+        .min(0.5)
+        .sliderRange(0.5, 3)
+        .build()
+    );
+
     // Background
 
     private final Setting<Boolean> background = sgBackground.add(new BoolSetting.Builder()
@@ -114,7 +126,7 @@ public class PlayerModelHud extends HudElement {
             float yaw = copyYaw.get() ? MathHelper.wrapDegrees(player.prevYaw + (player.getYaw() - player.prevYaw) * mc.getRenderTickCounter().getTickDelta(true) + offset) : (float) customYaw.get();
             float pitch = copyPitch.get() ? player.getPitch() : (float) customPitch.get();
 
-            drawEntity(renderer.drawContext, x, y, (int) (30 * scale.get()), -yaw, -pitch, player);
+            drawEntity(renderer.drawContext, x, y, (int) (30 * getScale()), -yaw, -pitch, player);
         });
 
         if (background.get()) {
@@ -127,7 +139,7 @@ public class PlayerModelHud extends HudElement {
     }
 
     private void calculateSize() {
-        setSize(50 * scale.get(), 75 * scale.get());
+        setSize(50 * getScale(), 75 * getScale());
     }
 
     /**
@@ -179,6 +191,10 @@ public class PlayerModelHud extends HudElement {
         entity.setPitch(previousPitch);
         entity.prevHeadYaw = previousPrevHeadYaw;
         entity.headYaw = prevHeadYaw;
+    }
+
+    private double getScale() {
+        return customScale.get() ? scale.get() : Hud.get().getTextScale();
     }
 
     private enum CenterOrientation {

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PlayerRadarHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PlayerRadarHud.java
@@ -91,7 +91,7 @@ public class PlayerRadarHud extends HudElement {
 
     private final Setting<Boolean> customScale = sgScale.add(new BoolSetting.Builder()
         .name("custom-scale")
-        .description("Applies custom text scale rather than the global one.")
+        .description("Applies a custom scale to this hud element.")
         .defaultValue(false)
         .build()
     );

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PlayerRadarHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PlayerRadarHud.java
@@ -210,6 +210,6 @@ public class PlayerRadarHud extends HudElement {
     }
 
     private double getScale() {
-        return customScale.get() ? scale.get() : -1;
+        return customScale.get() ? scale.get() : Hud.get().getTextScale();
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PotionTimersHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PotionTimersHud.java
@@ -123,7 +123,7 @@ public class PotionTimersHud extends HudElement {
 
     private final Setting<Boolean> customScale = sgScale.add(new BoolSetting.Builder()
         .name("custom-scale")
-        .description("Applies custom text scale rather than the global one.")
+        .description("Applies a custom scale to this hud element.")
         .defaultValue(false)
         .build()
     );

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PotionTimersHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PotionTimersHud.java
@@ -245,7 +245,7 @@ public class PotionTimersHud extends HudElement {
     }
 
     private double getScale() {
-        return customScale.get() ? scale.get() : -1;
+        return customScale.get() ? scale.get() : Hud.get().getTextScale();
     }
 
     private boolean hasNoVisibleEffects() {

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/TextHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/TextHud.java
@@ -259,7 +259,7 @@ public class TextHud extends HudElement {
     }
 
     private double getScale() {
-        return customScale.get() ? scale.get() : -1;
+        return customScale.get() ? scale.get() : Hud.get().getTextScale();
     }
 
     public static Color getSectionColor(int i) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/TextHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/TextHud.java
@@ -98,9 +98,9 @@ public class TextHud extends HudElement {
 
     public final Setting<Boolean> customScale = sgScale.add(new BoolSetting.Builder()
         .name("custom-scale")
-        .description("Applies custom text scale rather than the global one.")
+        .description("Applies a custom scale to this hud element.")
         .defaultValue(false)
-        .onChanged(integer -> recalculateSize = true)
+        .onChanged(aBoolean -> recalculateSize = true)
         .build()
     );
 
@@ -109,7 +109,7 @@ public class TextHud extends HudElement {
         .description("Custom scale.")
         .visible(customScale::get)
         .defaultValue(1)
-        .onChanged(integer -> recalculateSize = true)
+        .onChanged(aDouble -> recalculateSize = true)
         .min(0.5)
         .sliderRange(0.5, 3)
         .build()


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [x] New feature

## Description

Standardizing the background/scale settings for all modules aside from ModuleInfosHud. This makes it so that every hud module has separate scale and background setting groups. 

I excluded ModuleInfos since I plan to be opening another PR over break here in which I refactor the module along with the background settings of other line-by-line text modules to allow for both block and individual line backgrounds. Too out of scope for this PR and I'm tired

## Related issues

N/A

# How Has This Been Tested?

You'll just have to trust me when I say that this PR has been thoroughly tested with a full HUD of every element after every commit in both a prism instance and intellij

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
