### PR TITLE
Avoid mojang API ratelimit exception spamming on startup when refresh…

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/ReloadCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/ReloadCommand.java
@@ -28,7 +28,7 @@ public class ReloadCommand extends Command {
             Systems.load();
             Capes.init();
             Fonts.refresh();
-            MeteorExecutor.execute(() -> Friends.get().forEach(Friend::updateInfo));
+            Friends.get().refresh();
 
             return SINGLE_SUCCESS;
         });


### PR DESCRIPTION
…ing friends

## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Meteor does not handle rate limits when refreshing Friends list. This results in the friends list never getting updated and a lot of spam in logs at startup.

1 second delay should do the trick.

## Related issues

Mention any issues that this pr relates to.

# How Has This Been Tested?

Videos or screenshots of the changes if applicable.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
