### PR TITLE
Caught nullpointererror caused by getting world name

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
@@ -378,11 +378,21 @@ public class Utils {
         if (mc.isInSingleplayer()) {
             if (mc.world == null) return "";
 
-            File folder = ((MinecraftServerAccessor) mc.getServer()).getSession().getWorldDirectory(mc.world.getRegistryKey()).toFile();
-            if (folder.toPath().relativize(mc.runDirectory.toPath()).getNameCount() != 2) {
-                folder = folder.getParentFile();
+            try {
+                File folder = ((MinecraftServerAccessor) mc.getServer()).getSession().getWorldDirectory(mc.world.getRegistryKey()).toFile();
+                if (folder.toPath().relativize(mc.runDirectory.toPath()).getNameCount() != 2) {
+                    folder = folder.getParentFile();
+                }
+
+                // return here if everything works
+                return folder.getName();
+            } catch (NullPointerException e) {
+                System.err.println("Something just attempted to get singleplayer world name after leaving causing a NullPointerException, printing stack trace.");
+                e.printStackTrace();
+
+                // return this if we caught an error
+                return "FAILED_BECAUSE_LEFT_WORLD";
             }
-            return folder.getName();
         }
 
         // Multiplayer


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description
When saving a singleplayer world after leaving the Utils.getWorldName() function thinks you're still in the world, causing a NullPointerError. I decided to just catch this error and return "FAILED_BECAUSE_LEFT_WORLD" instead of a world name. This is given instead of an empty string so StashFinder doesn't make unnamed directories if it triggers this bug.

## Related issues
Fixes #5259

# How Has This Been Tested?

Here's a youtube video demonstrating the issue and the fix. https://youtu.be/LRlU5--Dwks

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
