### PR TITLE
Added raycasting to Hole Filler module

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/HoleFiller.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/HoleFiller.java
@@ -8,7 +8,6 @@ package meteordevelopment.meteorclient.systems.modules.combat;
 import meteordevelopment.meteorclient.events.render.Render3DEvent;
 import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.mixin.AbstractBlockAccessor;
-import meteordevelopment.meteorclient.mixininterface.IBox;
 import meteordevelopment.meteorclient.renderer.ShapeMode;
 import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.friends.Friends;
@@ -17,6 +16,7 @@ import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.utils.misc.Keybind;
 import meteordevelopment.meteorclient.utils.player.FindItemResult;
 import meteordevelopment.meteorclient.utils.player.InvUtils;
+import meteordevelopment.meteorclient.utils.player.PlayerUtils;
 import meteordevelopment.meteorclient.utils.render.color.Color;
 import meteordevelopment.meteorclient.utils.render.color.SettingColor;
 import meteordevelopment.meteorclient.utils.world.BlockIterator;
@@ -27,13 +27,13 @@ import meteordevelopment.orbit.EventPriority;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
-import net.minecraft.entity.TntEntity;
-import net.minecraft.entity.decoration.EndCrystalEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Box;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.world.RaycastContext;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -68,6 +68,15 @@ public class HoleFiller extends Module {
     private final Setting<Double> placeRange = sgGeneral.add(new DoubleSetting.Builder()
         .name("place-range")
         .description("How far away from the player you can place a block.")
+        .defaultValue(4.5)
+        .min(0)
+        .sliderMax(6)
+        .build()
+    );
+
+    private final Setting<Double> placeWallsRange = sgGeneral.add(new DoubleSetting.Builder()
+        .name("walls-range")
+        .description("How far away from the player you can place a block behind walls.")
         .defaultValue(4.5)
         .min(0)
         .sliderMax(6)
@@ -224,9 +233,6 @@ public class HoleFiller extends Module {
 
     private final List<PlayerEntity> targets = new ArrayList<>();
     private final List<Hole> holes = new ArrayList<>();
-
-    private final BlockPos.Mutable testPos = new BlockPos.Mutable();
-    private final Box box = new Box(0, 0, 0, 0, 0, 0);
     private int timer;
 
     public HoleFiller() {
@@ -243,13 +249,15 @@ public class HoleFiller extends Module {
         if (smart.get()) setTargets();
         holes.clear();
 
+        // Grab blocks from hotbar
         FindItemResult block = InvUtils.findInHotbar(itemStack -> blocks.get().contains(Block.getBlockFromItem(itemStack.getItem())));
         if (!block.found()) return;
 
+        // Probe for holes
         BlockIterator.register(searchRadius.get(), searchRadius.get(), (blockPos, blockState) -> {
             if (!validHole(blockPos)) return;
 
-            int bedrock = 0, obsidian = 0;
+            int surroundBlocks = 0;
             Direction air = null;
 
             for (Direction direction : Direction.values()) {
@@ -257,25 +265,23 @@ public class HoleFiller extends Module {
 
                 BlockState state = mc.world.getBlockState(blockPos.offset(direction));
 
-                if (state.getBlock() == Blocks.BEDROCK) bedrock++;
-                else if (state.getBlock() == Blocks.OBSIDIAN) obsidian++;
+                if (state.getBlock().getBlastResistance() >= 600) surroundBlocks++;
                 else if (direction == Direction.DOWN) return;
                 else if (validHole(blockPos.offset(direction)) && air == null) {
                     for (Direction dir : Direction.values()) {
                         if (dir == direction.getOpposite() || dir == Direction.UP) continue;
 
-                        BlockState blockState1 = mc.world.getBlockState(blockPos.offset(direction).offset(dir));
+                        BlockState state1 = mc.world.getBlockState(blockPos.offset(direction).offset(dir));
 
-                        if (blockState1.getBlock() == Blocks.BEDROCK) bedrock++;
-                        else if (blockState1.getBlock() == Blocks.OBSIDIAN) obsidian++;
+                        if (state1.getBlock().getBlastResistance() >= 600) surroundBlocks++;
                         else return;
                     }
 
                     air = direction;
                 }
 
-                if (obsidian + bedrock == 5 && air == null) holes.add(new Hole(blockPos, (byte) 0));
-                else if (obsidian + bedrock == 8 && doubles.get() && air != null) {
+                if (surroundBlocks == 5 && air == null) holes.add(new Hole(blockPos, (byte) 0));
+                else if (surroundBlocks == 8 && doubles.get() && air != null) {
                     holes.add(new Hole(blockPos, Dir.get(air)));
                 }
             }
@@ -284,10 +290,11 @@ public class HoleFiller extends Module {
         BlockIterator.after(() -> {
             if (timer > 0 || holes.isEmpty()) return;
 
-            int bpt = 0;
+            // Fill holes!
+            int placedCount = 0;
             for (Hole hole : holes) {
-                if (bpt >= blocksPerTick.get()) continue;
-                if (BlockUtils.place(hole.blockPos, block, rotate.get(), 10, swing.get(), true)) bpt++;
+                if (placedCount >= blocksPerTick.get()) continue;
+                if (BlockUtils.place(hole.blockPos, block, rotate.get(), 10, swing.get(), true)) placedCount++;
             }
 
             timer = placeDelay.get();
@@ -314,29 +321,23 @@ public class HoleFiller extends Module {
         }
     }
 
-    private boolean validHole(BlockPos pos) {
-        testPos.set(pos);
+    private boolean validHole(BlockPos blockPos) {
+        // Check if the player can place at pos
+        if (!BlockUtils.canPlace(blockPos)) return false;
 
-        if (mc.player.getBlockPos().equals(testPos)) return false;
-        if (distance(mc.player, testPos, false) > placeRange.get()) return false;
-        if (mc.world.getBlockState(testPos).getBlock() == Blocks.COBWEB) return false;
+        // Hole must have air above it
+        if (!mc.world.getBlockState(blockPos.up()).isReplaceable()) return false;
 
-        if (((AbstractBlockAccessor) mc.world.getBlockState(testPos).getBlock()).isCollidable()) return false;
-        testPos.add(0, 1, 0);
-        if (((AbstractBlockAccessor) mc.world.getBlockState(testPos).getBlock()).isCollidable()) return false;
-        testPos.add(0, -1, 0);
+        // Check raycast and range
+        if (isOutOfRange(blockPos)) return false;
 
-        ((IBox) box).meteor$set(pos);
-        if (!mc.world.getOtherEntities(null, box, entity
-            -> entity instanceof PlayerEntity
-            || entity instanceof TntEntity
-            || entity instanceof EndCrystalEntity).isEmpty()) return false;
-
+        // Check if we are allowed to force fill all nearby holes
         if (!smart.get() || forceFill.get().isPressed()) return true;
 
+        // Otherwise its valid if the target is close enough to the hole
         return targets.stream().anyMatch(target
-            -> target.getY() > testPos.getY()
-            && (distance(target, testPos, true) < feetRange.get()));
+            -> target.getY() > blockPos.getY()
+            && isCloseToHolePos(target, blockPos));
     }
 
     private void setTargets() {
@@ -357,38 +358,44 @@ public class HoleFiller extends Module {
     }
 
     private boolean isSurrounded(PlayerEntity target) {
-        for (Direction dir : Direction.values()) {
-            if (dir == Direction.UP || dir == Direction.DOWN) continue;
-
-            testPos.set(target.getBlockPos().offset(dir));
-            Block block = mc.world.getBlockState(testPos).getBlock();
-            if (block != Blocks.OBSIDIAN &&
-                block != Blocks.BEDROCK &&
-                block != Blocks.RESPAWN_ANCHOR &&
-                block != Blocks.CRYING_OBSIDIAN &&
-                block != Blocks.NETHERITE_BLOCK) return false;
+        for (Direction dir : Direction.HORIZONTAL) {
+            BlockPos blockPos = target.getBlockPos().offset(dir);
+            Block block = mc.world.getBlockState(blockPos).getBlock();
+            if (block.getBlastResistance() < 600) return false;
         }
 
         return true;
     }
 
-    private double distance(PlayerEntity player, BlockPos pos, boolean feet) {
-        Vec3d testVec = player.getPos();
-        if (!feet) testVec.add(0, player.getEyeHeight(mc.player.getPose()), 0);
+    private boolean isOutOfRange(BlockPos blockPos) {
+        Vec3d pos = blockPos.toCenterPos().add(new Vec3d(0, 0.499, 0)); // Set to the top of the block as holes will be viewed from above
+        if (!PlayerUtils.isWithin(pos, placeRange.get())) return true;
 
-        else if (predict.get()) {
-            testVec.add(
-                player.getX() - player.lastX,
-                player.getY() - player.lastY,
-                player.getZ() - player.lastZ
+        RaycastContext raycastContext = new RaycastContext(mc.player.getEyePos(), pos, RaycastContext.ShapeType.COLLIDER, RaycastContext.FluidHandling.NONE, mc.player);
+        BlockHitResult result = mc.world.raycast(raycastContext);
+        if (result == null || !result.getBlockPos().equals(blockPos))
+            return !PlayerUtils.isWithin(pos, placeWallsRange.get());
+
+        return false;
+    }
+
+    private boolean isCloseToHolePos(PlayerEntity target, BlockPos blockPos) {
+        Vec3d pos = target.getPos();
+
+        if (predict.get()) {
+            pos.add(
+                target.getX() - target.lastX,
+                target.getY() - target.lastY,
+                target.getZ() - target.lastZ
             );
         }
 
-        double i = testVec.x - (pos.getX() + 0.5);
-        double j = testVec.y - (pos.getY() + ((feet) ? 1 : 0.5));
-        double k = testVec.z - (pos.getZ() + 0.5);
+        double i = pos.x - (blockPos.getX() + 0.5);
+        double j = pos.y - (blockPos.getY() + 1.0);
+        double k = pos.z - (blockPos.getZ() + 0.5);
+        double distance = Math.sqrt(i * i + j * j + k * k);
 
-        return Math.sqrt(i * i + j * j + k * k);
+        return distance < feetRange.get();
     }
 
     private static class Hole {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/HoleESP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/HoleESP.java
@@ -172,6 +172,7 @@ public class HoleESP extends Module {
         for (Hole hole : holes) holePool.free(hole);
         holes.clear();
 
+        // Probe for holes
         BlockIterator.register(horizontalRadius.get(), verticalRadius.get(), (blockPos, blockState) -> {
             if (!validHole(blockPos)) return;
 
@@ -181,19 +182,19 @@ public class HoleESP extends Module {
             for (Direction direction : Direction.values()) {
                 if (direction == Direction.UP) continue;
                 BlockPos offsetPos = blockPos.offset(direction);
-                BlockState state = mc.world.getBlockState(offsetPos);
+                Block block = mc.world.getBlockState(offsetPos).getBlock();
 
-                if (state.getBlock() == Blocks.BEDROCK) bedrock++;
-                else if (state.getBlock() == Blocks.OBSIDIAN) obsidian++;
+                if (((AbstractBlockAccessor) block).isCollidable() && block.getHardness() < 0) bedrock++;
+                else if (block.getBlastResistance() >= 600) obsidian++;
                 else if (direction == Direction.DOWN) return;
                 else if (doubles.get() && air == null && validHole(offsetPos)) {
                     for (Direction dir : Direction.values()) {
                         if (dir == direction.getOpposite() || dir == Direction.UP) continue;
 
-                        BlockState blockState1 = mc.world.getBlockState(offsetPos.offset(dir));
+                        Block block1 = mc.world.getBlockState(offsetPos.offset(dir)).getBlock();
 
-                        if (blockState1.getBlock() == Blocks.BEDROCK) bedrock++;
-                        else if (blockState1.getBlock() == Blocks.OBSIDIAN) obsidian++;
+                        if (((AbstractBlockAccessor) block1).isCollidable() && block1.getHardness() < 0) bedrock++;
+                        else if (block1.getBlastResistance() >= 600) obsidian++;
                         else return;
                     }
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [x] New feature

## Description

* Adds optional raycasting to the Hole Filler module. This allows the module to function better on servers that have strict anti-cheat.

* Fixes a bug where holes that use blocks such as crying obsidian or netherrite would not be considered holes and would not be filled. HoleESP also failed to render those holes (also fixed in this PR).

# How Has This Been Tested?

Raycasting can be adjusted via the new ``Walls Range`` setting which decides how far blocks can be placed behind other blocks.

https://github.com/user-attachments/assets/a1ef574f-91b1-4899-8d4f-f6604ed8b4b9

This was also tested on Oldfag.org to make certain it functioned correctly on servers.


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
