### PR TITLE
add blockstate check to setupTuneHitsMap to prevent crashes

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notebot.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notebot.java
@@ -548,6 +548,8 @@ public class Notebot extends Module {
             BlockPos blockPos = entry.getValue();
 
             BlockState blockState = mc.world.getBlockState(blockPos);
+            if (blockState.getBlock() != Blocks.NOTE_BLOCK) continue;
+
             int currentLevel = blockState.get(NoteBlock.NOTE);
 
             if (targetLevel != currentLevel) {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Added another check for the blockstate in setupTuneHitsMap so it doesn't crash if the block is air or something else:
```diff
diff --git a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notebot.java b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notebot.java
index 237a6d2d..33e5ff12 100644
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notebot.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/Notebot.java
@@ -548,6 +548,8 @@ public class Notebot extends Module {
             BlockPos blockPos = entry.getValue();
 
             BlockState blockState = mc.world.getBlockState(blockPos);
+            if (blockState.getBlock() != Blocks.NOTE_BLOCK) continue;
+
             int currentLevel = blockState.get(NoteBlock.NOTE);
 
             if (targetLevel != currentLevel) {
```

## Related issues

No public issues, just a crash of me:
```
java.lang.IllegalArgumentException: Cannot get property class_2758{name=note, clazz=class java.lang.Integer, values=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]} as it does not exist in Block{minecraft:air}
	at knot//net.minecraft.class_2688.method_11654(class_2688.java:86)
	at knot//meteordevelopment.meteorclient.systems.modules.misc.Notebot.setupTuneHitsMap(Notebot.java:551)
	at knot//meteordevelopment.meteorclient.systems.modules.misc.Notebot.onTick(Notebot.java:418)
	at knot//meteordevelopment.orbit.listeners.LambdaListener.call(LambdaListener.java:83)
	at knot//meteordevelopment.orbit.EventBus.post(EventBus.java:53)
	at knot//net.minecraft.class_310.handler$cga000$meteor-client$onPreTick(class_310.java:30503)
	at knot//net.minecraft.class_310.method_1574(class_310.java)
	at knot//net.minecraft.class_310.method_1523(class_310.java:1302)
	at knot//net.minecraft.class_310.method_1514(class_310.java:922)
	at knot//net.minecraft.client.main.Main.main(Main.java:267)
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:480)
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:74)
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)
	at org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:105)
	at org.prismlauncher.EntryPoint.listen(EntryPoint.java:129)
	at org.prismlauncher.EntryPoint.main(EntryPoint.java:70)
```

# How Has This Been Tested?

I ran it and it worked just fine now

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
