### PR TITLE
Add 3d rendering with depth-test to api, among other things

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/events/render/Render3DEvent.java
+++ b/src/main/java/meteordevelopment/meteorclient/events/render/Render3DEvent.java
@@ -14,13 +14,15 @@ public class Render3DEvent {
 
     public MatrixStack matrices;
     public Renderer3D renderer;
+    public Renderer3D depthRenderer;
     public double frameTime;
     public float tickDelta;
     public double offsetX, offsetY, offsetZ;
 
-    public static Render3DEvent get(MatrixStack matrices, Renderer3D renderer, float tickDelta, double offsetX, double offsetY, double offsetZ) {
+    public static Render3DEvent get(MatrixStack matrices, Renderer3D renderer, Renderer3D depthRenderer, float tickDelta, double offsetX, double offsetY, double offsetZ) {
         INSTANCE.matrices = matrices;
         INSTANCE.renderer = renderer;
+        INSTANCE.depthRenderer = depthRenderer;
         INSTANCE.frameTime = Utils.frameTime;
         INSTANCE.tickDelta = tickDelta;
         INSTANCE.offsetX = offsetX;

--- a/src/main/java/meteordevelopment/meteorclient/gui/renderer/GuiDebugRenderer.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/renderer/GuiDebugRenderer.java
@@ -53,6 +53,8 @@ public class GuiDebugRenderer {
     }
 
     private void line(double x1, double y1, double x2, double y2, Color color) {
+        mesh.ensureLineCapacity();
+
         mesh.line(
             mesh.vec3(x1, y1, 0).color(color).next(),
             mesh.vec3(x2, y2, 0).color(color).next()

--- a/src/main/java/meteordevelopment/meteorclient/mixin/GameRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/GameRendererMixin.java
@@ -14,6 +14,7 @@ import meteordevelopment.meteorclient.events.render.GetFovEvent;
 import meteordevelopment.meteorclient.events.render.Render3DEvent;
 import meteordevelopment.meteorclient.events.render.RenderAfterWorldEvent;
 import meteordevelopment.meteorclient.mixininterface.IVec3d;
+import meteordevelopment.meteorclient.renderer.MeteorRenderPipelines;
 import meteordevelopment.meteorclient.renderer.Renderer3D;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.player.LiquidInteract;
@@ -66,6 +67,9 @@ public abstract class GameRendererMixin {
     private Renderer3D renderer;
 
     @Unique
+    private Renderer3D depthRenderer;
+
+    @Unique
     private final MatrixStack matrices = new MatrixStack();
 
     @Shadow
@@ -82,8 +86,9 @@ public abstract class GameRendererMixin {
 
         // Create renderer and event
 
-        if (renderer == null) renderer = new Renderer3D();
-        Render3DEvent event = Render3DEvent.get(matrixStack, renderer, tickDelta, camera.getPos().x, camera.getPos().y, camera.getPos().z);
+        if (renderer == null) renderer = new Renderer3D(MeteorRenderPipelines.WORLD_COLORED_LINES, MeteorRenderPipelines.WORLD_COLORED);
+        if (depthRenderer == null) depthRenderer = new Renderer3D(MeteorRenderPipelines.WORLD_COLORED_LINES_DEPTH, MeteorRenderPipelines.WORLD_COLORED_DEPTH);
+        Render3DEvent event = Render3DEvent.get(matrixStack, renderer, depthRenderer, tickDelta, camera.getPos().x, camera.getPos().y, camera.getPos().z);
 
         // Call utility classes
 
@@ -103,8 +108,10 @@ public abstract class GameRendererMixin {
         // Render
 
         renderer.begin();
+        depthRenderer.begin();
         MeteorClient.EVENT_BUS.post(event);
         renderer.render(matrixStack);
+        depthRenderer.render(matrixStack);
 
         // Revert model view matrix
 

--- a/src/main/java/meteordevelopment/meteorclient/renderer/FullScreenRenderer.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/FullScreenRenderer.java
@@ -16,7 +16,9 @@ public class FullScreenRenderer {
     @PreInit
     public static void init() {
         mesh = new MeshBuilder(MeteorVertexFormats.POS2, VertexFormat.DrawMode.TRIANGLES, 4, 6);
+
         mesh.begin();
+        mesh.ensureQuadCapacity();
 
         mesh.quad(
             mesh.vec2(-1, -1).next(),

--- a/src/main/java/meteordevelopment/meteorclient/renderer/FullScreenRenderer.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/FullScreenRenderer.java
@@ -15,10 +15,8 @@ public class FullScreenRenderer {
 
     @PreInit
     public static void init() {
-        mesh = new MeshBuilder(MeteorVertexFormats.POS2, VertexFormat.DrawMode.TRIANGLES);
+        mesh = new MeshBuilder(MeteorVertexFormats.POS2, VertexFormat.DrawMode.TRIANGLES, 4, 6);
         mesh.begin();
-
-        mesh.ensureQuadCapacity();
 
         mesh.quad(
             mesh.vec2(-1, -1).next(),

--- a/src/main/java/meteordevelopment/meteorclient/renderer/FullScreenRenderer.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/FullScreenRenderer.java
@@ -18,6 +18,8 @@ public class FullScreenRenderer {
         mesh = new MeshBuilder(MeteorVertexFormats.POS2, VertexFormat.DrawMode.TRIANGLES);
         mesh.begin();
 
+        mesh.ensureQuadCapacity();
+
         mesh.quad(
             mesh.vec2(-1, -1).next(),
             mesh.vec2(-1, 1).next(),

--- a/src/main/java/meteordevelopment/meteorclient/renderer/MeshBuilder.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/MeshBuilder.java
@@ -117,7 +117,6 @@ public class MeshBuilder {
         memPutInt(p + 4, i2);
 
         indicesCount += 2;
-        growIfNeeded();
     }
 
     public void quad(int i1, int i2, int i3, int i4) {
@@ -132,7 +131,6 @@ public class MeshBuilder {
         memPutInt(p + 20, i1);
 
         indicesCount += 6;
-        growIfNeeded();
     }
 
     public void triangle(int i1, int i2, int i3) {
@@ -143,16 +141,24 @@ public class MeshBuilder {
         memPutInt(p + 8, i3);
 
         indicesCount += 3;
-        growIfNeeded();
     }
 
-    public void growIfNeeded() {
-        // Vertices
-        if ((vertexI + 1) * primitiveVerticesSize >= vertices.capacity()) {
-            int offset = getVerticesOffset();
+    public void ensureQuadCapacity() {
+        ensureCapacity(4, 6);
+    }
 
+    public void ensureTriCapacity() {
+        ensureCapacity(3, 3);
+    }
+
+    public void ensureLineCapacity() {
+        ensureCapacity(2, 2);
+    }
+
+    public void ensureCapacity(int vertexCount, int indexCount) {
+        if ((vertexI + vertexCount) * primitiveVerticesSize >= vertices.capacity()) {
+            int offset = getVerticesOffset();
             int newSize = vertices.capacity() * 2;
-            if (newSize % primitiveVerticesSize != 0) newSize += newSize % primitiveVerticesSize;
 
             ByteBuffer newVertices = BufferUtils.createByteBuffer(newSize);
             memCopy(memAddress0(vertices), memAddress0(newVertices), offset);
@@ -162,10 +168,8 @@ public class MeshBuilder {
             verticesPointer = verticesPointerStart + offset;
         }
 
-        // Indices
-        if (indicesCount * 4 >= indices.capacity()) {
+        if ((indicesCount + indexCount) * 4 >= indices.capacity()) {
             int newSize = indices.capacity() * 2;
-            if (newSize % primitiveIndicesCount != 0) newSize += newSize % (primitiveIndicesCount * 4);
 
             ByteBuffer newIndices = BufferUtils.createByteBuffer(newSize);
             memCopy(memAddress0(indices), memAddress0(newIndices), indicesCount * 4L);

--- a/src/main/java/meteordevelopment/meteorclient/renderer/MeshBuilder.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/MeshBuilder.java
@@ -23,7 +23,6 @@ public class MeshBuilder {
 
     private final VertexFormat format;
     private final int primitiveVerticesSize;
-    private final int primitiveIndicesCount;
 
     private ByteBuffer vertices = null;
     private long verticesPointerStart, verticesPointer;
@@ -43,7 +42,6 @@ public class MeshBuilder {
     public MeshBuilder(VertexFormat format, VertexFormat.DrawMode drawMode) {
         this.format = format;
         primitiveVerticesSize = format.getVertexSize() * drawMode.firstVertexCount;
-        primitiveIndicesCount = drawMode.firstVertexCount;
     }
 
     public MeshBuilder(VertexFormat format, VertexFormat.DrawMode drawMode, int vertexCount, int indexCount) {
@@ -187,7 +185,7 @@ public class MeshBuilder {
         vertices = BufferUtils.createByteBuffer(primitiveVerticesSize * vertexCount);
         verticesPointer = verticesPointerStart = memAddress0(vertices);
 
-        indices = BufferUtils.createByteBuffer(primitiveIndicesCount * indexCount);
+        indices = BufferUtils.createByteBuffer(indexCount * 4);
         indicesPointer = memAddress0(indices);
     }
 

--- a/src/main/java/meteordevelopment/meteorclient/renderer/MeshBuilder.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/MeshBuilder.java
@@ -41,7 +41,7 @@ public class MeshBuilder {
 
     public MeshBuilder(VertexFormat format, VertexFormat.DrawMode drawMode) {
         this.format = format;
-        primitiveVerticesSize = format.getVertexSize() * drawMode.firstVertexCount;
+        primitiveVerticesSize = format.getVertexSize();
     }
 
     public MeshBuilder(VertexFormat format, VertexFormat.DrawMode drawMode, int vertexCount, int indexCount) {

--- a/src/main/java/meteordevelopment/meteorclient/renderer/MeshBuilder.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/MeshBuilder.java
@@ -46,9 +46,9 @@ public class MeshBuilder {
         primitiveIndicesCount = drawMode.firstVertexCount;
     }
 
-    public MeshBuilder(VertexFormat format, VertexFormat.DrawMode drawMode, int vertexCapacity, int indexCapacity) {
+    public MeshBuilder(VertexFormat format, VertexFormat.DrawMode drawMode, int vertexCount, int indexCount) {
         this(format, drawMode);
-        allocateBuffers(vertexCapacity, indexCapacity);
+        allocateBuffers(vertexCount, indexCount);
     }
 
     public void begin() {

--- a/src/main/java/meteordevelopment/meteorclient/renderer/MeshBuilder.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/MeshBuilder.java
@@ -25,10 +25,10 @@ public class MeshBuilder {
     private final int primitiveVerticesSize;
     private final int primitiveIndicesCount;
 
-    private ByteBuffer vertices;
+    private ByteBuffer vertices = null;
     private long verticesPointerStart, verticesPointer;
 
-    private ByteBuffer indices;
+    private ByteBuffer indices = null;
     private long indicesPointer;
 
     private int vertexI, indicesCount;
@@ -44,12 +44,6 @@ public class MeshBuilder {
         this.format = format;
         primitiveVerticesSize = format.getVertexSize() * drawMode.firstVertexCount;
         primitiveIndicesCount = drawMode.firstVertexCount;
-
-        vertices = BufferUtils.createByteBuffer(primitiveVerticesSize * 256 * 4);
-        verticesPointerStart = memAddress0(vertices);
-
-        indices = BufferUtils.createByteBuffer(primitiveIndicesCount * 512 * 4);
-        indicesPointer = memAddress0(indices);
     }
 
     public void begin() {
@@ -156,6 +150,16 @@ public class MeshBuilder {
     }
 
     public void ensureCapacity(int vertexCount, int indexCount) {
+        if (vertices == null || indices == null) {
+            vertices = BufferUtils.createByteBuffer(primitiveVerticesSize * 256 * 4);
+            verticesPointer = verticesPointerStart = memAddress0(vertices);
+
+            indices = BufferUtils.createByteBuffer(primitiveIndicesCount * 512 * 4);
+            indicesPointer = memAddress0(indices);
+
+            return;
+        }
+
         if ((vertexI + vertexCount) * primitiveVerticesSize >= vertices.capacity()) {
             int offset = getVerticesOffset();
             int newSize = vertices.capacity() * 2;

--- a/src/main/java/meteordevelopment/meteorclient/renderer/MeshBuilder.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/MeshBuilder.java
@@ -101,6 +101,8 @@ public class MeshBuilder {
     }
 
     public MeshBuilder color(Color c) {
+        debugVertexBufferCapacity();
+
         long p = verticesPointer;
 
         memPutByte(p, (byte) c.r);

--- a/src/main/java/meteordevelopment/meteorclient/renderer/MeshBuilder.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/MeshBuilder.java
@@ -189,7 +189,7 @@ public class MeshBuilder {
             verticesPointer = verticesPointerStart + offset;
         }
 
-        if ((indicesCount + indexCount) * 4 >= indices.capacity()) {
+        if ((indicesCount + indexCount) * Integer.BYTES >= indices.capacity()) {
             int newSize = indices.capacity() * 2;
 
             ByteBuffer newIndices = BufferUtils.createByteBuffer(newSize);
@@ -204,7 +204,7 @@ public class MeshBuilder {
         vertices = BufferUtils.createByteBuffer(primitiveVerticesSize * vertexCount);
         verticesPointer = verticesPointerStart = memAddress0(vertices);
 
-        indices = BufferUtils.createByteBuffer(indexCount * 4);
+        indices = BufferUtils.createByteBuffer(indexCount * Integer.BYTES);
         indicesPointer = memAddress0(indices);
     }
 
@@ -224,7 +224,7 @@ public class MeshBuilder {
     }
 
     public GpuBuffer getIndexBuffer() {
-        indices.limit(indicesCount * 4);
+        indices.limit(indicesCount * Integer.BYTES);
         return format.uploadImmediateIndexBuffer(indices);
     }
 
@@ -243,7 +243,7 @@ public class MeshBuilder {
     }
 
     private void debugIndexBufferCapacity() {
-        if (DEBUG && indicesCount * 4 >= indices.capacity()) {
+        if (DEBUG && indicesCount * Integer.BYTES >= indices.capacity()) {
             throw new IndexOutOfBoundsException("Indices written to MeshBuilder without calling 'ensureCapacity()' first!");
         }
     }

--- a/src/main/java/meteordevelopment/meteorclient/renderer/MeshBuilder.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/MeshBuilder.java
@@ -46,6 +46,11 @@ public class MeshBuilder {
         primitiveIndicesCount = drawMode.firstVertexCount;
     }
 
+    public MeshBuilder(VertexFormat format, VertexFormat.DrawMode drawMode, int vertexCapacity, int indexCapacity) {
+        this(format, drawMode);
+        allocateBuffers(vertexCapacity, indexCapacity);
+    }
+
     public void begin() {
         if (building) throw new IllegalStateException("Mesh.begin() called while already building.");
 
@@ -151,12 +156,7 @@ public class MeshBuilder {
 
     public void ensureCapacity(int vertexCount, int indexCount) {
         if (vertices == null || indices == null) {
-            vertices = BufferUtils.createByteBuffer(primitiveVerticesSize * 256 * 4);
-            verticesPointer = verticesPointerStart = memAddress0(vertices);
-
-            indices = BufferUtils.createByteBuffer(primitiveIndicesCount * 512 * 4);
-            indicesPointer = memAddress0(indices);
-
+            allocateBuffers(256 * 4, 512 * 4);
             return;
         }
 
@@ -181,6 +181,14 @@ public class MeshBuilder {
             indices = newIndices;
             indicesPointer = memAddress0(indices);
         }
+    }
+
+    private void allocateBuffers(int vertexCount, int indexCount) {
+        vertices = BufferUtils.createByteBuffer(primitiveVerticesSize * vertexCount);
+        verticesPointer = verticesPointerStart = memAddress0(vertices);
+
+        indices = BufferUtils.createByteBuffer(primitiveIndicesCount * indexCount);
+        indicesPointer = memAddress0(indices);
     }
 
     public void end() {

--- a/src/main/java/meteordevelopment/meteorclient/renderer/Renderer2D.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/Renderer2D.java
@@ -81,6 +81,8 @@ public class Renderer2D {
 
     // Tris
     public void triangle(double x1, double y1, double x2, double y2, double x3, double y3, Color color) {
+        triangles.ensureTriCapacity();
+
         triangles.triangle(
             triangles.vec2(x1, y1).color(color).next(),
             triangles.vec2(x2, y2).color(color).next(),
@@ -91,6 +93,8 @@ public class Renderer2D {
     // Lines
 
     public void line(double x1, double y1, double x2, double y2, Color color) {
+        lines.ensureLineCapacity();
+
         lines.line(
             lines.vec2(x1, y1).color(color).next(),
             lines.vec2(x2, y2).color(color).next()
@@ -98,6 +102,8 @@ public class Renderer2D {
     }
 
     public void boxLines(double x, double y, double width, double height, Color color) {
+        lines.ensureCapacity(4, 8);
+
         int i1 = lines.vec2(x, y).color(color).next();
         int i2 = lines.vec2(x, y + height).color(color).next();
         int i3 = lines.vec2(x + width, y + height).color(color).next();
@@ -112,6 +118,8 @@ public class Renderer2D {
     // Quads
 
     public void quad(double x, double y, double width, double height, Color cTopLeft, Color cTopRight, Color cBottomRight, Color cBottomLeft) {
+        triangles.ensureQuadCapacity();
+
         triangles.quad(
             triangles.vec2(x, y).color(cTopLeft).next(),
             triangles.vec2(x, y + height).color(cBottomLeft).next(),
@@ -127,6 +135,8 @@ public class Renderer2D {
     // Textured quads
 
     public void texQuad(double x, double y, double width, double height, Color color) {
+        triangles.ensureQuadCapacity();
+
         triangles.quad(
             triangles.vec2(x, y).vec2(0, 0).color(color).next(),
             triangles.vec2(x, y + height).vec2(0, 1).color(color).next(),
@@ -136,6 +146,8 @@ public class Renderer2D {
     }
 
     public void texQuad(double x, double y, double width, double height, TextureRegion texture, Color color) {
+        triangles.ensureQuadCapacity();
+
         triangles.quad(
             triangles.vec2(x, y).vec2(texture.x1, texture.y1).color(color).next(),
             triangles.vec2(x, y + height).vec2(texture.x1, texture.y2).color(color).next(),
@@ -145,6 +157,8 @@ public class Renderer2D {
     }
 
     public void texQuad(double x, double y, double width, double height, double rotation, double texX1, double texY1, double texX2, double texY2, Color color) {
+        triangles.ensureQuadCapacity();
+
         double rad = Math.toRadians(rotation);
         double cos = Math.cos(rad);
         double sin = Math.sin(rad);

--- a/src/main/java/meteordevelopment/meteorclient/renderer/Renderer3D.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/Renderer3D.java
@@ -53,13 +53,23 @@ public class Renderer3D {
 
     // Lines
 
-    public void line(double x1, double y1, double z1, double x2, double y2, double z2, Color color1, Color color2) {
-        lines.ensureLineCapacity();
+    public void line(double x1, double y1, double z1, double x2, double y2, double z2, Color color1, Color color2, boolean depth) {
+        MeshBuilder buffers = depth ? linesDepth : lines;
 
-        lines.line(
-            lines.vec3(x1, y1, z1).color(color1).next(),
-            lines.vec3(x2, y2, z2).color(color2).next()
+        buffers.ensureLineCapacity();
+
+        buffers.line(
+            buffers.vec3(x1, y1, z1).color(color1).next(),
+            buffers.vec3(x2, y2, z2).color(color2).next()
         );
+    }
+
+    public void line(double x1, double y1, double z1, double x2, double y2, double z2, Color color1, Color color2) {
+        line(x1, y1, z1, x2, y2, z2, color1, color2, false);
+    }
+
+    public void line(double x1, double y1, double z1, double x2, double y2, double z2, Color color, boolean depth) {
+        line(x1, y1, z1, x2, y2, z2, color, color, depth);
     }
 
     public void line(double x1, double y1, double z1, double x2, double y2, double z2, Color color) {
@@ -80,15 +90,25 @@ public class Renderer3D {
 
     // Quads
 
-    public void quad(double x1, double y1, double z1, double x2, double y2, double z2, double x3, double y3, double z3, double x4, double y4, double z4, Color topLeft, Color topRight, Color bottomRight, Color bottomLeft) {
-        triangles.ensureQuadCapacity();
+    public void quad(double x1, double y1, double z1, double x2, double y2, double z2, double x3, double y3, double z3, double x4, double y4, double z4, Color topLeft, Color topRight, Color bottomRight, Color bottomLeft, boolean depth) {
+        MeshBuilder buffers = depth ? trianglesDepth : triangles;
 
-        triangles.quad(
-            triangles.vec3(x1, y1, z1).color(bottomLeft).next(),
-            triangles.vec3(x2, y2, z2).color(topLeft).next(),
-            triangles.vec3(x3, y3, z3).color(topRight).next(),
-            triangles.vec3(x4, y4, z4).color(bottomRight).next()
+        buffers.ensureQuadCapacity();
+
+        buffers.quad(
+            buffers.vec3(x1, y1, z1).color(bottomLeft).next(),
+            buffers.vec3(x2, y2, z2).color(topLeft).next(),
+            buffers.vec3(x3, y3, z3).color(topRight).next(),
+            buffers.vec3(x4, y4, z4).color(bottomRight).next()
         );
+    }
+
+    public void quad(double x1, double y1, double z1, double x2, double y2, double z2, double x3, double y3, double z3, double x4, double y4, double z4, Color topLeft, Color topRight, Color bottomRight, Color bottomLeft) {
+        quad(x1, y1 ,z1, x2, y2, z2, x3, y3, z3, x4, y4, z4, topLeft, topRight, bottomRight, bottomLeft, false);
+    }
+
+    public void quad(double x1, double y1, double z1, double x2, double y2, double z2, double x3, double y3, double z3, double x4, double y4, double z4, Color color, boolean depth) {
+        quad(x1, y1, z1, x2, y2, z2, x3, y3, z3, x4, y4, z4, color, color, color, color, depth);
     }
 
     public void quad(double x1, double y1, double z1, double x2, double y2, double z2, double x3, double y3, double z3, double x4, double y4, double z4, Color color) {

--- a/src/main/java/meteordevelopment/meteorclient/renderer/Renderer3D.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/Renderer3D.java
@@ -38,6 +38,8 @@ public class Renderer3D {
     // Lines
 
     public void line(double x1, double y1, double z1, double x2, double y2, double z2, Color color1, Color color2) {
+        lines.ensureLineCapacity();
+
         lines.line(
             lines.vec3(x1, y1, z1).color(color1).next(),
             lines.vec3(x2, y2, z2).color(color2).next()
@@ -50,6 +52,8 @@ public class Renderer3D {
 
     @SuppressWarnings("Duplicates")
     public void boxLines(double x1, double y1, double z1, double x2, double y2, double z2, Color color, int excludeDir) {
+        lines.ensureCapacity(8, 24);
+
         int blb = lines.vec3(x1, y1, z1).color(color).next();
         int blf = lines.vec3(x1, y1, z2).color(color).next();
         int brb = lines.vec3(x2, y1, z1).color(color).next();
@@ -97,8 +101,6 @@ public class Renderer3D {
             if (Dir.isNot(excludeDir, Dir.NORTH) && Dir.isNot(excludeDir, Dir.UP)) lines.line(tlb, trb);
             if (Dir.isNot(excludeDir, Dir.SOUTH) && Dir.isNot(excludeDir, Dir.UP)) lines.line(tlf, trf);
         }
-
-        lines.growIfNeeded();
     }
 
     public void blockLines(int x, int y, int z, Color color, int excludeDir) {
@@ -108,6 +110,8 @@ public class Renderer3D {
     // Quads
 
     public void quad(double x1, double y1, double z1, double x2, double y2, double z2, double x3, double y3, double z3, double x4, double y4, double z4, Color topLeft, Color topRight, Color bottomRight, Color bottomLeft) {
+        triangles.ensureQuadCapacity();
+
         triangles.quad(
             triangles.vec3(x1, y1, z1).color(bottomLeft).next(),
             triangles.vec3(x2, y2, z2).color(topLeft).next(),
@@ -137,6 +141,8 @@ public class Renderer3D {
     @SuppressWarnings("Duplicates")
     public void side(double x1, double y1, double z1, double x2, double y2, double z2, double x3, double y3, double z3, double x4, double y4, double z4, Color sideColor, Color lineColor, ShapeMode mode) {
         if (mode.lines()) {
+            lines.ensureCapacity(4, 8);
+
             int i1 = lines.vec3(x1, y1, z1).color(lineColor).next();
             int i2 = lines.vec3(x2, y2, z2).color(lineColor).next();
             int i3 = lines.vec3(x3, y3, z3).color(lineColor).next();
@@ -165,6 +171,8 @@ public class Renderer3D {
 
     @SuppressWarnings("Duplicates")
     public void boxSides(double x1, double y1, double z1, double x2, double y2, double z2, Color color, int excludeDir) {
+        triangles.ensureCapacity(8, 36);
+
         int blb = triangles.vec3(x1, y1, z1).color(color).next();
         int blf = triangles.vec3(x1, y1, z2).color(color).next();
         int brb = triangles.vec3(x2, y1, z1).color(color).next();
@@ -200,8 +208,6 @@ public class Renderer3D {
             // Top
             if (Dir.isNot(excludeDir, Dir.UP)) triangles.quad(tlb, tlf, trf, trb);
         }
-
-        triangles.growIfNeeded();
     }
 
     public void blockSides(int x, int y, int z, Color color, int excludeDir) {

--- a/src/main/java/meteordevelopment/meteorclient/renderer/text/Font.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/text/Font.java
@@ -120,7 +120,10 @@ public class Font {
     public double render(MeshBuilder mesh, String string, double x, double y, Color color, double scale) {
         y += ascent * this.scale * scale;
 
-        for (int i = 0; i < string.length(); i++) {
+        int length = string.length();
+        mesh.ensureCapacity(length * 4, length * 6);
+
+        for (int i = 0; i < length; i++) {
             int cp = string.charAt(i);
             CharData c = charMap.get(cp);
             if (c == null) c = charMap.get(32);

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/LightOverlay.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/LightOverlay.java
@@ -119,6 +119,8 @@ public class LightOverlay extends Module {
     }
 
     private void line(double x1, double y1, double z1, double x2, double y2, double z2, Color color) {
+        mesh.ensureLineCapacity();
+
         mesh.line(
             mesh.vec3(x1, y1, z1).color(color).next(),
             mesh.vec3(x2, y2, z2).color(color).next()

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/LightOverlay.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/LightOverlay.java
@@ -99,8 +99,10 @@ public class LightOverlay extends Module {
     private void onRender(Render3DEvent event) {
         if (crosses.isEmpty()) return;
 
+        Renderer3D renderer = seeThroughBlocks.get() ? event.renderer : event.depthRenderer;
+
         for (Cross cross : crosses) {
-            cross.render(event.renderer);
+            cross.render(renderer);
         }
     }
 
@@ -120,10 +122,9 @@ public class LightOverlay extends Module {
 
         public void render(Renderer3D renderer) {
             Color c = potential ? potentialColor.get() : color.get();
-            boolean depth = !seeThroughBlocks.get();
 
-            renderer.line(x, y, z, x + 1, y, z + 1, c, depth);
-            renderer.line(x + 1, y, z, x, y, z + 1, c, depth);
+            renderer.line(x, y, z, x + 1, y, z + 1, c);
+            renderer.line(x + 1, y, z, x, y, z + 1, c);
         }
     }
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/LightOverlay.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/LightOverlay.java
@@ -7,9 +7,7 @@ package meteordevelopment.meteorclient.systems.modules.render;
 
 import meteordevelopment.meteorclient.events.render.Render3DEvent;
 import meteordevelopment.meteorclient.events.world.TickEvent;
-import meteordevelopment.meteorclient.renderer.MeshBuilder;
-import meteordevelopment.meteorclient.renderer.MeshRenderer;
-import meteordevelopment.meteorclient.renderer.MeteorRenderPipelines;
+import meteordevelopment.meteorclient.renderer.Renderer3D;
 import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
@@ -79,8 +77,6 @@ public class LightOverlay extends Module {
     private final Pool<Cross> crossPool = new Pool<>(Cross::new);
     private final List<Cross> crosses = new ArrayList<>();
 
-    private final MeshBuilder mesh = new MeshBuilder(MeteorRenderPipelines.WORLD_COLORED_LINES);
-
     public LightOverlay() {
         super(Categories.Render, "light-overlay", "Shows blocks where mobs can spawn.");
     }
@@ -103,28 +99,9 @@ public class LightOverlay extends Module {
     private void onRender(Render3DEvent event) {
         if (crosses.isEmpty()) return;
 
-        mesh.begin();
-
         for (Cross cross : crosses) {
-            cross.render();
+            cross.render(event.renderer);
         }
-
-        mesh.end();
-
-        MeshRenderer.begin()
-            .attachments(mc.getFramebuffer())
-            .pipeline(seeThroughBlocks.get() ? MeteorRenderPipelines.WORLD_COLORED_LINES : MeteorRenderPipelines.WORLD_COLORED_LINES_DEPTH)
-            .mesh(mesh, event.matrices)
-            .end();
-    }
-
-    private void line(double x1, double y1, double z1, double x2, double y2, double z2, Color color) {
-        mesh.ensureLineCapacity();
-
-        mesh.line(
-            mesh.vec3(x1, y1, z1).color(color).next(),
-            mesh.vec3(x2, y2, z2).color(color).next()
-        );
     }
 
     private class Cross {
@@ -141,11 +118,12 @@ public class LightOverlay extends Module {
             return this;
         }
 
-        public void render() {
+        public void render(Renderer3D renderer) {
             Color c = potential ? potentialColor.get() : color.get();
+            boolean depth = !seeThroughBlocks.get();
 
-            line(x, y, z, x + 1, y, z + 1, c);
-            line(x + 1, y, z, x, y, z + 1, c);
+            renderer.line(x, y, z, x + 1, y, z + 1, c, depth);
+            renderer.line(x + 1, y, z, x, y, z + 1, c, depth);
         }
     }
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/MeshBuilderVertexConsumerProvider.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/MeshBuilderVertexConsumerProvider.java
@@ -60,6 +60,8 @@ public class MeshBuilderVertexConsumerProvider implements IVertexConsumerProvide
             zs[i] = (double) offsetZ + z;
 
             if (++i >= 4) {
+                mesh.ensureQuadCapacity();
+
                 mesh.quad(
                     mesh.vec3(xs[0], ys[0], zs[0]).color(color).next(),
                     mesh.vec3(xs[1], ys[1], zs[1]).color(color).next(),


### PR DESCRIPTION
Changes:
- `Render3DEvent` now has a field called `depthRenderer` which holds a separate `Renderer3D` with depth test enabled (does not render through blocks).
- `LightOverlay` now uses the depth-test renderer.

Improvements:
- `MeshBuilder` no longer accidentally writes data out of bounds into unmanaged memory, causing offheap corruption.
- `MeshBuilder` now has a separate constructor that takes in initial buffer sizes.
- `MeshBuilder` buffers are now lazily allocated.

Extra considerations:
If you were rendering things by manually calling `MeshBuilder` methods, you now have to manually do bounds checking through calling `MeshBuilder#ensureCapacity`. (This is not required when using existing renderer classes like `Renderer2D` and `Renderer3D`)