### PR TITLE
Added Silent Mine module

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
@@ -443,6 +443,7 @@ public class Modules extends System<Modules> {
         add(new PotionSaver());
         add(new Reach());
         add(new Rotation());
+        add(new SilentMine());
         add(new SpeedMine());
     }
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/SilentMine.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/SilentMine.java
@@ -1,0 +1,54 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.systems.modules.player;
+
+import meteordevelopment.meteorclient.events.packets.PacketEvent;
+import meteordevelopment.meteorclient.events.world.TickEvent;
+import meteordevelopment.meteorclient.systems.modules.Categories;
+import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.orbit.EventHandler;
+import net.minecraft.network.packet.c2s.play.PlayerActionC2SPacket;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+
+public class SilentMine extends Module {
+    public SilentMine() {
+        super(Categories.Player, "silent-mine", "Prevents block breaking animations from being visible to other players.");
+    }
+
+    private boolean mining;
+    private BlockPos lastBlockPos;
+    private Direction lastDirection;
+
+    @Override
+    public void onDeactivate() {
+        mining = false;
+    }
+
+    @EventHandler
+    private void onSendPacket(PacketEvent.Send event) {
+        if (!(event.packet instanceof PlayerActionC2SPacket)) return;
+
+        PlayerActionC2SPacket packet = (PlayerActionC2SPacket) event.packet;
+
+        if (packet.getAction() == PlayerActionC2SPacket.Action.START_DESTROY_BLOCK) {
+            mining = true;
+            lastBlockPos = packet.getPos();
+            lastDirection = packet.getDirection();
+        }
+
+        if (packet.getAction() == PlayerActionC2SPacket.Action.STOP_DESTROY_BLOCK) {
+            mining = false;
+        }
+    }
+
+    @EventHandler
+    private void onTick(TickEvent.Pre event) {
+        if (mining) {
+            mc.getNetworkHandler().sendPacket(new PlayerActionC2SPacket(PlayerActionC2SPacket.Action.ABORT_DESTROY_BLOCK, lastBlockPos, lastDirection));
+        }
+    }
+}


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Adds a new module **Silent Mine**. Which has been known by the names "No mining animation" or "No break animation".

This module prevents block breaking animations from being visible to other players. 

It works by sending packets to the server which ends up resetting the block break progress to nearby clients.

# How Has This Been Tested?

Video here demonstrates Silent Mine on Oldfag.Org.

https://github.com/user-attachments/assets/51858b7a-f01f-4a6c-946b-41b9bfcb8f6c

Requires two clients to test, as the breaking has to be viewed from another client.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
