### PR TITLE
various esp performance patches

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/EntityMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/EntityMixin.java
@@ -144,7 +144,7 @@ public abstract class EntityMixin {
     @Inject(method = "getTeamColorValue", at = @At("HEAD"), cancellable = true)
     private void onGetTeamColorValue(CallbackInfoReturnable<Integer> info) {
         if (PostProcessShaders.rendering) {
-            Color color = Modules.get().get(ESP.class).getColor((Entity) (Object) this);
+            Color color = ESP.getColor((Entity) (Object) this);
             if (color != null) info.setReturnValue(color.getPacked());
         }
     }
@@ -161,8 +161,7 @@ public abstract class EntityMixin {
     @ModifyReturnValue(method = "isInvisibleTo(Lnet/minecraft/entity/player/PlayerEntity;)Z", at = @At("RETURN"))
     private boolean isInvisibleToCanceller(boolean original) {
         if (!Utils.canUpdate()) return original;
-        ESP esp = Modules.get().get(ESP.class);
-        if (Modules.get().get(NoRender.class).noInvisibility() || esp.isActive() && !esp.shouldSkip((Entity) (Object) this)) return false;
+        if (Modules.get().get(NoRender.class).noInvisibility() || ESP.get().isActive() && !ESP.shouldSkip((Entity) (Object) this)) return false;
         return original;
     }
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/MinecraftClientMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MinecraftClientMixin.java
@@ -268,11 +268,10 @@ public abstract class MinecraftClientMixin implements IMinecraftClient {
 
     @ModifyReturnValue(method = "hasOutline", at = @At("RETURN"))
     private boolean hasOutlineModifyIsOutline(boolean original, Entity entity) {
-        ESP esp = Modules.get().get(ESP.class);
-        if (esp == null) return original;
-        if (!esp.isGlow() || esp.shouldSkip(entity)) return original;
+        if (ESP.get() == null) return original;
+        if (!ESP.isGlow() || ESP.shouldSkip(entity)) return original;
 
-        return esp.getColor(entity) != null || original;
+        return ESP.getColor(entity) != null || original;
     }
 
     // Interface

--- a/src/main/java/meteordevelopment/meteorclient/mixin/WorldRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/WorldRendererMixin.java
@@ -47,8 +47,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(WorldRenderer.class)
 public abstract class WorldRendererMixin implements IWorldRenderer {
-    @Unique private ESP esp;
-
     @Shadow
     protected abstract void renderEntity(Entity entity, double cameraX, double cameraY, double cameraZ, float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumers);
 
@@ -103,7 +101,7 @@ public abstract class WorldRendererMixin implements IWorldRenderer {
     @Inject(method = "renderEntity", at = @At("HEAD"))
     private void renderEntity(Entity entity, double cameraX, double cameraY, double cameraZ, float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumers, CallbackInfo info) {
         draw(entity, cameraX, cameraY, cameraZ, tickDelta, vertexConsumers, matrices, PostProcessShaders.CHAMS, Color.WHITE);
-        draw(entity, cameraX, cameraY, cameraZ, tickDelta, vertexConsumers, matrices, PostProcessShaders.ENTITY_OUTLINE, Modules.get().get(ESP.class).getColor(entity));
+        draw(entity, cameraX, cameraY, cameraZ, tickDelta, vertexConsumers, matrices, PostProcessShaders.ENTITY_OUTLINE, ESP.getColor(entity));
     }
 
     @Unique
@@ -127,9 +125,9 @@ public abstract class WorldRendererMixin implements IWorldRenderer {
 
     @WrapOperation(method = "renderEntities", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/OutlineVertexConsumerProvider;setColor(IIII)V"))
     private void setGlowColor(OutlineVertexConsumerProvider instance, int red, int green, int blue, int alpha, Operation<Void> original, @Local LocalRef<Entity> entity) {
-        if (!getESP().isGlow() || getESP().shouldSkip(entity.get())) original.call(instance, red, green, blue, alpha);
+        if (!ESP.isGlow() || ESP.shouldSkip(entity.get())) original.call(instance, red, green, blue, alpha);
         else {
-            Color color = getESP().getColor(entity.get());
+            Color color = ESP.getColor(entity.get());
 
             if (color == null) original.call(instance, red, green, blue, alpha);
             else instance.setColor(color.r, color.g, color.b, color.a);
@@ -139,15 +137,6 @@ public abstract class WorldRendererMixin implements IWorldRenderer {
     @Inject(method = "onResized", at = @At("HEAD"))
     private void onResized(int width, int height, CallbackInfo info) {
         PostProcessShaders.onResized(width, height);
-    }
-
-    @Unique
-    private ESP getESP() {
-        if (esp == null) {
-            esp = Modules.get().get(ESP.class);
-        }
-
-        return esp;
     }
 
     // IWorldRenderer

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/ESP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/ESP.java
@@ -305,6 +305,7 @@ public class ESP extends Module {
     }
 
     public Color getColor(Entity entity) {
+        if (!isActive()) return null;
         if (!entities.get().contains(entity.getType())) return null;
 
         double alpha = getFadeAlpha(entity);

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/ESP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/ESP.java
@@ -14,6 +14,7 @@ import meteordevelopment.meteorclient.systems.config.Config;
 import meteordevelopment.meteorclient.systems.friends.Friends;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.utils.entity.EntityUtils;
 import meteordevelopment.meteorclient.utils.player.PlayerUtils;
 import meteordevelopment.meteorclient.utils.render.NametagUtils;
@@ -21,6 +22,7 @@ import meteordevelopment.meteorclient.utils.render.WireframeEntityRenderer;
 import meteordevelopment.meteorclient.utils.render.color.Color;
 import meteordevelopment.meteorclient.utils.render.color.SettingColor;
 import meteordevelopment.orbit.EventHandler;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.player.PlayerEntity;
@@ -31,6 +33,7 @@ import org.joml.Vector3d;
 import java.util.Set;
 
 public class ESP extends Module {
+    private static ESP esp;
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
     private final SettingGroup sgColors = settings.createGroup("Colors");
 
@@ -297,22 +300,35 @@ public class ESP extends Module {
 
     // Utils
 
-    public boolean shouldSkip(Entity entity) {
-        if (!entities.get().contains(entity.getType())) return true;
-        if (entity == mc.player && ignoreSelf.get()) return true;
-        if (entity == mc.cameraEntity && mc.options.getPerspective().isFirstPerson()) return true;
+    public static ESP get() {
+        if (esp == null) {
+            esp = Modules.get().get(ESP.class);
+        }
+
+        return esp;
+    }
+
+    public static boolean shouldSkip(Entity entity) {
+        ESP esp = get();
+
+        if (!esp.entities.get().contains(entity.getType())) return true;
+        if (entity == MinecraftClient.getInstance().player && esp.ignoreSelf.get()) return true;
+        if (entity == MinecraftClient.getInstance().cameraEntity
+            && MinecraftClient.getInstance().options.getPerspective().isFirstPerson()) return true;
         return !EntityUtils.isInRenderDistance(entity);
     }
 
-    public Color getColor(Entity entity) {
-        if (!isActive()) return null;
-        if (!entities.get().contains(entity.getType())) return null;
+    public static Color getColor(Entity entity) {
+        ESP esp = get();
 
-        double alpha = getFadeAlpha(entity);
+        if (!esp.isActive()) return null;
+        if (!esp.entities.get().contains(entity.getType())) return null;
+
+        double alpha = esp.getFadeAlpha(entity);
         if (alpha == 0) return null;
 
-        Color color = getEntityTypeColor(entity);
-        return baseColor.set(color.r, color.g, color.b, (int) (color.a * alpha));
+        Color color = esp.getEntityTypeColor(entity);
+        return esp.baseColor.set(color.r, color.g, color.b, (int) (color.a * alpha));
     }
 
     private double getFadeAlpha(Entity entity) {
@@ -347,12 +363,14 @@ public class ESP extends Module {
         return Integer.toString(count);
     }
 
-    public boolean isShader() {
-        return isActive() && mode.get() == Mode.Shader;
+    public static boolean isShader() {
+        ESP esp = get();
+        return esp.isActive() && esp.mode.get() == Mode.Shader;
     }
 
-    public boolean isGlow() {
-        return isActive() && mode.get() == Mode.Glow;
+    public static boolean isGlow() {
+        ESP esp = get();
+        return esp.isActive() && esp.mode.get() == Mode.Glow;
     }
 
     public enum Mode {

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/postprocess/EntityOutlineShader.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/postprocess/EntityOutlineShader.java
@@ -2,31 +2,27 @@ package meteordevelopment.meteorclient.utils.render.postprocess;
 
 import meteordevelopment.meteorclient.renderer.MeshRenderer;
 import meteordevelopment.meteorclient.renderer.MeteorRenderPipelines;
-import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.render.ESP;
 import net.minecraft.entity.Entity;
 
 public class EntityOutlineShader extends EntityShader {
-    private static ESP esp;
-
     public EntityOutlineShader() {
         init(MeteorRenderPipelines.POST_OUTLINE);
     }
 
     @Override
     protected boolean shouldDraw() {
-        if (esp == null) esp = Modules.get().get(ESP.class);
-        return esp.isShader();
+        return ESP.isShader();
     }
 
     @Override
     public boolean shouldDraw(Entity entity) {
-        if (!shouldDraw()) return false;
-        return !esp.shouldSkip(entity);
+        return !ESP.shouldSkip(entity);
     }
 
     @Override
     protected void setupPass(MeshRenderer renderer) {
+        ESP esp = ESP.get();
         renderer.uniform("OutlineData", OutlineUniforms.write(
             esp.outlineWidth.get(),
             esp.fillOpacity.get().floatValue(),

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/postprocess/EntityShader.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/postprocess/EntityShader.java
@@ -3,15 +3,13 @@ package meteordevelopment.meteorclient.utils.render.postprocess;
 import com.mojang.blaze3d.systems.RenderSystem;
 import meteordevelopment.meteorclient.mixininterface.IWorldRenderer;
 
-import java.util.OptionalInt;
-
 import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public abstract class EntityShader extends PostProcessShader {
     @Override
     public boolean beginRender() {
         if (super.beginRender()) {
-            RenderSystem.getDevice().createCommandEncoder().createRenderPass(() -> "Meteor EntityShader", framebuffer.getColorAttachmentView(), OptionalInt.of(0)).close();
+            RenderSystem.getDevice().createCommandEncoder().clearColorTexture(framebuffer.getColorAttachment(), 0);
             return true;
         }
 


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

- Replaced render pass in `EntityShader` with `CommandEncoder#clearColorTexture`
- Added a short-circuit in `ESP#getColor` to prevent extra computations from `WorldRendererMixin` when esp is disabled
- Removed esp instance cache from `WorldRendererMixin` and `EntityOutlineShader` in favor of one directly in `ESP`

## Related issues

none

# How Has This Been Tested?

the J

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
