### PR TITLE
added new get method in Settings api

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/settings/Settings.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/Settings.java
@@ -42,6 +42,18 @@ public class Settings implements ISerializable<Settings>, Iterable<SettingGroup>
         return null;
     }
 
+    public <T> Setting<T> get(String name, Class<T> tClass) {
+        for (SettingGroup sg : this) {
+            for (Setting<?> setting : sg) {
+                Class<?> sClass = setting.getDefaultValue().getClass();
+                if (name.equalsIgnoreCase(setting.name) && tClass.equals(sClass))
+                    return (Setting<T>) setting;
+            }
+        }
+
+        return null;
+    }
+
     public void reset() {
         for (SettingGroup group : groups) {
             for (Setting<?> setting : group) {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

When i was porting some meteor addon to 1.21.5 i saw the ugly casting like this `Setting<Boolean> setting = ((Setting<Boolean>) module.settings.get(...));` so i decided to add new method to the api that prevents that.


## Related issues

Mention any issues that this pr relates to.

# How Has This Been Tested?

it works

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
