### PR TITLE
Support for line breaks in module descriptions

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/WMultiLabel.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/WMultiLabel.java
@@ -36,7 +36,6 @@ public abstract class WMultiLabel extends WLabel {
         int iInLine = 0;
 
         for (String line : textLines) {
-            System.out.println(Arrays.stream(textLines).toList());
             for (String word : line.split(" ")) {
                 double wordWidth = theme.textWidth(word, word.length(), title);
 
@@ -59,11 +58,10 @@ public abstract class WMultiLabel extends WLabel {
 
                     sb.append(word);
                     lineWidth += wordWidth;
-
-                    // now this line is not pointless!
-                    maxLineWidth = Math.max(maxLineWidth, lineWidth);
                     iInLine++;
                 }
+                // now this line is not pointless!
+                maxLineWidth = Math.max(maxLineWidth, lineWidth);
             }
             lines.add(sb.toString());
             sb.setLength(0);

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/WMultiLabel.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/WMultiLabel.java
@@ -6,6 +6,7 @@
 package meteordevelopment.meteorclient.gui.widgets;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public abstract class WMultiLabel extends WLabel {
@@ -23,7 +24,7 @@ public abstract class WMultiLabel extends WLabel {
     protected void onCalculateSize() {
         lines.clear();
 
-        String[] words = text.split(" ");
+        String[] textLines = text.split("\n");
         StringBuilder sb = new StringBuilder();
 
         double spaceWidth = theme.textWidth(" ", 1, title);
@@ -34,33 +35,40 @@ public abstract class WMultiLabel extends WLabel {
 
         int iInLine = 0;
 
-        for (int i = 0; i < words.length; i++) {
-            double wordWidth = theme.textWidth(words[i], words[i].length(), title);
+        for (String line : textLines) {
+            System.out.println(Arrays.stream(textLines).toList());
+            for (String word : line.split(" ")) {
+                double wordWidth = theme.textWidth(word, word.length(), title);
 
-            double toAdd = wordWidth;
-            if (iInLine > 0) toAdd += spaceWidth;
+                double toAdd = wordWidth;
+                if (iInLine > 0) toAdd += spaceWidth;
 
-            if (lineWidth + toAdd > maxWidth) {
-                lines.add(sb.toString());
-                sb.setLength(0);
+                if (lineWidth + toAdd > maxWidth) {
+                    lines.add(sb.toString());
+                    sb.setLength(0);
 
-                lineWidth = 0;
-                iInLine = 0;
+                    sb.append(word);
+                    lineWidth = wordWidth;
+                    iInLine = 1;
 
-                i--;
-            }
-            else {
-                if (iInLine > 0) {
-                    sb.append(' ');
-                    lineWidth += spaceWidth;
+                } else {
+                    if (iInLine > 0) {
+                        sb.append(' ');
+                        lineWidth += spaceWidth;
+                    }
+
+                    sb.append(word);
+                    lineWidth += wordWidth;
+
+                    // now this line is not pointless!
+                    maxLineWidth = Math.max(maxLineWidth, lineWidth);
+                    iInLine++;
                 }
-
-                sb.append(words[i]);
-                lineWidth += wordWidth;
-
-                maxLineWidth = Math.max(maxLineWidth, lineWidth);
-                iInLine++;
             }
+            lines.add(sb.toString());
+            sb.setLength(0);
+            lineWidth = 0;
+            iInLine = 0;
         }
 
         if (!sb.isEmpty()) lines.add(sb.toString());


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Added support for line breaks in module description and fixed an infinity loop caused a game crash if a word is longer than module window size! Hints and usage info look way better now 

# How Has This Been Tested?
**Before:**
![image](https://github.com/user-attachments/assets/5ba19191-fd7f-49a3-8378-e96d3ab81738)

**After:**
![image](https://github.com/user-attachments/assets/ef35b3d1-bd80-4718-af46-428c754ee0bb)

These screenshots were taken at different window resolutions, because original code gets stuck in an infinite loop on a small window size
I actually use this fix myself

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [x] I have added one unnecessary comment to my code!
- [x] I have tested the code in both development and production environments.
