### PR TITLE
Bed Aura rewrite

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/BedAura.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/BedAura.java
@@ -8,6 +8,7 @@ package meteordevelopment.meteorclient.systems.modules.combat;
 import meteordevelopment.meteorclient.events.render.Render3DEvent;
 import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.events.world.BlockUpdateEvent;
+import meteordevelopment.meteorclient.mixin.DirectionAccessor;
 import meteordevelopment.meteorclient.renderer.ShapeMode;
 import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Categories;
@@ -33,8 +34,6 @@ import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.world.RaycastContext;
-import net.minecraft.network.packet.c2s.play.ClientCommandC2SPacket;
-import net.minecraft.network.packet.c2s.play.ClientCommandC2SPacket.Mode;
 
 public class BedAura extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
@@ -365,7 +364,7 @@ public class BedAura extends Module {
 
         Direction rotateDirection = Direction.fromHorizontalDegrees(Rotations.getYaw(footPos.toCenterPos()));
 
-        for (Direction placeDirection : Direction.HORIZONTAL) {
+        for (Direction placeDirection : DirectionAccessor.meteor$getHorizontal()) {
             BlockPos headPos = footPos.offset(placeDirection);
             if (!mc.world.getBlockState(headPos).isReplaceable()) continue;
 
@@ -447,11 +446,6 @@ public class BedAura extends Module {
     }
 
     private void doInteract() {
-        // Stop sneaking so interactions with the bed are successful
-        if (mc.player.isSneaking()) {
-            mc.player.networkHandler.sendPacket(new ClientCommandC2SPacket(mc.player, Mode.RELEASE_SHIFT_KEY));
-        }
-
         BlockUtils.interact(new BlockHitResult(bestBreakPos.toCenterPos(), BlockUtils.getDirection(bestBreakPos), bestBreakPos, true), Hand.MAIN_HAND, swing.get());
         breakDelayLeft = 0;
     }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/BedAura.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/BedAura.java
@@ -147,7 +147,8 @@ public class BedAura extends Module {
         .name("min-damage")
         .description("The minimum damage to inflict on your target.")
         .defaultValue(7)
-        .range(0, 36)
+        .min(0)
+        .sliderMax(36)
         .build()
     );
 
@@ -155,7 +156,8 @@ public class BedAura extends Module {
         .name("max-self-damage")
         .description("The maximum damage to inflict on yourself.")
         .defaultValue(7)
-        .range(0, 36)
+        .min(0)
+        .sliderMax(36)
         .build()
     );
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [x] New feature

## Description

* Completely overhauls Bed Aura, with massive improvements.

Previously, beds could only be placed onto the target player, with a total of three positions (with rotations).
It wasn't even able to explode beds either. Did anyone notice?

This new Bed Aura is very similar to my Anchor Aura rewrite, with a few key differences regarding directional placement for beds.

# How Has This Been Tested?

https://github.com/user-attachments/assets/ee0e7759-f72f-4044-87a8-b16bfb27aa1b

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
