### PR TITLE
Placeholder for StringSetting

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/DefaultSettingsWidgetFactory.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/DefaultSettingsWidgetFactory.java
@@ -188,7 +188,7 @@ public class DefaultSettingsWidgetFactory extends SettingsWidgetFactory {
 
     private void stringW(WTable table, StringSetting setting) {
         CharFilter filter = setting.filter == null ? (text, c) -> true : setting.filter;
-        Cell<WTextBox> cell = table.add(theme.textBox(setting.get(), filter, setting.renderer));
+        Cell<WTextBox> cell = table.add(theme.textBox(setting.get(), setting.placeholder, filter, setting.renderer));
         if (setting.wide) cell.minWidth(Utils.getWindowWidth() - Utils.getWindowWidth() / 4.0);
 
         WTextBox textBox = cell.expandX().widget();

--- a/src/main/java/meteordevelopment/meteorclient/settings/ProvidedStringSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/ProvidedStringSetting.java
@@ -14,7 +14,7 @@ public class ProvidedStringSetting extends StringSetting {
     public final Supplier<String[]> supplier;
 
     public ProvidedStringSetting(String name, String description, String defaultValue, Consumer<String> onChanged, Consumer<Setting<String>> onModuleActivated, IVisible visible, Class<? extends WTextBox.Renderer> renderer, boolean wide, Supplier<String[]> supplier) {
-        super(name, description, defaultValue, onChanged, onModuleActivated, visible, renderer, null, wide);
+        super(name, description, defaultValue, onChanged, onModuleActivated, visible, "", renderer, null, wide);
 
         this.supplier = supplier;
     }

--- a/src/main/java/meteordevelopment/meteorclient/settings/StringSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/StringSetting.java
@@ -12,13 +12,15 @@ import net.minecraft.nbt.NbtCompound;
 import java.util.function.Consumer;
 
 public class StringSetting extends Setting<String> {
+    public final String placeholder;
     public final Class<? extends WTextBox.Renderer> renderer;
     public final CharFilter filter;
     public final boolean wide;
 
-    public StringSetting(String name, String description, String defaultValue, Consumer<String> onChanged, Consumer<Setting<String>> onModuleActivated, IVisible visible, Class<? extends WTextBox.Renderer> renderer, CharFilter filter, boolean wide) {
+    public StringSetting(String name, String description, String defaultValue, Consumer<String> onChanged, Consumer<Setting<String>> onModuleActivated, IVisible visible, String placeholder, Class<? extends WTextBox.Renderer> renderer, CharFilter filter, boolean wide) {
         super(name, description, defaultValue, onChanged, onModuleActivated, visible);
 
+        this.placeholder = placeholder;
         this.renderer = renderer;
         this.filter = filter;
         this.wide = wide;
@@ -49,12 +51,18 @@ public class StringSetting extends Setting<String> {
     }
 
     public static class Builder extends SettingBuilder<Builder, String, StringSetting> {
+        private String placeholder;
         private Class<? extends WTextBox.Renderer> renderer;
         private CharFilter filter;
         private boolean wide;
 
         public Builder() {
             super("");
+        }
+
+        public Builder placeholder(String placeholder) {
+            this.placeholder = placeholder;
+            return this;
         }
 
         public Builder renderer(Class<? extends WTextBox.Renderer> renderer) {
@@ -74,7 +82,7 @@ public class StringSetting extends Setting<String> {
 
         @Override
         public StringSetting build() {
-            return new StringSetting(name, description, defaultValue, onChanged, onModuleActivated, visible, renderer, filter, wide);
+            return new StringSetting(name, description, defaultValue, onChanged, onModuleActivated, visible, placeholder, renderer, filter, wide);
         }
     }
 }


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Adds support for placeholders in `StringSetting`, allowing modules to display helpful hint text when the input field is empty.

Example usage:
```java
new StringSetting.Builder()
    .name("server-ip")
    .description("IP address of the target server.")
    .placeholder("play.hypixel.net")
    .build();
```

## Related issues
null

# How Has This Been Tested?
Successfully built using GitHub Codespaces
Ran locally on a Windows machine with Minecraft client

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
