### PR TITLE
Fix game crash caused by NullPointerException in KillAura

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/KillAura.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/KillAura.java
@@ -266,7 +266,7 @@ public class KillAura extends Module {
 
     @EventHandler
     private void onTick(TickEvent.Pre event) {
-        if (!mc.player.isAlive() || PlayerUtils.getGameMode() == GameMode.SPECTATOR) {
+        if (!mc.player || !mc.player.isAlive() || PlayerUtils.getGameMode() == GameMode.SPECTATOR) {
             stopAttacking();
             return;
         }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Added a check to ensure `mc.player` has value before checking the `.isAlive()` function. This fixes a NullPointerException caused by leaving a server right as KillAura attacks an enemy.

## Related issues

Mention any issues that this pr relates to.

# How Has This Been Tested?

I used it and it worked

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
