### PR TITLE
fix compat with baritone deobf "unoptimized" builds

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/pathing/BaritonePathManager.java
+++ b/src/main/java/meteordevelopment/meteorclient/pathing/BaritonePathManager.java
@@ -24,15 +24,11 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
 
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.VarHandle;
-import java.lang.reflect.Field;
 import java.util.function.Predicate;
 
 import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class BaritonePathManager implements IPathManager {
-    private final VarHandle rotationField;
     private final BaritoneSettings settings;
 
     private GoalDirection directionGoal;
@@ -41,23 +37,6 @@ public class BaritonePathManager implements IPathManager {
     public BaritonePathManager() {
         // Subscribe to event bus
         MeteorClient.EVENT_BUS.subscribe(this);
-
-        // Find rotation field
-        Class<?> klass = BaritoneAPI.getProvider().getPrimaryBaritone().getLookBehavior().getClass();
-        VarHandle rotationField = null;
-
-        for (Field field : klass.getDeclaredFields()) {
-            if (field.getType() == Rotation.class) {
-                try {
-                    rotationField = MethodHandles.lookup().unreflectVarHandle(field);
-                    break;
-                } catch (IllegalAccessException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-        }
-
-        this.rotationField = rotationField;
 
         // Create settings
         settings = new BaritoneSettings();
@@ -119,14 +98,12 @@ public class BaritonePathManager implements IPathManager {
 
     @Override
     public float getTargetYaw() {
-        Rotation rotation = (Rotation) rotationField.get(BaritoneAPI.getProvider().getPrimaryBaritone().getLookBehavior());
-        return rotation == null ? 0 : rotation.getYaw();
+        return BaritoneAPI.getProvider().getPrimaryBaritone().getPlayerContext().playerRotations().getYaw();
     }
 
     @Override
     public float getTargetPitch() {
-        Rotation rotation = (Rotation) rotationField.get(BaritoneAPI.getProvider().getPrimaryBaritone().getLookBehavior());
-        return rotation == null ? 0 : rotation.getPitch();
+        return BaritoneAPI.getProvider().getPrimaryBaritone().getPlayerContext().playerRotations().getPitch();
     }
 
     @Override


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

crash on game launch due to reflection accessing a private field in non-proguard baritone

target rotation accessor is in the api, see [here](https://github.com/cabaletta/baritone/blob/4d27d56ff5e79a12e336fc383221988f944f218b/src/main/java/baritone/utils/player/BaritonePlayerContext.java#L80) and [here](https://github.com/cabaletta/baritone/blob/4d27d56ff5e79a12e336fc383221988f944f218b/src/main/java/baritone/behavior/LookBehavior.java#L161-L167)

# How Has This Been Tested?

baritone 1.21.7 builds: https://github.com/cabaletta/baritone/pull/4800
