### PR TITLE
Add killaura exception for non-attacking piglins

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/KillAura.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/KillAura.java
@@ -28,6 +28,7 @@ import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.Tameable;
 import net.minecraft.entity.mob.EndermanEntity;
+import net.minecraft.entity.mob.PiglinEntity;
 import net.minecraft.entity.mob.ZombifiedPiglinEntity;
 import net.minecraft.entity.passive.AnimalEntity;
 import net.minecraft.entity.passive.WolfEntity;
@@ -402,7 +403,8 @@ public class KillAura extends Module {
         }
         if (ignorePassive.get()) {
             if (entity instanceof EndermanEntity enderman && !enderman.isAngry()) return false;
-            if (entity instanceof ZombifiedPiglinEntity piglin && !piglin.isAttacking()) return false;
+            if (entity instanceof PiglinEntity piglin && !piglin.isAttacking()) return false;
+            if (entity instanceof ZombifiedPiglinEntity zombified_piglin && !zombified_piglin.isAttacking()) return false;
             if (entity instanceof WolfEntity wolf && !wolf.isAttacking()) return false;
         }
         if (entity instanceof PlayerEntity player) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/KillAura.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/KillAura.java
@@ -404,7 +404,7 @@ public class KillAura extends Module {
         if (ignorePassive.get()) {
             if (entity instanceof EndermanEntity enderman && !enderman.isAngry()) return false;
             if (entity instanceof PiglinEntity piglin && !piglin.isAttacking()) return false;
-            if (entity instanceof ZombifiedPiglinEntity zombified_piglin && !zombified_piglin.isAttacking()) return false;
+            if (entity instanceof ZombifiedPiglinEntity zombifiedPiglin && !zombifiedPiglin.isAttacking()) return false;
             if (entity instanceof WolfEntity wolf && !wolf.isAttacking()) return false;
         }
         if (entity instanceof PlayerEntity player) {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

This PR fixes an issue when a killaura with Ignore Passive enabled always attacks any piglin regardless if the piglin is aggressive or not. Killaura with Ignore Passive enabled now no longer attacks any piglins that is not in the attacking state, even if the piglin is in bartering state while still aggressive.
Zombified piglin killaura behavior is not affected.

## Related issues

https://github.com/MeteorDevelopment/meteor-client/issues/5481

# How Has This Been Tested?
Previously the kill aura with Ignore Passive enabled always attacks the piglins regardless of the piglin being aggressive or not. This proof of functionality video proves that the issue has been fixed after using a compiled build with the fix applied.

[piglintestkillaura.webm](https://github.com/user-attachments/assets/e9917fab-210b-4b31-8840-08b512c324d7)

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
