### PR TITLE
Enhance `DropCommand` to support item quantity

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/DropCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/DropCommand.java
@@ -5,7 +5,9 @@
 
 package meteordevelopment.meteorclient.commands.commands;
 
+import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import meteordevelopment.meteorclient.commands.Command;
@@ -17,6 +19,7 @@ import net.minecraft.component.type.AttributeModifierSlot;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
+import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.Text;
 
 public class DropCommand extends Command {
@@ -67,17 +70,38 @@ public class DropCommand extends Command {
         })));
 
         // Specific item
-        builder.then(argument("item", ItemStackArgumentType.itemStack(REGISTRY_ACCESS)).executes(context -> drop(player -> {
-            ItemStack stack = ItemStackArgumentType.getItemStackArgument(context, "item").createStack(1, false);
+        builder.then(argument("item", ItemStackArgumentType.itemStack(REGISTRY_ACCESS))
+            .executes(context -> drop(player -> {
+                dropItem(player, context, Integer.MAX_VALUE);
+            }))
+            .then(argument("amount", IntegerArgumentType.integer(1))
+                .executes(context -> drop(player -> {
+                    int amount = IntegerArgumentType.getInteger(context, "amount");
+                    dropItem(player, context, amount);
+                })))
+        );
+    }
 
-            if (stack == null || stack.getItem() == Items.AIR) throw NO_SUCH_ITEM.create();
+    private void dropItem(ClientPlayerEntity player, CommandContext<CommandSource> context, int amount) throws CommandSyntaxException {
+        ItemStack stack = ItemStackArgumentType.getItemStackArgument(context, "item").createStack(1, false);
+        if (stack == null || stack.getItem() == Items.AIR) throw NO_SUCH_ITEM.create();
 
-            for (int i = 0; i < player.getInventory().size(); i++) {
-                if (stack.getItem() == player.getInventory().getStack(i).getItem()) {
-                    InvUtils.drop().slot(i);
+        for (int i = 0; i < player.getInventory().size() && amount > 0; i++) {
+            ItemStack invStack = player.getInventory().getStack(i);
+            if (invStack.isEmpty() || stack.getItem() != invStack.getItem()) continue;
+
+            int dropCount = Math.min(amount, invStack.getCount());
+
+            if (dropCount == invStack.getCount()) {
+                InvUtils.drop().slot(i);
+            } else {
+                for (int j = 0; j < dropCount; j++) {
+                    InvUtils.dropOne().slot(i);
                 }
             }
-        })));
+
+            amount -= dropCount;
+        }
     }
 
     private int drop(PlayerConsumer consumer) throws CommandSyntaxException {

--- a/src/main/java/meteordevelopment/meteorclient/utils/player/InvUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/InvUtils.java
@@ -207,6 +207,12 @@ public class InvUtils {
         return ACTION;
     }
 
+    public static Action dropOne() {
+        ACTION.type = SlotActionType.THROW;
+        ACTION.data = 0;
+        return ACTION;
+    }
+
     public static void dropHand() {
         if (!mc.player.currentScreenHandler.getCursorStack().isEmpty()) mc.interactionManager.clickSlot(mc.player.currentScreenHandler.syncId, ScreenHandler.EMPTY_SPACE_SLOT_INDEX, 0, SlotActionType.PICKUP, mc.player);
     }


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

The `DropCommand` now supports an optional amount argument, allowing players to drop a specific number of items instead of entire stacks. The dropping logic was refactored into a dedicated `dropItem` method for cleaner structure, and `InvUtils` gained a `dropOne` helper to handle single-item drops.

## Related issues

Closes #4222 

# How Has This Been Tested?

https://github.com/user-attachments/assets/b53904ac-6b09-45a5-8df8-c4dfbdcbff72

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
