### PR TITLE
fix gradle configuration cache task inputs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -165,9 +165,10 @@ tasks {
     shadowJar {
         configurations = listOf(project.configurations.shadow.get())
 
-        val licenseSuffix = project.base.archivesName.get()
+        inputs.property("archivesName", project.base.archivesName.get())
+
         from("LICENSE") {
-            rename { "${it}_${licenseSuffix}" }
+            rename { "${it}_${inputs.properties["archivesName"]}" }
         }
 
         dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -135,9 +135,10 @@ tasks {
     }
 
     jar {
-        val licenseSuffix = project.base.archivesName.get()
+        inputs.property("archivesName", project.base.archivesName.get())
+
         from("LICENSE") {
-            rename { "${it}_${licenseSuffix}" }
+            rename { "${it}_${inputs.properties["archivesName"]}" }
         }
 
         manifest {


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

use task inputs rather than a variable for `processResources` & `shadowJar` configuration cache support

## Related issues

none

# How Has This Been Tested?

the J

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
