### PR TITLE
Add nbt support to inv sorter

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/utils/player/InventorySorter.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/InventorySorter.java
@@ -167,7 +167,10 @@ public class InventorySorter {
         else if (!bestI.isEmpty() && slotI.isEmpty()) return false;
 
         int c = Registries.ITEM.getId(bestI.getItem()).compareTo(Registries.ITEM.getId(slotI.getItem()));
-        if (c == 0) return slotI.getCount() > bestI.getCount();
+        if (c == 0) {
+            if (slotI.getCount() != bestI.getCount()) return slotI.getCount() > bestI.getCount();
+            if (slotI.getDamage() != bestI.getDamage()) return slotI.getDamage() > bestI.getDamage();
+        }
 
         return c > 0;
     }
@@ -208,7 +211,7 @@ public class InventorySorter {
 
         public List<MySlot> get(ItemStack itemStack) {
             for (Pair<ItemStack, List<MySlot>> entry : map) {
-                if (ItemStack.areItemsEqual(itemStack, entry.getLeft())) {
+                if (ItemStack.areItemsAndComponentsEqual(itemStack, entry.getLeft())) {
                     return entry.getRight();
                 }
             }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

A comparison method has been changed from ItemStack#areItemsEqual to ItemStack#areItemsAndComponentsEqual to include nbt.
The comparison for if two items are the same has also been adjusted to include the damage of an item if both the type and count of an item are equal. (I find that this looks amazing in mob farm chest or something with a bunch of damaged weapons :D )

## Related issues

None that I am aware of

# How Has This Been Tested?

Using a few chests in a server where typically the sorter would try and combine items with differing nbt together and and up just shuffling them around. Examples of this could be banners, firework rockets with different flight durations, written books, and any other item with a custom name or something. After the change the sorter sorts each item separately.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
