### PR TITLE
Fix colon for port in ipFilter util

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
@@ -654,6 +654,6 @@ public class Utils {
 
     public static boolean ipFilter(String text, char character) {
         if (text.contains(":") && character == ':') return false;
-        return (character >= 'a' && character <= 'z') || (character >= 'A' && character <= 'Z') || (character >= '0' && character <= '9') || character == '.' || character == '-';
+        return (character >= 'a' && character <= 'z') || (character >= 'A' && character <= 'Z') || (character >= '0' && character <= '9') || character == '.' || character == '-' || character == ':';
     }
 }


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

The ip filter has the initial colon check to prevent multiple colons but since the colon is not in the check below that it is still not able to be put in whether there is one there or not, this simply adds it on

## Related issues

None (idk didn't check but I wouldn't assume so)

# How Has This Been Tested?

I tested it in game using the auto load profile feature

# Checklist:

- [X] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
