### PR TITLE
instantly display tooltips on icon buttons

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/DefaultSettingsWidgetFactory.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/DefaultSettingsWidgetFactory.java
@@ -243,6 +243,7 @@ public class DefaultSettingsWidgetFactory extends SettingsWidgetFactory {
 
         WButton reset = list.add(theme.button(GuiRenderer.RESET)).expandCellX().right().widget();
         reset.action = keybind::resetBind;
+        reset.tooltip = "Reset";
     }
 
     private void blockW(WTable table, BlockSetting setting) {
@@ -484,6 +485,7 @@ public class DefaultSettingsWidgetFactory extends SettingsWidgetFactory {
             setting.reset();
             if (action != null) action.run();
         };
+        reset.tooltip = "Reset";
     }
 
     private static class WSelectedCountLabel extends WMeteorLabel {

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/ModuleScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/ModuleScreen.java
@@ -84,6 +84,7 @@ public class ModuleScreen extends WindowScreen {
 
         WButton reset = bind.add(theme.button(GuiRenderer.RESET)).expandCellX().right().widget();
         reset.action = keybind::resetBind;
+        reset.tooltip = "Reset";
 
         // Toggle on bind release
         WHorizontalList tobr = section.add(theme.horizontalList()).widget();

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/ColorSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/ColorSettingScreen.java
@@ -108,6 +108,7 @@ public class ColorSettingScreen extends WindowScreen {
             setFromSetting();
             callAction();
         };
+        resetButton.tooltip = "Reset";
 
         hueQuad.calculateFromSetting(false);
         brightnessQuad.calculateFromColor(setting.get(), false);

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/base/CollectionMapSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/base/CollectionMapSettingScreen.java
@@ -11,6 +11,7 @@ import meteordevelopment.meteorclient.gui.renderer.GuiRenderer;
 import meteordevelopment.meteorclient.gui.widgets.WWidget;
 import meteordevelopment.meteorclient.gui.widgets.containers.WTable;
 import meteordevelopment.meteorclient.gui.widgets.input.WTextBox;
+import meteordevelopment.meteorclient.gui.widgets.pressable.WButton;
 import meteordevelopment.meteorclient.settings.Setting;
 import meteordevelopment.meteorclient.utils.misc.IChangeable;
 import org.jetbrains.annotations.Nullable;
@@ -63,9 +64,9 @@ public abstract class CollectionMapSettingScreen<K, V> extends WindowScreen {
             table.add(theme.label(isChanged ? "*" : " "));
             table.add(getDataWidget(t, data));
 
-            table.add(theme.button(GuiRenderer.RESET)).widget().action = () -> {
-                removeValue(t);
-            };
+            WButton reset = table.add(theme.button(GuiRenderer.RESET)).widget();
+            reset.action = () -> removeValue(t);
+            reset.tooltip = "Reset";
 
             table.row();
         });

--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/HudTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/HudTab.java
@@ -69,6 +69,7 @@ public class HudTab extends Tab {
 
             WButton resetSettings = bottom.add(theme.button(GuiRenderer.RESET)).widget();
             resetSettings.action = hud.settings::reset;
+            resetSettings.tooltip = "Reset";
         }
 
         @Override

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/WWidget.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/WWidget.java
@@ -21,6 +21,7 @@ public abstract class WWidget implements BaseWidget {
     public String tooltip;
 
     public boolean mouseOver;
+    protected boolean instantTooltips;
     protected double mouseOverTimer;
 
     public void init() {}
@@ -73,7 +74,7 @@ public abstract class WWidget implements BaseWidget {
 
         if (isOver(mouseX, mouseY)) {
             mouseOverTimer += delta;
-            if (mouseOverTimer >= 1 && tooltip != null) renderer.tooltip(tooltip);
+            if ((instantTooltips || mouseOverTimer >= 1) && tooltip != null) renderer.tooltip(tooltip);
         }
         else {
             mouseOverTimer = 0;

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/pressable/WButton.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/pressable/WButton.java
@@ -16,6 +16,8 @@ public abstract class WButton extends WPressable {
     public WButton(String text, GuiTexture texture) {
         this.text = text;
         this.texture = texture;
+
+        if (text == null) instantTooltips = true;
     }
 
     @Override

--- a/src/main/java/meteordevelopment/meteorclient/settings/StringListSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/StringListSetting.java
@@ -115,6 +115,7 @@ public class StringListSetting extends Setting<List<String>>{
 
             fillTable(theme, table, setting);
         };
+        reset.tooltip = "Reset";
     }
 
     public static class Builder extends SettingBuilder<Builder, List<String>, StringListSetting> {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Improves accessibility by making tooltips appear instantly on hover for icon buttons. Primarily for the copy & paste buttons, which look similar at a glance
Also adds tooltips to reset buttons

## Related issues

none

# How Has This Been Tested?

the J

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
