### PR TITLE
Spawn proofer improvement

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/LightOverlay.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/LightOverlay.java
@@ -51,10 +51,12 @@ public class LightOverlay extends Module {
         .build()
     );
 
-    private final Setting<Boolean> newMobSpawnLightLevel = sgGeneral.add(new BoolSetting.Builder()
-        .name("new-mob-spawn-light-level")
-        .description("Use the new (1.18+) mob spawn behavior")
-        .defaultValue(true)
+    private final Setting<Integer> lightLevel = sgGeneral.add(new IntSetting.Builder()
+        .name("light-level")
+        .description("Which light levels to render. Old spawning light: 7.")
+        .defaultValue(0)
+        .min(0)
+        .sliderMax(15)
         .build()
     );
 
@@ -86,9 +88,8 @@ public class LightOverlay extends Module {
         for (Cross cross : crosses) crossPool.free(cross);
         crosses.clear();
 
-        int spawnLightLevel = newMobSpawnLightLevel.get() ? 0 : 7;
         BlockIterator.register(horizontalRange.get(), verticalRange.get(), (blockPos, blockState) -> {
-            switch (BlockUtils.isValidMobSpawn(blockPos, blockState, spawnLightLevel)) {
+            switch (BlockUtils.isValidMobSpawn(blockPos, blockState, lightLevel.get())) {
                 case Potential -> crosses.add(crossPool.get().set(blockPos, true));
                 case Always -> crosses.add((crossPool.get().set(blockPos, false)));
             }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/SpawnProofer.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/SpawnProofer.java
@@ -12,46 +12,71 @@ import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.utils.misc.Pool;
 import meteordevelopment.meteorclient.utils.player.FindItemResult;
 import meteordevelopment.meteorclient.utils.player.InvUtils;
+import meteordevelopment.meteorclient.utils.player.PlayerUtils;
 import meteordevelopment.meteorclient.utils.world.BlockIterator;
 import meteordevelopment.meteorclient.utils.world.BlockUtils;
 import meteordevelopment.orbit.EventHandler;
 import net.minecraft.block.*;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.world.RaycastContext;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Comparator;
 
 public class SpawnProofer extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
 
-    private final Setting<Integer> range = sgGeneral.add(new IntSetting.Builder()
-        .name("range")
-        .description("Range for block placement and rendering")
-        .defaultValue(3)
+    private final Setting<Integer> placeDelay = sgGeneral.add(new IntSetting.Builder()
+        .name("place-delay")
+        .description("The tick delay between placing blocks.")
+        .defaultValue(1)
+        .range(0, 10)
+        .build()
+    );
+
+    private final Setting<Double> placeRange = sgGeneral.add(new DoubleSetting.Builder()
+        .name("place-range")
+        .description("How far away from the player you can place a block.")
+        .defaultValue(4.5)
         .min(0)
+        .sliderMax(6)
+        .build()
+    );
+
+    private final Setting<Double> wallsRange = sgGeneral.add(new DoubleSetting.Builder()
+        .name("walls-range")
+        .description("How far away from the player you can place a block behind walls.")
+        .defaultValue(4.5)
+        .min(0)
+        .sliderMax(6)
+        .build()
+    );
+
+    private final Setting<Integer> blocksPerTick = sgGeneral.add(new IntSetting.Builder()
+        .name("blocks-per-tick")
+        .description("How many blocks to place in one tick.")
+        .defaultValue(1)
+        .min(1)
+        .build()
+    );
+
+    private final Setting<Integer> lightLevel = sgGeneral.add(new IntSetting.Builder()
+        .name("light-level")
+        .description("Light levels to spawn proof. Old spawning light: 7.")
+        .defaultValue(0)
+        .min(0)
+        .sliderMax(15)
         .build()
     );
 
     private final Setting<List<Block>> blocks = sgGeneral.add(new BlockListSetting.Builder()
         .name("blocks")
-        .description("Block to use for spawn proofing")
+        .description("Block to use for spawn proofing.")
         .defaultValue(Blocks.TORCH, Blocks.STONE_BUTTON, Blocks.STONE_SLAB)
         .filter(this::filterBlocks)
-        .build()
-    );
-
-    private final Setting<Integer> delay = sgGeneral.add(new IntSetting.Builder()
-        .name("delay")
-        .description("Delay in ticks between placing blocks")
-        .defaultValue(0)
-        .min(0)
-        .build()
-    );
-
-    private final Setting<Boolean> rotate = sgGeneral.add(new BoolSetting.Builder()
-        .name("rotate")
-        .description("Rotates towards the blocks being placed.")
-        .defaultValue(true)
         .build()
     );
 
@@ -62,17 +87,16 @@ public class SpawnProofer extends Module {
         .build()
     );
 
-    private final Setting<Boolean> newMobSpawnLightLevel = sgGeneral.add(new BoolSetting.Builder()
-        .name("new-mob-spawn-light-level")
-        .description("Use the new (1.18+) mob spawn behavior")
+    private final Setting<Boolean> rotate = sgGeneral.add(new BoolSetting.Builder()
+        .name("rotate")
+        .description("Rotates towards the blocks being placed.")
         .defaultValue(true)
         .build()
     );
 
-
     private final Pool<BlockPos.Mutable> spawnPool = new Pool<>(BlockPos.Mutable::new);
     private final List<BlockPos.Mutable> spawns = new ArrayList<>();
-    private int ticksWaited;
+    private int timer;
 
     public SpawnProofer() {
         super(Categories.World, "spawn-proofer", "Automatically spawnproofs unlit areas.");
@@ -80,15 +104,12 @@ public class SpawnProofer extends Module {
 
     @EventHandler
     private void onTickPre(TickEvent.Pre event) {
-        // Delay
-        if (delay.get() != 0 && ticksWaited < delay.get() - 1) {
-            return;
-        }
+        if (timer < placeDelay.get()) return;
 
         // Find slot
         boolean foundBlock = InvUtils.testInHotbar(itemStack -> blocks.get().contains(Block.getBlockFromItem(itemStack.getItem())));
         if (!foundBlock) {
-            error("Found none of the chosen blocks in hotbar");
+            error("Found none of the chosen blocks in hotbar.");
             toggle();
             return;
         }
@@ -97,12 +118,16 @@ public class SpawnProofer extends Module {
         for (BlockPos.Mutable blockPos : spawns) spawnPool.free(blockPos);
         spawns.clear();
 
-        int lightLevel = newMobSpawnLightLevel.get() ? 0 : 7;
-        BlockIterator.register(range.get(), range.get(), (blockPos, blockState) -> {
-            BlockUtils.MobSpawn spawn = BlockUtils.isValidMobSpawn(blockPos, blockState, lightLevel);
+        BlockIterator.register((int) Math.ceil(placeRange.get()), (int) Math.ceil(placeRange.get()), (blockPos, blockState) -> {
+            BlockUtils.MobSpawn spawn = BlockUtils.isValidMobSpawn(blockPos, blockState, lightLevel.get());
 
             if ((spawn == BlockUtils.MobSpawn.Always && (mode.get() == Mode.Always || mode.get() == Mode.Both)) ||
                     spawn == BlockUtils.MobSpawn.Potential && (mode.get() == Mode.Potential || mode.get() == Mode.Both)) {
+
+                if (!BlockUtils.canPlace(blockPos)) return;
+
+                // Check range and raycast
+                if (isOutOfRange(blockPos)) return;
 
                 spawns.add(spawnPool.get().set(blockPos));
             }
@@ -112,49 +137,48 @@ public class SpawnProofer extends Module {
     @EventHandler
     private void onTickPost(TickEvent.Post event) {
         // Delay
-        if (delay.get() != 0 && ticksWaited < delay.get() - 1) {
-            ticksWaited++;
-            return;
-        }
+        if (timer++ < placeDelay.get()) return;
 
         if (spawns.isEmpty()) return;
 
         // Find slot
         FindItemResult block = InvUtils.findInHotbar(itemStack -> blocks.get().contains(Block.getBlockFromItem(itemStack.getItem())));
         if (!block.found()) {
-            error("Found none of the chosen blocks in hotbar");
+            error("Found none of the chosen blocks in hotbar.");
             toggle();
             return;
         }
 
-        // Place blocks
-        if (delay.get() == 0) {
-            for (BlockPos blockPos : spawns) BlockUtils.place(blockPos, block, rotate.get(), -50, false);
+        int placedCount = 0;
+
+        // Sort blocks to use lowest light level spawns first
+        if (isLightSource(Block.getBlockFromItem(mc.player.getInventory().getStack(block.slot()).getItem()))) {
+            spawns.sort(Comparator.comparingInt(blockPos -> mc.world.getLightLevel(blockPos)));
+            placedCount = blocksPerTick.get() - 1; // Force only one light source per tick to stop unnecessary placements
         }
-        else {
-            // Check if light source
-            if (isLightSource(Block.getBlockFromItem(mc.player.getInventory().getStack(block.slot()).getItem()))) {
 
-                // Find lowest light level
-                int lowestLightLevel = 16;
-                BlockPos.Mutable selectedBlockPos = spawns.getFirst();
+        // Place blocks!
+        for (BlockPos blockPos : spawns) {
+            if (placedCount >= blocksPerTick.get()) continue;
 
-                for (BlockPos blockPos : spawns) {
-                    int lightLevel = mc.world.getLightLevel(blockPos);
-                    if (lightLevel < lowestLightLevel) {
-                        lowestLightLevel = lightLevel;
-                        selectedBlockPos.set(blockPos);
-                    }
-                }
-
-                BlockUtils.place(selectedBlockPos, block, rotate.get(), -50, false);
-            }
-            else {
-                BlockUtils.place(spawns.getFirst(), block, rotate.get(), -50, false);
+            if (BlockUtils.place(blockPos, block, rotate.get(), -50, false)) {
+                placedCount++;
             }
         }
 
-        ticksWaited = 0;
+        timer = 0;
+    }
+
+    private boolean isOutOfRange(BlockPos blockPos) {
+        Vec3d pos = blockPos.toCenterPos();
+        if (!PlayerUtils.isWithin(pos, placeRange.get())) return true;
+
+        RaycastContext raycastContext = new RaycastContext(mc.player.getEyePos(), pos, RaycastContext.ShapeType.COLLIDER, RaycastContext.FluidHandling.NONE, mc.player);
+        BlockHitResult result = mc.world.raycast(raycastContext);
+        if (result == null || !result.getBlockPos().equals(blockPos))
+            return !PlayerUtils.isWithin(pos, wallsRange.get());
+
+        return false;
     }
 
     private boolean filterBlocks(Block block) {
@@ -180,7 +204,6 @@ public class SpawnProofer extends Module {
     public enum Mode {
         Always,
         Potential,
-        Both,
-        None
+        Both
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/utils/world/BlockUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/world/BlockUtils.java
@@ -306,22 +306,12 @@ public class BlockUtils {
             || block instanceof TrapdoorBlock;
     }
 
-    public static MobSpawn isValidMobSpawn(BlockPos blockPos, boolean newMobSpawnLightLevel) {
-        return isValidMobSpawn(blockPos, mc.world.getBlockState(blockPos), newMobSpawnLightLevel ? 0 : 7);
-    }
 
     public static MobSpawn isValidMobSpawn(BlockPos blockPos, BlockState blockState, int spawnLightLimit) {
-        if (!(blockState.getBlock() instanceof AirBlock)) return MobSpawn.Never;
+        boolean snow = blockState.getBlock() instanceof SnowBlock && blockState.get(SnowBlock.LAYERS) == 1;
+        if (!blockState.isAir() && !snow) return MobSpawn.Never;
 
-        BlockPos down = blockPos.down();
-        BlockState downState = mc.world.getBlockState(down);
-        if (downState.getBlock() == Blocks.BEDROCK) return MobSpawn.Never;
-
-        if (!topSurface(downState)) {
-            if (downState.getCollisionShape(mc.world, down) != VoxelShapes.fullCube())
-                return MobSpawn.Never;
-            if (downState.isTransparent()) return MobSpawn.Never;
-        }
+        if (!isValidSpawnBlock(mc.world.getBlockState(blockPos.down()))) return MobSpawn.Never;
 
         if (mc.world.getLightLevel(LightType.BLOCK, blockPos) > spawnLightLimit) return MobSpawn.Never;
         else if (mc.world.getLightLevel(LightType.SKY, blockPos) > spawnLightLimit) return  MobSpawn.Potential;
@@ -329,9 +319,14 @@ public class BlockUtils {
         return MobSpawn.Always;
     }
 
-    public static boolean topSurface(BlockState blockState) {
-        if (blockState.getBlock() instanceof SlabBlock && blockState.get(SlabBlock.TYPE) == SlabType.TOP) return true;
-        else return blockState.getBlock() instanceof StairsBlock && blockState.get(StairsBlock.HALF) == BlockHalf.TOP;
+    public static boolean isValidSpawnBlock(BlockState blockState) {
+        Block block = blockState.getBlock();
+        if (block == Blocks.BEDROCK) return false;
+        if (block == Blocks.SOUL_SAND || block == Blocks.MUD) return true;
+        if (block instanceof SlabBlock && blockState.get(SlabBlock.TYPE) == SlabType.TOP) return true;
+        if (block instanceof StairsBlock && blockState.get(StairsBlock.HALF) == BlockHalf.TOP) return true;
+
+        return blockState.isOpaqueFullCube();
     }
 
     // Finds the best block direction to get when interacting with the block.


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [x] New feature

## Description

* Added optional raycasting, to allow better use on stricter servers.
* Added blocks per tick option so Spawn Proofer can place faster on servers where allowed.
* Added adjustable light levels, this allows for players to be able to place blocks wherever regardless of light level (useful for the nether).
* Added adjustable light levels to the light overlay. This will help a lot when players are trying to spawn proof odd mobs that don't spawn in typical light levels.
* Fixed Spawn Proofer not placing on soul sand and snow. Light overlay also renders those blocks now.

## Related issues

resolves #3956 , resolves #3554, resolves #2056 - Soulsand problems
resolves #3656 - Snow problems
resolves #2875 - Adjustable light level

# How Has This Been Tested?

https://github.com/user-attachments/assets/8964a5d5-70ce-4cd4-a15f-9b40557a31b8

https://github.com/user-attachments/assets/0377e8f4-0b62-4ba5-a644-fb8492e29c2f

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.

# Note:
After these changes I am considering if Light Overlay and Spawn Proofer should be merged into one module. The reason to do this would be to keep the light overlay synced with the spawn proofer because now the light levels can be adjusted differently for each. Nothing would really be different aside from losing the ability to hotkey each one separately (does anyone hotkey both of them though?). If you care, leave your thoughts in the comments.