### PR TITLE
proxy import can now read authentication info

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/ProxiesImportScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/ProxiesImportScreen.java
@@ -5,6 +5,7 @@
 
 package meteordevelopment.meteorclient.gui.screens;
 
+import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.gui.GuiTheme;
 import meteordevelopment.meteorclient.gui.WindowScreen;
 import meteordevelopment.meteorclient.gui.widgets.containers.WVerticalList;
@@ -40,13 +41,13 @@ public class ProxiesImportScreen extends WindowScreen {
             WVerticalList list = add(theme.section("Log", false)).widget().add(theme.verticalList()).expandX().widget();
             Proxies proxies = Proxies.get();
             try {
-                int pog = 0, bruh = 0;
+                int success = 0, fail = 0;
                 for (String line : Files.readAllLines(file.toPath())) {
                     Matcher matcher;
                     Proxy proxy = null;
 
                     matcher = Proxies.PROXY_PATTERN.matcher(line);
-                    if (proxy == null && matcher.matches()) {
+                    if (matcher.matches()) {
                         String address = matcher.group(2).replaceAll("\\b0+\\B", "");
                         int port = Integer.parseInt(matcher.group(3));
 
@@ -78,36 +79,44 @@ public class ProxiesImportScreen extends WindowScreen {
                         String address = matcher.group("addr").replaceAll("\\b0+\\B", "");
                         int port = Integer.parseInt(matcher.group("port"));
 
+                        ProxyType type = ProxyType.parse(matcher.group(1));
+                        if (type == null) {
+                            if (matcher.group(1) != null && matcher.group(1).equals("socks")) type = ProxyType.Socks5;
+                            // if it has a password it's a socks5 proxy
+                            else if (matcher.group("pass") != null) type = ProxyType.Socks5;
+                            else type = ProxyType.Socks4;
+                        }
+
                         proxy = new Proxy.Builder()
                             .address(address)
                             .port(port)
                             .name(address + ":" + port)
                             .username(matcher.group("user") != null ? matcher.group("user") : "")
                             .password(matcher.group("pass") != null ? matcher.group("pass") : "")
-                            .type(matcher.group(1) != null && matcher.group(1).equals("socks4") ? ProxyType.Socks4 : ProxyType.Socks5)
+                            .type(type)
                             .build();
                     }
 
                     if (proxy == null) {
                         list.add(theme.label("Unrecognised proxy format: " + line).color(Color.RED));
-                        bruh++;
+                        fail++;
                     } else {
                         if (proxies.add(proxy)) {
                             list.add(theme.label("Imported proxy: " + proxy.name.get()).color(Color.GREEN));
-                            pog++;
+                            success++;
                         }
                         else {
                             list.add(theme.label("Proxy already exists: " + proxy.name.get()).color(Color.ORANGE));
-                            bruh++;
+                            fail++;
                         }
                     }
                 }
                 add(theme
-                    .label("Successfully imported " + pog + "/" + (bruh + pog) + " proxies.")
-                    .color(Utils.lerp(Color.RED, Color.GREEN, (float) pog / (pog + bruh)))
+                    .label("Successfully imported " + success + "/" + (fail + success) + " proxies.")
+                    .color(Utils.lerp(Color.RED, Color.GREEN, (float) success / (success + fail)))
                 );
             } catch (IOException e) {
-                e.printStackTrace();
+                MeteorClient.LOG.error("An error occurred while importing the proxy file", e);
             }
         } else {
             add(theme.label("Invalid File!"));

--- a/src/main/java/meteordevelopment/meteorclient/systems/proxies/Proxies.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/proxies/Proxies.java
@@ -19,6 +19,10 @@ import java.util.regex.Pattern;
 public class Proxies extends System<Proxies> implements Iterable<Proxy> {
     // https://regex101.com/r/gRHjnd/latest
     public static final Pattern PROXY_PATTERN = Pattern.compile("^(?:([\\w\\s]+)=)?((?:0*(?:\\d|[1-9]\\d|1\\d\\d|2[0-4]\\d|25[0-5])(?:\\.(?!:)|)){4}):(?!0)(\\d{1,4}|[1-5]\\d{4}|6[0-4]\\d{3}|65[0-4]\\d{2}|655[0-2]\\d|6553[0-5])(?i:@(socks[45]))?$", Pattern.MULTILINE);
+    // https://regex101.com/r/QXATIS/1
+    public static final Pattern PROXY_PATTERN_WEBSHARE = Pattern.compile("^((?:0*(?:\\d|[1-9]\\d|1\\d\\d|2[0-4]\\d|25[0-5])(?:\\.(?!\\:)|)){4})\\:(?!0)(\\d{1,4}|[1-5]\\d{4}|6[0-4]\\d{3}|65[0-4]\\d{2}|655[0-2]\\d|6553[0-5])(?:\\:([^:]+)(?:\\:(.+))?)$", Pattern.MULTILINE);
+    // https://regex101.com/r/7M2LFx/1
+    public static final Pattern PROXY_PATTERN_URI = Pattern.compile("^(?:(socks|socks4)\\:\\/\\/)?(?:(?<user>[\\w~-]+)(\\:(?<pass>[\\w~-]+))?\\@)?(?<addr>(?:0*(?:\\d|[1-9]\\d|1\\d\\d|2[0-4]\\d|25[0-5])(?:\\.(?!\\:)|)){4})\\:(?!0)(?<port>\\d{1,4}|[1-5]\\d{4}|6[0-4]\\d{3}|65[0-4]\\d{2}|655[0-2]\\d|6553[0-5])$", Pattern.MULTILINE);
 
     private List<Proxy> proxies = new ArrayList<>();
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/proxies/Proxies.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/proxies/Proxies.java
@@ -14,15 +14,16 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 public class Proxies extends System<Proxies> implements Iterable<Proxy> {
     // https://regex101.com/r/gRHjnd/latest
     public static final Pattern PROXY_PATTERN = Pattern.compile("^(?:([\\w\\s]+)=)?((?:0*(?:\\d|[1-9]\\d|1\\d\\d|2[0-4]\\d|25[0-5])(?:\\.(?!:)|)){4}):(?!0)(\\d{1,4}|[1-5]\\d{4}|6[0-4]\\d{3}|65[0-4]\\d{2}|655[0-2]\\d|6553[0-5])(?i:@(socks[45]))?$", Pattern.MULTILINE);
     // https://regex101.com/r/QXATIS/1
-    public static final Pattern PROXY_PATTERN_WEBSHARE = Pattern.compile("^((?:0*(?:\\d|[1-9]\\d|1\\d\\d|2[0-4]\\d|25[0-5])(?:\\.(?!\\:)|)){4})\\:(?!0)(\\d{1,4}|[1-5]\\d{4}|6[0-4]\\d{3}|65[0-4]\\d{2}|655[0-2]\\d|6553[0-5])(?:\\:([^:]+)(?:\\:(.+))?)$", Pattern.MULTILINE);
+    public static final Pattern PROXY_PATTERN_WEBSHARE = Pattern.compile("^((?:0*(?:\\d|[1-9]\\d|1\\d\\d|2[0-4]\\d|25[0-5])(?:\\.(?!:)|)){4}):(?!0)(\\d{1,4}|[1-5]\\d{4}|6[0-4]\\d{3}|65[0-4]\\d{2}|655[0-2]\\d|6553[0-5])(?::([^:]+)(?::(.+))?)$", Pattern.MULTILINE);
     // https://regex101.com/r/7M2LFx/1
-    public static final Pattern PROXY_PATTERN_URI = Pattern.compile("^(?:(socks|socks4)\\:\\/\\/)?(?:(?<user>[\\w~-]+)(\\:(?<pass>[\\w~-]+))?\\@)?(?<addr>(?:0*(?:\\d|[1-9]\\d|1\\d\\d|2[0-4]\\d|25[0-5])(?:\\.(?!\\:)|)){4})\\:(?!0)(?<port>\\d{1,4}|[1-5]\\d{4}|6[0-4]\\d{3}|65[0-4]\\d{2}|655[0-2]\\d|6553[0-5])$", Pattern.MULTILINE);
+    public static final Pattern PROXY_PATTERN_URI = Pattern.compile("^(?:(socks|socks4|socks5)://)?(?:(?<user>[\\w~-]+)(:(?<pass>[\\w~-]+))?@)?(?<addr>(?:0*(?:\\d|[1-9]\\d|1\\d\\d|2[0-4]\\d|25[0-5])(?:\\.(?!:)|)){4}):(?!0)(?<port>\\d{1,4}|[1-5]\\d{4}|6[0-4]\\d{3}|65[0-4]\\d{2}|655[0-2]\\d|6553[0-5])$", Pattern.MULTILINE);
 
     private List<Proxy> proxies = new ArrayList<>();
 
@@ -36,7 +37,7 @@ public class Proxies extends System<Proxies> implements Iterable<Proxy> {
 
     public boolean add(Proxy proxy) {
         for (Proxy p : proxies) {
-            if (p.type.get().equals(proxy.type.get()) && p.address.get().equals(proxy.address.get()) && p.port.get() == proxy.port.get()) return false;
+            if (p.type.get().equals(proxy.type.get()) && p.address.get().equals(proxy.address.get()) && Objects.equals(p.port.get(), proxy.port.get())) return false;
         }
 
         if (proxies.isEmpty()) proxy.enabled.set(true);

--- a/src/main/java/meteordevelopment/meteorclient/systems/proxies/Proxy.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/proxies/Proxy.java
@@ -86,6 +86,7 @@ public class Proxy implements ISerializable<Proxy> {
         protected int port = 0;
         protected String name = "";
         protected String username = "";
+        protected String password = "";
         protected boolean enabled = false;
 
         public Builder type(ProxyType type) {
@@ -113,6 +114,10 @@ public class Proxy implements ISerializable<Proxy> {
             return this;
         }
 
+        public Builder password(String password) {
+            this.password = password;
+            return this;
+        }
         public Builder enabled(boolean enabled) {
             this.enabled = enabled;
             return this;
@@ -126,6 +131,7 @@ public class Proxy implements ISerializable<Proxy> {
             if (port != proxy.port.getDefaultValue()) proxy.port.set(port);
             if (!name.equals(proxy.name.getDefaultValue())) proxy.name.set(name);
             if (!username.equals(proxy.username.getDefaultValue())) proxy.username.set(username);
+            if (!password.equals(proxy.password.getDefaultValue())) proxy.password.set(password);
             if (enabled != proxy.enabled.getDefaultValue()) proxy.enabled.set(enabled);
 
             return proxy;

--- a/src/main/java/meteordevelopment/meteorclient/systems/proxies/Proxy.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/proxies/Proxy.java
@@ -118,6 +118,7 @@ public class Proxy implements ISerializable<Proxy> {
             this.password = password;
             return this;
         }
+
         public Builder enabled(boolean enabled) {
             this.enabled = enabled;
             return this;


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature

## Description

proxy import now can read these two formats commonly seen in proxy lists exported from providers:
- `address:port:username:password`  (used by at least Webshare)
- `username:password@address:port` (also accepts a `socks://` at the start)

## Related issues

random complaint on discord

# How Has This Been Tested?

tested against
```
19.34.56.78:1234
19.34.56.78:4444@socks4
17.34.56.78:1234:username:password
12.53.12.64:5231:username
username@21.53.64.21:3122
username:password@31.43.65.54:3123
socks4://31.43.65.54:4444
socks://username:password@42.12.54.32:3123
```

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
