### PR TITLE
Add Y component to EntitySpeed for happy ghast

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/EntitySpeed.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/EntitySpeed.java
@@ -60,16 +60,7 @@ public class EntitySpeed extends Module {
 
         // Set velocity
         Vec3d vel = PlayerUtils.getHorizontalVelocity(speed.get());
-
-        // Calculate vertical velocity based on pitch
-        Vec3d forward = Vec3d.fromPolar(mc.player.getPitch(), mc.player.getYaw());
-        double velY = 0;
-        if (mc.player.input.playerInput.forward()) velY += forward.y / 20 * speed.get();
-        if (mc.player.input.playerInput.backward()) velY -= forward.y / 20 * speed.get();
-
-        boolean horizontal = mc.player.input.playerInput.forward() || mc.player.input.playerInput.backward();
-        boolean sideways = mc.player.input.playerInput.left() || mc.player.input.playerInput.right();
-        if (horizontal && sideways) velY *= 1 / Math.sqrt(2);
+        double velY = PlayerUtils.getVerticalVelocity(speed.get());
 
         ((IVec3d) event.movement).meteor$setXZ(vel.x, vel.z);
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/EntitySpeed.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/EntitySpeed.java
@@ -16,6 +16,7 @@ import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.utils.player.PlayerUtils;
 import meteordevelopment.orbit.EventHandler;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.registry.Registries;
 import net.minecraft.util.math.Vec3d;
 
 public class EntitySpeed extends Module {
@@ -23,7 +24,7 @@ public class EntitySpeed extends Module {
 
     private final Setting<Double> speed = sgGeneral.add(new DoubleSetting.Builder()
         .name("speed")
-        .description("Horizontal speed in blocks per second.")
+        .description("Movement speed in blocks per second.")
         .defaultValue(10)
         .min(0)
         .sliderMax(50)
@@ -57,8 +58,23 @@ public class EntitySpeed extends Module {
         if (onlyOnGround.get() && !entity.isOnGround()) return;
         if (!inWater.get() && entity.isTouchingWater()) return;
 
-        // Set horizontal velocity
+        // Set velocity
         Vec3d vel = PlayerUtils.getHorizontalVelocity(speed.get());
+
+        // Calculate vertical velocity based on pitch
+        Vec3d forward = Vec3d.fromPolar(mc.player.getPitch(), mc.player.getYaw());
+        double velY = 0;
+        if (mc.player.input.playerInput.forward()) velY += forward.y / 20 * speed.get();
+        if (mc.player.input.playerInput.backward()) velY -= forward.y / 20 * speed.get();
+
+        boolean horizontal = mc.player.input.playerInput.forward() || mc.player.input.playerInput.backward();
+        boolean sideways = mc.player.input.playerInput.left() || mc.player.input.playerInput.right();
+        if (horizontal && sideways) velY *= 1 / Math.sqrt(2);
+
         ((IVec3d) event.movement).meteor$setXZ(vel.x, vel.z);
+
+        if (Registries.ENTITY_TYPE.getId(entity.getType()).getPath().equals("happy_ghast")) {
+            ((IVec3d) event.movement).meteor$setY(velY);
+        }
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/utils/player/PlayerUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/PlayerUtils.java
@@ -104,6 +104,27 @@ public class PlayerUtils {
         return horizontalVelocity;
     }
 
+    public static double getVerticalVelocity(double bps) {
+        Vec3d forward = Vec3d.fromPolar(mc.player.getPitch(), mc.player.getYaw());
+        double velY = 0;
+
+        boolean a = false;
+        if (mc.player.input.playerInput.forward()) {
+            velY += forward.y / 20 * bps;
+            a = true;
+        }
+        if (mc.player.input.playerInput.backward()) {
+            velY -= forward.y / 20 * bps;
+            a = true;
+        }
+
+        if (a && (mc.player.input.playerInput.left() || mc.player.input.playerInput.right())) {
+            velY *= diagonal;
+        }
+
+        return velY;
+    }
+
     public static void centerPlayer() {
         double x = MathHelper.floor(mc.player.getX()) + 0.5;
         double z = MathHelper.floor(mc.player.getZ()) + 0.5;


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

The new [Happy Ghast](https://minecraft.wiki/w/Happy_Ghast) mob is ridable. Entity speed worked, but only the x and z component. With the happy ghast looking up and down will result in ascending or descending. This PR is to apply the entity speed to the y component

## Related issues

[Mention any issues that this pr relates to.](https://github.com/MeteorDevelopment/meteor-client/issues/5662)

# How Has This Been Tested?
Before:
https://github.com/user-attachments/assets/ab5213ba-9065-45b5-adc2-857cf605a5ca
After
https://github.com/user-attachments/assets/5b8ea201-12a2-4400-a726-9e47b00f67b2
# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
