### PR TITLE
Allow waypoints to auto hide when a player is close enough

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/WaypointsModule.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/WaypointsModule.java
@@ -105,6 +105,8 @@ public class WaypointsModule extends Module {
             Vector3d pos = new Vector3d(blockPos.getX() + 0.5, blockPos.getY(), blockPos.getZ() + 0.5);
             double dist = PlayerUtils.distanceToCamera(pos.x, pos.y, pos.z);
 
+            waypoint.hideWhenNear((int) Math.floor(dist));
+
             // Continue if this waypoint should not be rendered
             if (dist > waypoint.maxVisible.get()) continue;
             if (!NametagUtils.to2D(pos, waypoint.scale.get() - 0.2)) continue;
@@ -171,6 +173,10 @@ public class WaypointsModule extends Module {
                 .pos(BlockPos.ofFloored(deathPos).up(2))
                 .dimension(PlayerUtils.getDimension())
                 .build();
+
+            // Configure death waypoints to auto hide when the player is within 4 blocks
+            waypoint.hideWhenNear.set(true);
+            waypoint.hideWhenNearDistance.set(4);
 
             Waypoints.get().add(waypoint);
         }

--- a/src/main/java/meteordevelopment/meteorclient/systems/waypoints/Waypoint.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/waypoints/Waypoint.java
@@ -94,6 +94,21 @@ public class Waypoint implements ISerializable<Waypoint> {
         .build()
     );
 
+    public Setting<Boolean> hideWhenNear = sgPosition.add(new BoolSetting.Builder()
+        .name("hide-when-near")
+        .description("Whether to set the waypoint to hidden when the player is near enough.")
+        .defaultValue(false)
+        .build()
+    );
+
+    public Setting<Integer> hideWhenNearDistance = sgPosition.add(new IntSetting.Builder()
+        .name("hide-when-near-distance")
+        .description("Hides the waypoint if the player is closer than this distance, and hide when near is enabled.")
+        .defaultValue(8)
+        .sliderRange(0, 32)
+        .build()
+    );
+
     public final UUID uuid;
 
     private Waypoint() {
@@ -135,6 +150,13 @@ public class Waypoint implements ISerializable<Waypoint> {
             case Nether -> new BlockPos(pos.getX() * 8, pos.getY(), pos.getZ() * 8);
             default -> null;
         };
+    }
+
+    public void hideWhenNear(int distance) {
+        if (!hideWhenNear.get()) { return; }
+        if (distance > hideWhenNearDistance.get()) { return; }
+
+        visible.set(false);
     }
 
     private void validateIcon() {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description
This PR adds functionality to waypoints to allow them to toggle off their visibility once a player is within a particular range of the waypoint. This is useful for creating "temporary" waypoints, that only stay visible whilst the player is travelling to that point, and can automatically turn themselves off once the player has reached the destination.

As well, this PR makes death waypoints automatically hide themselves once the player is within 4 blocks of the waypoint.

# How Has This Been Tested?
<img width="648" height="193" alt="image" src="https://github.com/user-attachments/assets/87370c5d-b9e2-4641-979f-7d07ab970f67" />