### PR TITLE
Ignore AutoTool if not in survival

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoTool.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoTool.java
@@ -27,6 +27,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.ShearsItem;
 import net.minecraft.registry.tag.BlockTags;
 import net.minecraft.registry.tag.ItemTags;
+import net.minecraft.world.GameMode;
 
 import java.util.List;
 import java.util.function.Predicate;
@@ -146,6 +147,7 @@ public class AutoTool extends Module {
     @EventHandler(priority = EventPriority.HIGH)
     private void onStartBreakingBlock(StartBreakingBlockEvent event) {
         if (Modules.get().isActive(InfinityMiner.class)) return;
+        if (mc.player.getGameMode() != GameMode.SURVIVAL) return;
 
         // Get blockState
         BlockState blockState = mc.world.getBlockState(event.blockPos);


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [X] New feature

## Description

yuh uh it wont switch to other tools no more if you aint in survival
Ik like you can still break stuff on adventure mode if the tools has attribute stuff but no one plays adventure anyway and it will be just be bloat

## Related issues

![image](https://github.com/user-attachments/assets/eca99df4-f537-41f3-88be-a651bc33c815)

# How Has This Been Tested?

👍

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
