### PR TITLE
Macros tab changes

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/MacrosTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/MacrosTab.java
@@ -64,7 +64,7 @@ public class MacrosTab extends Tab {
 
                 Keybind keybind = macro.keybind.get();
                 Color keybindColor = keybind.isSet() ? Color.GREEN : Color.LIGHT_GRAY;
-                table.add(theme.label("(")).expandCellX().right();
+                table.add(theme.label(" (")).expandCellX().right();
                 table.add(theme.label(keybind.toString()).color(keybindColor)).center();
                 table.add(theme.label(")")).right();
 


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Align keybind strings in macros tab to right of column and add color for readability and visual clarity.

I've also made a variant in which the bound and unbound text colors are added as settings to Config. I'd be happy to update the PR to include it if you prefer.

## Related issues

None

# How Has This Been Tested?

Tested in-game with various dummy data
<img width="793" height="223" alt="image" src="https://github.com/user-attachments/assets/6c4745bb-61ee-483e-9a28-a384c93a3fc7" />

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
