### PR TITLE
Improve .macro functionality, allowing recursive macros etc

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/commands/arguments/MacroArgumentType.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/arguments/MacroArgumentType.java
@@ -46,7 +46,14 @@ public class MacroArgumentType implements ArgumentType<Macro> {
 
     @Override
     public CompletableFuture<Suggestions> listSuggestions(CommandContext context, SuggestionsBuilder builder) {
-        return CommandSource.suggestMatching(Macros.get().getAll().stream().map(macro -> macro.name.get()), builder);
+        return CommandSource.suggestMatching(Macros.get().getAll().stream().map(macro -> {
+            String name = macro.name.get();
+            if (name.contains(" ")) {
+                name = "\"" + name.replace("\"", "\\\"") + "\"";
+            }
+
+            return name;
+        }), builder);
     }
 
     @Override

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/MacroCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/MacroCommand.java
@@ -49,9 +49,9 @@ public class MacroCommand extends Command {
                         Macro macro = MacroArgumentType.get(context);
 
                         if (!isScheduled(macro)) {
-                            error("This module is not currently scheduled.");
+                            error("This macro is not currently scheduled.");
                             return SINGLE_SUCCESS;
-                        };
+                        }
 
                         clear(macro);
                         info("Cleared scheduled macro.");
@@ -116,8 +116,7 @@ class ScheduledMacro {
     public int delay;
     public Macro macro;
 
-
-    public ScheduledMacro (int tickDelay, Macro scheduledMacro) {
+    public ScheduledMacro(int tickDelay, Macro scheduledMacro) {
         delay = tickDelay;
         macro = scheduledMacro;
     }
@@ -127,14 +126,14 @@ class ScheduledMacro {
     }
 
     public boolean run() {
-        if (delay > 0) { return false; }
+        if (delay > 0) return false;
 
         runMacro();
         return true;
     }
 
     private void runMacro() {
-        if (MeteorClient.mc.player == null) { return; }
+        if (MeteorClient.mc.player == null) return;
 
         macro.onAction();
     }

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/MacroCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/MacroCommand.java
@@ -5,23 +5,132 @@
 
 package meteordevelopment.meteorclient.commands.commands;
 
+import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.commands.Command;
 import meteordevelopment.meteorclient.commands.arguments.MacroArgumentType;
+import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.systems.macros.Macro;
+import meteordevelopment.orbit.EventHandler;
 import net.minecraft.command.CommandSource;
+import net.minecraft.command.argument.TimeArgumentType;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class MacroCommand extends Command {
     public MacroCommand() {
         super("macro", "Allows you to execute macros.");
+
+        MeteorClient.EVENT_BUS.subscribe(this);
     }
+
+    List<ScheduledMacro> scheduleQueue = new ArrayList<>();
+    List<ScheduledMacro> scheduledMacros = new ArrayList<>();
 
     @Override
     public void build(LiteralArgumentBuilder<CommandSource> builder) {
-        builder.then(argument("macro", MacroArgumentType.create()).executes(context -> {
-            Macro macro = MacroArgumentType.get(context);
-            macro.onAction();
-            return SINGLE_SUCCESS;
-        }));
+        builder
+            .then(literal("clear")
+                .executes(context -> {
+                    if (scheduleQueue.isEmpty() && scheduledMacros.isEmpty()) {
+                        error("No macros are currently scheduled.");
+                        return SINGLE_SUCCESS;
+                    }
+
+                    clearAll();
+                    info("Cleared all scheduled macros.");
+
+                    return SINGLE_SUCCESS;
+                })
+            )
+            .then(argument("macro", MacroArgumentType.create())
+                .executes(context -> {
+                    Macro macro = MacroArgumentType.get(context);
+                    scheduleQueue.add(new ScheduledMacro(1, macro));
+
+                    return SINGLE_SUCCESS;
+                })
+                .then(literal("clear")
+                    .executes(context -> {
+                        Macro macro = MacroArgumentType.get(context);
+
+                        if (!isScheduled(macro)) {
+                            error("This module is not currently scheduled.");
+                            return SINGLE_SUCCESS;
+                        };
+
+                        clear(macro);
+                        info("Cleared scheduled macro.");
+                        return SINGLE_SUCCESS;
+                    })
+                )
+                .then(argument("delay", TimeArgumentType.time(1))
+                    .executes(context -> {
+                        Macro macro = MacroArgumentType.get(context);
+                        scheduleQueue.add(new ScheduledMacro(IntegerArgumentType.getInteger(context, "delay"), macro));
+
+                        return SINGLE_SUCCESS;
+                    })
+                )
+            )
+        ;
+    }
+
+    public void clearAll() {
+        scheduleQueue.clear();
+        scheduledMacros.clear();
+    }
+
+    public boolean isScheduled(Macro macro) {
+        return scheduleQueue.stream().anyMatch(element -> element.macro == macro) ||
+            scheduledMacros.stream().noneMatch(element -> element.macro == macro);
+    }
+
+    public void clear(Macro macro) {
+        scheduleQueue.removeIf(scheduledMacro -> scheduledMacro.macro == macro);
+        scheduledMacros.removeIf(scheduledMacro -> scheduledMacro.macro == macro);
+    }
+
+    @EventHandler
+    private void onTick(TickEvent.Pre event) {
+        if (!scheduleQueue.isEmpty()) {
+            scheduledMacros.addAll(scheduleQueue);
+            scheduleQueue.clear();
+        }
+
+        if (!scheduledMacros.isEmpty()) {
+            tickMacros();
+        }
+    }
+
+    private void tickMacros() {
+        scheduledMacros.removeIf(ScheduledMacro::tick);
+    }
+}
+
+class ScheduledMacro {
+    public int delay;
+    public Macro macro;
+
+
+    public ScheduledMacro (int tickDelay, Macro scheduledMacro) {
+        delay = tickDelay;
+        macro = scheduledMacro;
+    }
+
+    public boolean tick() {
+       delay--;
+       if (delay > 0) { return false; }
+
+       run();
+       return true;
+    }
+
+    private void run() {
+        if (MeteorClient.mc.player == null) { return; }
+
+        macro.onAction();
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/MacroCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/MacroCommand.java
@@ -44,15 +44,7 @@ public class MacroCommand extends Command {
 
                     return SINGLE_SUCCESS;
                 })
-            )
-            .then(argument("macro", MacroArgumentType.create())
-                .executes(context -> {
-                    Macro macro = MacroArgumentType.get(context);
-                    scheduleQueue.add(new ScheduledMacro(1, macro));
-
-                    return SINGLE_SUCCESS;
-                })
-                .then(literal("clear")
+                .then(argument("macro", MacroArgumentType.create())
                     .executes(context -> {
                         Macro macro = MacroArgumentType.get(context);
 
@@ -66,6 +58,14 @@ public class MacroCommand extends Command {
                         return SINGLE_SUCCESS;
                     })
                 )
+            )
+            .then(argument("macro", MacroArgumentType.create())
+                .executes(context -> {
+                    Macro macro = MacroArgumentType.get(context);
+                    scheduleQueue.add(new ScheduledMacro(1, macro));
+
+                    return SINGLE_SUCCESS;
+                })
                 .then(argument("delay", TimeArgumentType.time(1))
                     .executes(context -> {
                         Macro macro = MacroArgumentType.get(context);
@@ -85,7 +85,7 @@ public class MacroCommand extends Command {
 
     public boolean isScheduled(Macro macro) {
         return scheduleQueue.stream().anyMatch(element -> element.macro == macro) ||
-            scheduledMacros.stream().noneMatch(element -> element.macro == macro);
+            scheduledMacros.stream().anyMatch(element -> element.macro == macro);
     }
 
     public void clear(Macro macro) {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description
Previously, if a macro called itself with .macro, the game would crash. To fix this, I have implemented a scheduling system to the .macro command, allowing it to behave similarly to /schedule.

The command syntax is now as follows:
```
.macro <name>                    - Schedules the macro with 1 tick delay
.macro <name> <time>             - Schedules the macro with <time> delay
.macro clear                     - Clear all scheduled macros
.macro clear <name>              - Clear all scheduled macros named <name>
```

As well, if a macro name has spaces in it, the autocomplete will automatically add quotes to it.

## Related issues
This PR fixes https://github.com/MeteorDevelopment/meteor-client/issues/5207

# How Has This Been Tested?
<img width="438" height="216" alt="image" src="https://github.com/user-attachments/assets/bdef1d84-2414-4c76-a58d-36d5f3e4c24f" />

Rotate 90 degrees every second:
<img width="436" height="300" alt="image" src="https://github.com/user-attachments/assets/66a07002-fec2-4af6-918a-b23cfa8d97d4" />
