### PR TITLE
Despawn fake players and clear table on deactivate

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/FakePlayer.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/FakePlayer.java
@@ -42,13 +42,21 @@ public class FakePlayer extends Module {
         .build()
     );
 
+    private WTable table;
+
     public FakePlayer() {
         super(Categories.Player, "fake-player", "Spawns a client-side fake player for testing usages. No need to be active.");
     }
 
     @Override
+    public void onDeactivate() {
+        FakePlayerManager.clear();
+        if (table != null) table.clear();
+    }
+
+    @Override
     public WWidget getWidget(GuiTheme theme) {
-        WTable table = theme.table();
+        table = theme.table();
         fillTable(theme, table);
 
         return table;


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Despawn fake players and clear table on deactivate.
Previously they would stay rendered even wen toggling the module off, which was confusing.

## Related issues

None.

# How Has This Been Tested?

Singleplayer testing.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
