### PR TITLE
[fix] missing AW entry

### DIFF
--- a/src/main/resources/meteor-client.accesswidener
+++ b/src/main/resources/meteor-client.accesswidener
@@ -16,7 +16,9 @@ accessible   class   net/minecraft/client/resource/ResourceReloadLogger$ReloadSt
 
 accessible   class   com/mojang/blaze3d/opengl/GlStateManager$CapabilityTracker
 accessible   method  com/mojang/blaze3d/pipeline/RenderPipeline$Builder <init> ()V
-accessible   method   com/mojang/blaze3d/pipeline/RenderPipeline$Builder withSnippet (Lcom/mojang/blaze3d/pipeline/RenderPipeline$Snippet;)V
+accessible   method  com/mojang/blaze3d/pipeline/RenderPipeline$Builder withSnippet (Lcom/mojang/blaze3d/pipeline/RenderPipeline$Snippet;)V
+
+accessible   field   net/minecraft/client/render/RenderPhase ITEM_ENTITY_TARGET Lnet/minecraft/client/render/RenderPhase$Target;
 
 # Auto Fish
 accessible class net/minecraft/entity/projectile/FishingBobberEntity$State


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

used in `WireframeEntityRenderer`.

present at compile time due to `fabric-transitive-access-wideners` pulled in by `fabric-renderer-indigo`, but crashes at runtime

## Related issues

none

# How Has This Been Tested?

trivial

# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [ ] I have tested the code in both development and production environments.
