### PR TITLE
fix(AutoGap): respect allowEgap setting when choosing enchanted gaps

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoGap.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoGap.java
@@ -280,8 +280,6 @@ public class AutoGap extends Module {
     }
 
     private int findSlot() {
-        boolean allowEgapSetting = allowEgap.get();
-
         for (int i = 0; i < 9; i++) {
             ItemStack stack = mc.player.getInventory().getStack(i);
 
@@ -294,7 +292,7 @@ public class AutoGap extends Module {
             Item item = stack.getItem();
 
             // If egap was found and allowEgapSetting is true we can return the current slot
-            if (item == Items.ENCHANTED_GOLDEN_APPLE && allowEgapSetting) return i;
+            if (item == Items.ENCHANTED_GOLDEN_APPLE && allowEgap.get()) return i;
 
             // If gap was found and egap is not required we can return the current slot
             if (item == Items.GOLDEN_APPLE && !requiresEGap) return i;


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

`findSlot()` selected enchanted golden apples even when allowEgap was false 

`preferEGap = this.allowEgap.get() || requiresEGap`, so `requiresEGap` forced EGAP preference and ignored the user setting.

bug demo: 

https://github.com/user-attachments/assets/8fc6bab7-ef95-4e0e-9512-ce28e6a18d5a

## Related issues

#5165

# How Has This Been Tested?

https://github.com/user-attachments/assets/e3522738-2f33-4d30-9b63-e41ddb4a51dc

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
