### PR TITLE
Added options to disable pitch lock and auto takeoff to ElytraFly bounce

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFlightMode.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFlightMode.java
@@ -84,13 +84,12 @@ public class ElytraFlightMode {
     }
 
     public void autoTakeoff() {
-        if (elytraFly.manualTakeoff.get()) return;
-
         if (incrementJumpTimer) jumpTimer++;
 
         boolean jumpPressed = mc.options.jumpKey.isPressed();
 
-        if (elytraFly.autoTakeOff.get() && jumpPressed) {
+        if ((elytraFly.autoTakeOff.get() && elytraFly.flightMode.get() != ElytraFlightModes.Pitch40 && elytraFly.flightMode.get() != ElytraFlightModes.Bounce) ||
+            (!elytraFly.manualTakeoff.get() && elytraFly.flightMode.get() == ElytraFlightModes.Bounce) && jumpPressed) {
             if (!lastJumpPressed && !mc.player.isGliding()) {
                 jumpTimer = 0;
                 incrementJumpTimer = true;

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFlightMode.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFlightMode.java
@@ -84,6 +84,8 @@ public class ElytraFlightMode {
     }
 
     public void autoTakeoff() {
+        if (elytraFly.manualTakeoff.get()) return;
+
         if (incrementJumpTimer) jumpTimer++;
 
         boolean jumpPressed = mc.options.jumpKey.isPressed();

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFly.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFly.java
@@ -199,11 +199,29 @@ public class ElytraFly extends Module {
     );
 
     public final Setting<Rotation.LockMode> yawLockMode = sgGeneral.add(new EnumSetting.Builder<Rotation.LockMode>()
-            .name("yaw-lock")
-            .description("Whether to enable yaw lock or not")
-            .defaultValue(Rotation.LockMode.Smart)
-            .visible(() -> flightMode.get() == ElytraFlightModes.Bounce)
-            .build()
+        .name("yaw-lock")
+        .description("Whether to enable yaw lock or not")
+        .defaultValue(Rotation.LockMode.Smart)
+        .visible(() -> flightMode.get() == ElytraFlightModes.Bounce)
+        .build()
+    );
+
+    public final Setting<Double> yaw = sgGeneral.add(new DoubleSetting.Builder()
+        .name("yaw")
+        .description("The yaw angle to look at when using simple rotation lock in bounce mode.")
+        .defaultValue(0)
+        .range(0, 360)
+        .sliderRange(0,360)
+        .visible(() -> flightMode.get() == ElytraFlightModes.Bounce && yawLockMode.get() == Rotation.LockMode.Simple)
+        .build()
+    );
+
+    public final Setting<Boolean> lockPitch = sgGeneral.add(new BoolSetting.Builder()
+        .name("pitch-lock")
+        .description("Whether to lock your pitch angle.")
+        .defaultValue(true)
+        .visible(() -> flightMode.get() == ElytraFlightModes.Bounce)
+        .build()
     );
 
     public final Setting<Double> pitch = sgGeneral.add(new DoubleSetting.Builder()
@@ -212,18 +230,8 @@ public class ElytraFly extends Module {
         .defaultValue(85)
         .range(0, 90)
         .sliderRange(0, 90)
-        .visible(() -> flightMode.get() == ElytraFlightModes.Bounce)
+        .visible(() -> flightMode.get() == ElytraFlightModes.Bounce && lockPitch.get())
         .build()
-    );
-
-    public final Setting<Double> yaw = sgGeneral.add(new DoubleSetting.Builder()
-            .name("yaw")
-            .description("The yaw angle to look at when using simple rotation lock in bounce mode.")
-            .defaultValue(0)
-            .range(0, 360)
-            .sliderRange(0,360)
-            .visible(() -> flightMode.get() == ElytraFlightModes.Bounce && yawLockMode.get() == Rotation.LockMode.Simple)
-            .build()
     );
 
     public final Setting<Boolean> restart = sgGeneral.add(new BoolSetting.Builder()
@@ -245,24 +253,16 @@ public class ElytraFly extends Module {
     );
 
     public final Setting<Boolean> sprint = sgGeneral.add(new BoolSetting.Builder()
-        .name("sprint")
+        .name("sprint-constantly")
         .description("Sprints all the time. If turned off, it will only sprint when the player is touching the ground.")
         .defaultValue(true)
         .visible(() -> flightMode.get() == ElytraFlightModes.Bounce)
         .build()
     );
 
-    public final Setting<Boolean> pitchUnlock = sgGeneral.add(new BoolSetting.Builder()
-        .name("pitch-unlock")
-        .description("Does not lock the pitch angle, allowing player to jump around freely")
-        .defaultValue(false)
-        .visible(() -> flightMode.get() == ElytraFlightModes.Bounce)
-        .build()
-    );
-
     public final Setting<Boolean> manualTakeoff = sgGeneral.add(new BoolSetting.Builder()
         .name("manual-takeoff")
-        .description("Does not automatically take off")
+        .description("Does not automatically take off.")
         .defaultValue(false)
         .visible(() -> flightMode.get() == ElytraFlightModes.Bounce)
         .build()
@@ -281,8 +281,8 @@ public class ElytraFly extends Module {
         .name("replace-durability")
         .description("The durability threshold your elytra will be replaced at.")
         .defaultValue(2)
-        .range(1, Items.ELYTRA.getComponents().get(DataComponentTypes.MAX_DAMAGE) - 1)
-        .sliderRange(1, Items.ELYTRA.getComponents().get(DataComponentTypes.MAX_DAMAGE) - 1)
+        .range(1, Items.ELYTRA.getComponents().getOrDefault(DataComponentTypes.MAX_DAMAGE, 432) - 1)
+        .sliderRange(1, Items.ELYTRA.getComponents().getOrDefault(DataComponentTypes.MAX_DAMAGE, 432) - 1)
         .visible(replace::get)
         .build()
     );

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFly.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/ElytraFly.java
@@ -252,6 +252,22 @@ public class ElytraFly extends Module {
         .build()
     );
 
+    public final Setting<Boolean> pitchUnlock = sgGeneral.add(new BoolSetting.Builder()
+        .name("pitch-unlock")
+        .description("Does not lock the pitch angle, allowing player to jump around freely")
+        .defaultValue(false)
+        .visible(() -> flightMode.get() == ElytraFlightModes.Bounce)
+        .build()
+    );
+
+    public final Setting<Boolean> manualTakeoff = sgGeneral.add(new BoolSetting.Builder()
+        .name("manual-takeoff")
+        .description("Does not automatically take off")
+        .defaultValue(false)
+        .visible(() -> flightMode.get() == ElytraFlightModes.Bounce)
+        .build()
+    );
+
     // Inventory
 
     public final Setting<Boolean> replace = sgInventory.add(new BoolSetting.Builder()

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/modes/Bounce.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/modes/Bounce.java
@@ -41,13 +41,12 @@ public class Bounce extends ElytraFlightMode {
 
         // Make sure all the conditions are met (player has an elytra, isn't in water, etc)
         if (checkConditions(mc.player)) {
-
             if (!rubberbanded) {
                 if (prevFov != 0 && !elytraFly.sprint.get()) mc.options.getFovEffectScale().setValue(0.0); // This stops the FOV effects from constantly going on and off.
                 if (elytraFly.autoJump.get()) setPressed(mc.options.jumpKey, true);
                 setPressed(mc.options.forwardKey, true);
                 mc.player.setYaw(getYawDirection());
-                if (!elytraFly.pitchUnlock.get()) mc.player.setPitch(elytraFly.pitch.get().floatValue());
+                if (elytraFly.lockPitch.get()) mc.player.setPitch(elytraFly.pitch.get().floatValue());
             }
 
             if (!elytraFly.sprint.get()) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/modes/Bounce.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/modes/Bounce.java
@@ -37,7 +37,7 @@ public class Bounce extends ElytraFlightMode {
     public void onTick() {
         super.onTick();
 
-        if (mc.options.jumpKey.isPressed() && !mc.player.isGliding()) mc.getNetworkHandler().sendPacket(new ClientCommandC2SPacket(mc.player, ClientCommandC2SPacket.Mode.START_FALL_FLYING));
+        if (mc.options.jumpKey.isPressed() && !mc.player.isGliding() && !elytraFly.manualTakeoff.get()) mc.getNetworkHandler().sendPacket(new ClientCommandC2SPacket(mc.player, ClientCommandC2SPacket.Mode.START_FALL_FLYING));
 
         // Make sure all the conditions are met (player has an elytra, isn't in water, etc)
         if (checkConditions(mc.player)) {
@@ -47,7 +47,7 @@ public class Bounce extends ElytraFlightMode {
                 if (elytraFly.autoJump.get()) setPressed(mc.options.jumpKey, true);
                 setPressed(mc.options.forwardKey, true);
                 mc.player.setYaw(getYawDirection());
-                mc.player.setPitch(elytraFly.pitch.get().floatValue());
+                if (!elytraFly.pitchUnlock.get()) mc.player.setPitch(elytraFly.pitch.get().floatValue());
             }
 
             if (!elytraFly.sprint.get()) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/ChestSwap.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/ChestSwap.java
@@ -40,7 +40,7 @@ public class ChestSwap extends Module {
     private final Setting<Boolean> closeInventory = sgGeneral.add(new BoolSetting.Builder()
         .name("close-inventory")
         .description("Sends inventory close after swap.")
-        .defaultValue(false)
+        .defaultValue(true)
         .build()
     );
 


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Added these two options to ElytraFly bounce
- pitchUnlock to disable pick lock, really useful if you're traveling on terrain instead of a highway
- manualTakeoff to disable auto takeoff feature, it's very glitchy and sometimes just doesn't work

## Related issues


# How Has This Been Tested?

Tested on singleplayer and 2b2t, seems to work fine

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
