### PR TITLE
Compatibility between clicktp and freecam

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/ClickTP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/ClickTP.java
@@ -11,6 +11,8 @@ import meteordevelopment.meteorclient.settings.Setting;
 import meteordevelopment.meteorclient.settings.SettingGroup;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.meteorclient.systems.modules.Modules;
+import meteordevelopment.meteorclient.systems.modules.render.Freecam;
 import meteordevelopment.orbit.EventHandler;
 import net.minecraft.block.BlockState;
 import net.minecraft.util.ActionResult;
@@ -41,7 +43,15 @@ public class ClickTP extends Module {
         if (mc.player.isUsingItem()) return;
 
         if (mc.options.useKey.isPressed()) {
-            HitResult hitResult = mc.player.raycast(maxDistance.get(), 1f / 20f, false);
+            HitResult hitResult;
+
+            if (Modules.get().get(Freecam.class).isActive()) {
+                hitResult = mc.crosshairTarget;
+            }
+            else {
+                hitResult = mc.player.raycast(maxDistance.get(), 1f / 20f, false);
+            }
+
 
             if (hitResult.getType() == HitResult.Type.ENTITY && mc.player.interact(((EntityHitResult) hitResult).getEntity(), Hand.MAIN_HAND) != ActionResult.PASS) return;
 


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

This checks for if freecam is enabled and then uses MinecraftClient.crosshairTarget (which is already modified in a mixin) instead of raycast. This does limit it so that you can only tp to blocks that are targeted so you can't tp to a block 30 blocks away (This does not affect use while not in freecam).

While searching issues I did see two other pull requests that did implement a raycast method to get around the aforementioned limitation which may be better to use than this: [4549](https://github.com/MeteorDevelopment/meteor-client/pull/4549) and [4146](https://github.com/MeteorDevelopment/meteor-client/pull/4146)

## Related issues

#2775 

# How Has This Been Tested?

Tested in singleplayer and a public muliplayer server

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
