### PR TITLE
Potion Spoof Related Fixes

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/DefaultSettingsWidgetFactory.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/DefaultSettingsWidgetFactory.java
@@ -7,6 +7,7 @@ package meteordevelopment.meteorclient.gui;
 
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
+import it.unimi.dsi.fastutil.objects.Reference2IntMap;
 import meteordevelopment.meteorclient.gui.renderer.GuiRenderer;
 import meteordevelopment.meteorclient.gui.screens.settings.*;
 import meteordevelopment.meteorclient.gui.themes.meteor.widgets.WMeteorLabel;
@@ -509,6 +510,18 @@ public class DefaultSettingsWidgetFactory extends SettingsWidgetFactory {
         }
 
         public static int getSize(Setting<?> setting) {
+            if (setting instanceof StatusEffectAmplifierMapSetting mapSetting) {
+                int selected = 0;
+
+                for (int potionLevel : mapSetting.get().values()) {
+                    if (potionLevel == 0) continue;
+                    selected++;
+                }
+
+                return selected;
+
+            }
+
             if (setting.get() instanceof Collection<?> collection) return collection.size();
             if (setting.get() instanceof Map<?, ?> map) return map.size();
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/PotionSpoof.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/PotionSpoof.java
@@ -7,6 +7,8 @@ package meteordevelopment.meteorclient.systems.modules.player;
 
 import it.unimi.dsi.fastutil.objects.Reference2IntMap;
 import meteordevelopment.meteorclient.events.world.TickEvent;
+import meteordevelopment.meteorclient.gui.GuiTheme;
+import meteordevelopment.meteorclient.gui.widgets.WWidget;
 import meteordevelopment.meteorclient.mixin.StatusEffectInstanceAccessor;
 import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Categories;
@@ -58,6 +60,16 @@ public class PotionSpoof extends Module {
         .defaultValue(true)
         .build()
     );
+
+
+    @Override
+    public WWidget getWidget(GuiTheme theme) {
+        return theme.label("""
+            Warning: haste, jump boost, slow falling and levitation are handled by
+            the game such that spoofing these potions will alter client behavior,
+            which anticheats can detect and ban for. Spoof these at your own risk!
+            """, Utils.getWindowWidth() / 3.0);
+    }
 
     public PotionSpoof() {
         super(Categories.Player, "potion-spoof", "Spoofs potion statuses on you.");

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/PotionSpoof.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/PotionSpoof.java
@@ -31,13 +31,6 @@ public class PotionSpoof extends Module {
         .build()
     );
 
-    private final Setting<Boolean> clearEffects = sgGeneral.add(new BoolSetting.Builder()
-        .name("clear-effects")
-        .description("Clears effects on module disable.")
-        .defaultValue(true)
-        .build()
-    );
-
     private final Setting<List<StatusEffect>> antiPotion = sgGeneral.add(new StatusEffectListSetting.Builder()
         .name("blocked-potions")
         .description("Potions to block.")
@@ -59,8 +52,15 @@ public class PotionSpoof extends Module {
         .build()
     );
 
+    private final Setting<Boolean> clearEffects = sgGeneral.add(new BoolSetting.Builder()
+        .name("clear-effects")
+        .description("Clears effects on module disable.")
+        .defaultValue(true)
+        .build()
+    );
+
     public PotionSpoof() {
-        super(Categories.Player, "potion-spoof", "Spoofs potion statuses for you. SOME effects DO NOT work.");
+        super(Categories.Player, "potion-spoof", "Spoofs potion statuses on you.");
     }
 
     @Override
@@ -69,7 +69,9 @@ public class PotionSpoof extends Module {
 
         for (Reference2IntMap.Entry<StatusEffect> entry : spoofPotions.get().reference2IntEntrySet()) {
             if (entry.getIntValue() <= 0) continue;
-            if (mc.player.hasStatusEffect(Registries.STATUS_EFFECT.getEntry(entry.getKey()))) mc.player.removeStatusEffect(Registries.STATUS_EFFECT.getEntry(entry.getKey()));
+            if (!mc.player.hasStatusEffect(Registries.STATUS_EFFECT.getEntry(entry.getKey()))) continue;
+
+            mc.player.removeStatusEffect(Registries.STATUS_EFFECT.getEntry(entry.getKey()));
         }
     }
 
@@ -84,7 +86,9 @@ public class PotionSpoof extends Module {
                 ((StatusEffectInstanceAccessor) instance).setAmplifier(level - 1);
                 if (instance.getDuration() < effectDuration.get()) ((StatusEffectInstanceAccessor) instance).setDuration(effectDuration.get());
             } else {
-                mc.player.addStatusEffect(new StatusEffectInstance(Registries.STATUS_EFFECT.getEntry(entry.getKey()), effectDuration.get(), level - 1));
+                mc.player.addStatusEffect(new StatusEffectInstance(
+                    Registries.STATUS_EFFECT.getEntry(entry.getKey()), effectDuration.get(), level - 1
+                ));
             }
         }
     }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Reorganizees the settings in potion spoof, updates some descriptions and adds a warning to the module widget that some effects modify client behavior so to be careful when using them. Also fixes the potion amplifiers setting showing the size of the list of potions available rather than those that have actually been modified. 

## Related issues

N/A

# How Has This Been Tested?

![image](https://github.com/user-attachments/assets/a2dfdb13-371a-4123-9058-470393742119)

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
