### PR TITLE
fix: AutoEat not switching slots when food runs out 

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoEat.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoEat.java
@@ -124,18 +124,18 @@ public class AutoEat extends Module {
             // If we are eating check if we should still be eating
             if (shouldEat()) {
                 // Check if the item in current slot is not food
-                if (mc.player.getInventory().getStack(slot).get(DataComponentTypes.FOOD) != null) {
+                if (mc.player.getInventory().getStack(slot).get(DataComponentTypes.FOOD) == null) {
                     // If not try finding a new slot
-                    int slot = findSlot();
+                    int newSlot = findSlot();
 
                     // If no valid slot was found then stop eating
-                    if (slot == -1) {
+                    if (newSlot == -1) {
                         stopEating();
                         return;
                     }
                     // Otherwise change to the new slot
                     else {
-                        changeSlot(slot);
+                        changeSlot(newSlot);
                     }
                 }
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Fixed condition that checks for food in current slot to allow switching when food is depleted.

When using AutoEat, if the food in the current slot runs out, the module fails to switch to another slot with food. The player gets stuck with the empty slot until another food item appears in that same slot.

- Fixed the condition in `onTick` that checks if the current slot contains food
- refactor method  onTick to remove nesting

bug demo:
![2025-05-05 14-30-34](https://github.com/user-attachments/assets/f1cfdf79-63a2-4f21-ba04-535851583be2)

## Related issues

#4836

# How Has This Been Tested?

![2025-05-05 14-58-40](https://github.com/user-attachments/assets/911b33e9-1703-4b34-865d-07f7727fb590)

you can see in the gif that the slots can be switched after applying this patch

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
