### PR TITLE
Fix crash with VFP on 1.8 related to offhand slot not existing

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/DropCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/DropCommand.java
@@ -54,7 +54,7 @@ public class DropCommand extends Command {
             for (int i = 0; i < player.getInventory().size(); i++) {
                 InvUtils.drop().slot(i);
             }
-            InvUtils.drop().slotOffhand();
+            if (!mc.player.getOffHandStack().isEmpty()) InvUtils.drop().slotOffhand();
         })));
 
         // Armor


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Fix crash with VFP on 1.8 related to offhand slot not existing.

## Related issues

Closes #5424.

# How Has This Been Tested?

Multiplayer with VFP set to 1.8 compatibility.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
