### PR TITLE
[feat] prevent misclicks on delete buttons

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/GuiTheme.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/GuiTheme.java
@@ -88,7 +88,16 @@ public abstract class GuiTheme implements ISerializable<GuiTheme> {
         return button(null, texture);
     }
 
+    protected abstract WConfirmedButton confirmedButton(String text, String confirmText, GuiTexture texture);
+    public WConfirmedButton confirmedButton(String text, String confirmText) {
+        return confirmedButton(text, confirmText, null);
+    }
+    public WConfirmedButton confirmedButton(GuiTexture texture) {
+        return confirmedButton(null, null, texture);
+    }
+
     public abstract WMinus minus();
+    public abstract WConfirmedMinus confirmedMinus();
     public abstract WPlus plus();
 
     public abstract WCheckbox checkbox(boolean checked);

--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/MacrosTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/MacrosTab.java
@@ -13,7 +13,7 @@ import meteordevelopment.meteorclient.gui.tabs.TabScreen;
 import meteordevelopment.meteorclient.gui.tabs.WindowTabScreen;
 import meteordevelopment.meteorclient.gui.widgets.containers.WTable;
 import meteordevelopment.meteorclient.gui.widgets.pressable.WButton;
-import meteordevelopment.meteorclient.gui.widgets.pressable.WMinus;
+import meteordevelopment.meteorclient.gui.widgets.pressable.WConfirmedMinus;
 import meteordevelopment.meteorclient.settings.Settings;
 import meteordevelopment.meteorclient.systems.macros.Macro;
 import meteordevelopment.meteorclient.systems.macros.Macros;
@@ -63,7 +63,7 @@ public class MacrosTab extends Tab {
                 WButton edit = table.add(theme.button(GuiRenderer.EDIT)).expandCellX().right().widget();
                 edit.action = () -> mc.setScreen(new EditMacroScreen(theme, macro, this::reload));
 
-                WMinus remove = table.add(theme.minus()).widget();
+                WConfirmedMinus remove = table.add(theme.confirmedMinus()).widget();
                 remove.action = () -> {
                     Macros.get().remove(macro);
                     reload();

--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/ProfilesTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/ProfilesTab.java
@@ -14,6 +14,8 @@ import meteordevelopment.meteorclient.gui.tabs.WindowTabScreen;
 import meteordevelopment.meteorclient.gui.widgets.containers.WContainer;
 import meteordevelopment.meteorclient.gui.widgets.containers.WTable;
 import meteordevelopment.meteorclient.gui.widgets.pressable.WButton;
+import meteordevelopment.meteorclient.gui.widgets.pressable.WConfirmedButton;
+import meteordevelopment.meteorclient.gui.widgets.pressable.WConfirmedMinus;
 import meteordevelopment.meteorclient.gui.widgets.pressable.WMinus;
 import meteordevelopment.meteorclient.systems.profiles.Profile;
 import meteordevelopment.meteorclient.systems.profiles.Profiles;
@@ -65,8 +67,9 @@ public class ProfilesTab extends Tab {
             for (Profile profile : Profiles.get()) {
                 table.add(theme.label(profile.name.get())).expandCellX();
 
-                WButton save = table.add(theme.button("Save")).widget();
+                WConfirmedButton save = theme.confirmedButton("Save", "Confirm");;
                 save.action = profile::save;
+                table.add(save).right();
 
                 WButton load = table.add(theme.button("Load")).widget();
                 load.action = profile::load;
@@ -74,7 +77,7 @@ public class ProfilesTab extends Tab {
                 WButton edit = table.add(theme.button(GuiRenderer.EDIT)).widget();
                 edit.action = () -> mc.setScreen(new EditProfileScreen(theme, profile, this::reload));
 
-                WMinus remove = table.add(theme.minus()).widget();
+                WConfirmedMinus remove = table.add(theme.confirmedMinus()).widget();
                 remove.action = () -> {
                     Profiles.get().remove(profile);
                     reload();

--- a/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/MeteorGuiTheme.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/MeteorGuiTheme.java
@@ -211,8 +211,18 @@ public class MeteorGuiTheme extends GuiTheme {
     }
 
     @Override
+    protected WConfirmedButton confirmedButton(String text, String confirmText, GuiTexture texture) {
+        return w(new WMeteorConfirmedButton(text, confirmText, texture));
+    }
+
+    @Override
     public WMinus minus() {
         return w(new WMeteorMinus());
+    }
+
+    @Override
+    public WConfirmedMinus confirmedMinus() {
+        return w(new WMeteorConfirmedMinus());
     }
 
     @Override

--- a/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/MeteorWidget.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/MeteorWidget.java
@@ -15,16 +15,20 @@ public interface MeteorWidget extends BaseWidget {
         return (MeteorGuiTheme) getTheme();
     }
 
-    default void renderBackground(GuiRenderer renderer, WWidget widget, boolean pressed, boolean mouseOver) {
+    default void renderBackground(GuiRenderer renderer, WWidget widget, Color outlineColor, Color backgroundColor) {
         MeteorGuiTheme theme = theme();
         double s = theme.scale(2);
 
-        renderer.quad(widget.x + s, widget.y + s, widget.width - s * 2, widget.height - s * 2, theme.backgroundColor.get(pressed, mouseOver));
+        renderer.quad(widget.x + s, widget.y + s, widget.width - s * 2, widget.height - s * 2, backgroundColor);
 
-        Color outlineColor = theme.outlineColor.get(pressed, mouseOver);
         renderer.quad(widget.x, widget.y, widget.width, s, outlineColor);
         renderer.quad(widget.x, widget.y + widget.height - s, widget.width, s, outlineColor);
         renderer.quad(widget.x, widget.y + s, s, widget.height - s * 2, outlineColor);
         renderer.quad(widget.x + widget.width - s, widget.y + s, s, widget.height - s * 2, outlineColor);
+    }
+
+    default void renderBackground(GuiRenderer renderer, WWidget widget, boolean pressed, boolean mouseOver) {
+        MeteorGuiTheme theme = theme();
+        renderBackground(renderer, widget, theme.outlineColor.get(pressed, mouseOver), theme.backgroundColor.get(pressed, mouseOver));
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/pressable/WMeteorConfirmedButton.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/pressable/WMeteorConfirmedButton.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.gui.themes.meteor.widgets.pressable;
+
+import meteordevelopment.meteorclient.gui.renderer.GuiRenderer;
+import meteordevelopment.meteorclient.gui.renderer.packer.GuiTexture;
+import meteordevelopment.meteorclient.gui.themes.meteor.MeteorGuiTheme;
+import meteordevelopment.meteorclient.gui.themes.meteor.MeteorWidget;
+import meteordevelopment.meteorclient.gui.widgets.pressable.WButton;
+import meteordevelopment.meteorclient.gui.widgets.pressable.WConfirmedButton;
+import meteordevelopment.meteorclient.utils.render.color.Color;
+
+public class WMeteorConfirmedButton extends WConfirmedButton implements MeteorWidget {
+    public WMeteorConfirmedButton(String text, String confirmText, GuiTexture texture) {
+        super(text, confirmText, texture);
+    }
+
+    @Override
+    protected void onRender(GuiRenderer renderer, double mouseX, double mouseY, double delta) {
+        MeteorGuiTheme theme = theme();
+        double pad = pad();
+
+        Color outline = theme.outlineColor.get(pressed, mouseOver);
+        Color fg = pressedOnce ? theme.backgroundColor.get(pressed, mouseOver) : theme.textColor.get();
+        Color bg = pressedOnce ? theme.textColor.get() : theme.backgroundColor.get(pressed, mouseOver);
+
+        renderBackground(renderer, this, outline, bg);
+
+        String text = getText();
+
+        if (text != null) {
+            renderer.text(text, x + width / 2 - textWidth / 2, y + pad, fg, false);
+        }
+        else {
+            double ts = theme.textHeight();
+            renderer.quad(x + width / 2 - ts / 2, y + pad, ts, ts, texture, fg);
+        }
+    }
+}

--- a/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/pressable/WMeteorConfirmedMinus.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/pressable/WMeteorConfirmedMinus.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.gui.themes.meteor.widgets.pressable;
+
+import meteordevelopment.meteorclient.gui.renderer.GuiRenderer;
+import meteordevelopment.meteorclient.gui.themes.meteor.MeteorGuiTheme;
+import meteordevelopment.meteorclient.gui.themes.meteor.MeteorWidget;
+import meteordevelopment.meteorclient.gui.widgets.pressable.WConfirmedMinus;
+import meteordevelopment.meteorclient.utils.render.color.Color;
+
+public class WMeteorConfirmedMinus extends WConfirmedMinus implements MeteorWidget {
+    @Override
+    protected void onRender(GuiRenderer renderer, double mouseX, double mouseY, double delta) {
+        MeteorGuiTheme theme = theme();
+        double pad = pad();
+        double s = theme.scale(3);
+
+        Color outline = theme.outlineColor.get(pressed, mouseOver);
+        Color fg = pressedOnce ? theme.backgroundColor.get(pressed, mouseOver) : theme().minusColor.get();
+        Color bg = pressedOnce ? theme().minusColor.get() : theme.backgroundColor.get(pressed, mouseOver);
+
+        renderBackground(renderer, this, outline, bg);
+        renderer.quad(x + pad, y + height / 2 - s / 2, width - pad * 2, s, fg);
+    }
+}

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/WAccount.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/WAccount.java
@@ -9,7 +9,7 @@ import meteordevelopment.meteorclient.gui.WidgetScreen;
 import meteordevelopment.meteorclient.gui.screens.accounts.AccountInfoScreen;
 import meteordevelopment.meteorclient.gui.widgets.containers.WHorizontalList;
 import meteordevelopment.meteorclient.gui.widgets.pressable.WButton;
-import meteordevelopment.meteorclient.gui.widgets.pressable.WMinus;
+import meteordevelopment.meteorclient.gui.widgets.pressable.WConfirmedMinus;
 import meteordevelopment.meteorclient.systems.accounts.Account;
 import meteordevelopment.meteorclient.systems.accounts.Accounts;
 import meteordevelopment.meteorclient.systems.accounts.TokenAccount;
@@ -73,7 +73,7 @@ public abstract class WAccount extends WHorizontalList {
         };
 
         // Remove
-        WMinus remove = add(theme.minus()).widget();
+        WConfirmedMinus remove = add(theme.confirmedMinus()).widget();
         remove.action = () -> {
             Accounts.get().remove(account);
             if (refreshScreenAction != null) refreshScreenAction.run();

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/pressable/WButton.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/pressable/WButton.java
@@ -22,6 +22,8 @@ public abstract class WButton extends WPressable {
     protected void onCalculateSize() {
         double pad = pad();
 
+        String text = getText();
+
         if (text != null) {
             textWidth = theme.textWidth(text);
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/pressable/WConfirmedButton.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/pressable/WConfirmedButton.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.gui.widgets.pressable;
+
+import meteordevelopment.meteorclient.gui.renderer.packer.GuiTexture;
+
+public abstract class WConfirmedButton extends WButton {
+
+    protected boolean pressedOnce = false;
+    protected String confirmText;
+
+    public WConfirmedButton(String text, String confirmText, GuiTexture texture) {
+        super(text, texture);
+        this.confirmText = confirmText;
+    }
+
+    @Override
+    protected void onCalculateSize() {
+        double pad = pad();
+
+        String text = getText();
+
+        if (text != null) {
+            textWidth = theme.textWidth(text);
+
+            width = pad + textWidth + pad;
+            height = pad + theme.textHeight() + pad;
+        }
+        else {
+            double s = theme.textHeight();
+
+            width = pad + s + pad;
+            height = pad + s + pad;
+        }
+    }
+
+    @Override
+    protected void onPressed(int button) {
+        pressedOnce = false;
+        super.onPressed(button);
+    }
+
+    @Override
+    public boolean onMouseClicked(double mouseX, double mouseY, int button, boolean used) {
+        boolean pressed = super.onMouseClicked(mouseX, mouseY, button, used);
+        if (!pressed) {
+            pressedOnce = false;
+            invalidate();
+        }
+        return pressed;
+    }
+
+    @Override
+    public boolean onMouseReleased(double mouseX, double mouseY, int button) {
+        if (pressed) {
+            if (pressedOnce) super.onMouseReleased(mouseX, mouseY, button);
+            else pressedOnce = true;
+        } else pressedOnce = false;
+        invalidate();
+        return pressed = false;
+    }
+
+    public String getText() {
+        return pressedOnce ? confirmText : text;
+    }
+}

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/pressable/WConfirmedButton.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/pressable/WConfirmedButton.java
@@ -38,12 +38,6 @@ public abstract class WConfirmedButton extends WButton {
     }
 
     @Override
-    protected void onPressed(int button) {
-        pressedOnce = false;
-        super.onPressed(button);
-    }
-
-    @Override
     public boolean onMouseClicked(double mouseX, double mouseY, int button, boolean used) {
         boolean pressed = super.onMouseClicked(mouseX, mouseY, button, used);
         if (!pressed) {
@@ -55,10 +49,8 @@ public abstract class WConfirmedButton extends WButton {
 
     @Override
     public boolean onMouseReleased(double mouseX, double mouseY, int button) {
-        if (pressed) {
-            if (pressedOnce) super.onMouseReleased(mouseX, mouseY, button);
-            else pressedOnce = true;
-        } else pressedOnce = false;
+        if (pressed && pressedOnce) super.onMouseReleased(mouseX, mouseY, button);
+        pressedOnce = pressed;
         invalidate();
         return pressed = false;
     }

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/pressable/WConfirmedButton.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/pressable/WConfirmedButton.java
@@ -18,26 +18,6 @@ public abstract class WConfirmedButton extends WButton {
     }
 
     @Override
-    protected void onCalculateSize() {
-        double pad = pad();
-
-        String text = getText();
-
-        if (text != null) {
-            textWidth = theme.textWidth(text);
-
-            width = pad + textWidth + pad;
-            height = pad + theme.textHeight() + pad;
-        }
-        else {
-            double s = theme.textHeight();
-
-            width = pad + s + pad;
-            height = pad + s + pad;
-        }
-    }
-
-    @Override
     public boolean onMouseClicked(double mouseX, double mouseY, int button, boolean used) {
         boolean pressed = super.onMouseClicked(mouseX, mouseY, button, used);
         if (!pressed) {
@@ -55,6 +35,7 @@ public abstract class WConfirmedButton extends WButton {
         return pressed = false;
     }
 
+    @Override
     public String getText() {
         return pressedOnce ? confirmText : text;
     }

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/pressable/WConfirmedMinus.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/pressable/WConfirmedMinus.java
@@ -9,12 +9,6 @@ public class WConfirmedMinus extends WMinus {
     protected boolean pressedOnce = false;
 
     @Override
-    protected void onPressed(int button) {
-        pressedOnce = false;
-        super.onPressed(button);
-    }
-
-    @Override
     public boolean onMouseClicked(double mouseX, double mouseY, int button, boolean used) {
         boolean pressed = super.onMouseClicked(mouseX, mouseY, button, used);
         if (!pressed) {
@@ -25,10 +19,8 @@ public class WConfirmedMinus extends WMinus {
 
     @Override
     public boolean onMouseReleased(double mouseX, double mouseY, int button) {
-        if (pressed) {
-            if (pressedOnce) super.onMouseReleased(mouseX, mouseY, button);
-            else pressedOnce = true;
-        } else pressedOnce = false;
+        if (pressed && pressedOnce) super.onMouseReleased(mouseX, mouseY, button);
+        pressedOnce = pressed;
         return pressed = false;
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/pressable/WConfirmedMinus.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/pressable/WConfirmedMinus.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.gui.widgets.pressable;
+
+public class WConfirmedMinus extends WMinus {
+    protected boolean pressedOnce = false;
+
+    @Override
+    protected void onPressed(int button) {
+        pressedOnce = false;
+        super.onPressed(button);
+    }
+
+    @Override
+    public boolean onMouseClicked(double mouseX, double mouseY, int button, boolean used) {
+        boolean pressed = super.onMouseClicked(mouseX, mouseY, button, used);
+        if (!pressed) {
+            pressedOnce = false;
+        }
+        return pressed;
+    }
+
+    @Override
+    public boolean onMouseReleased(double mouseX, double mouseY, int button) {
+        if (pressed) {
+            if (pressedOnce) super.onMouseReleased(mouseX, mouseY, button);
+            else pressedOnce = true;
+        } else pressedOnce = false;
+        return pressed = false;
+    }
+}

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/WaypointsModule.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/WaypointsModule.java
@@ -15,7 +15,7 @@ import meteordevelopment.meteorclient.gui.widgets.WWidget;
 import meteordevelopment.meteorclient.gui.widgets.containers.WTable;
 import meteordevelopment.meteorclient.gui.widgets.pressable.WButton;
 import meteordevelopment.meteorclient.gui.widgets.pressable.WCheckbox;
-import meteordevelopment.meteorclient.gui.widgets.pressable.WMinus;
+import meteordevelopment.meteorclient.gui.widgets.pressable.WConfirmedMinus;
 import meteordevelopment.meteorclient.pathing.PathManagers;
 import meteordevelopment.meteorclient.renderer.text.TextRenderer;
 import meteordevelopment.meteorclient.settings.*;
@@ -233,7 +233,7 @@ public class WaypointsModule extends Module {
                 };
             }
 
-            WMinus remove = table.add(theme.minus()).widget();
+            WConfirmedMinus remove = table.add(theme.confirmedMinus()).widget();
             remove.action = () -> {
                 Waypoints.get().remove(waypoint);
                 initTable(theme, table);


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature

## Description

meteor has several destructive buttons positioned a few pixels away from other buttons.
requires such buttons to be pressed twice to avoid destructive misclicks (which have happened at least a few times)

cherry-pick from profile system changes

## Related issues

none

# How Has This Been Tested?

works.

visual indications of the button requiring confirmation:
<img width="234" height="69" alt="image" src="https://github.com/user-attachments/assets/e9ef0dca-f47b-4f71-98b3-73fd87ce5165" /> <img width="210" height="69" alt="image" src="https://github.com/user-attachments/assets/880872b3-ddbf-4db6-a4c9-e70ef7dd1fac" />

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
