### PR TITLE
skip regular lightmap computations with Fullbright & Xray

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/LightmapTextureManagerMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/LightmapTextureManagerMixin.java
@@ -5,6 +5,7 @@
 
 package meteordevelopment.meteorclient.mixin;
 
+import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.textures.GpuTexture;
 import meteordevelopment.meteorclient.systems.modules.Modules;
@@ -14,6 +15,7 @@ import meteordevelopment.meteorclient.systems.modules.render.Xray;
 import net.minecraft.client.render.LightmapTextureManager;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.util.math.ColorHelper;
+import net.minecraft.util.profiler.Profiler;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -22,18 +24,18 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.OptionalInt;
-
 @Mixin(LightmapTextureManager.class)
 public abstract class LightmapTextureManagerMixin {
     @Shadow
     @Final
     private GpuTexture glTexture;
 
-    @Inject(method = "update", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/profiler/Profiler;pop()V", shift = At.Shift.BEFORE))
-    private void update$clear(float tickProgress, CallbackInfo info) {
+    @Inject(method = "update", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/profiler/Profiler;push(Ljava/lang/String;)V"), cancellable = true)
+    private void update$skip(float tickProgress, CallbackInfo ci, @Local Profiler profiler) {
         if (Modules.get().get(Fullbright.class).getGamma() || Modules.get().isActive(Xray.class)) {
-            RenderSystem.getDevice().createCommandEncoder().createRenderPass(glTexture, OptionalInt.of(ColorHelper.getArgb(255, 255, 255, 255))).close();
+            RenderSystem.getDevice().createCommandEncoder().clearColorTexture(glTexture, ColorHelper.getArgb(255, 255, 255, 255));
+            profiler.pop();
+            ci.cancel();
         }
     }
 


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Optimization

## Description

instead of overwriting the work done by `LightmapTextureManager#update`, simply skip the entire function call if applicable

also, replace the `createRenderPass` call with the more lightweight `clearColorTexture` call

## Related issues

none

# How Has This Been Tested?

works on my pc :+1:

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
