### PR TITLE
More tweaks in Entity Speed for happy ghast

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/EntitySpeed.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/EntitySpeed.java
@@ -43,7 +43,7 @@ public class EntitySpeed extends Module {
 
     private final Setting<Boolean> onlyOnGround = sgGeneral.add(new BoolSetting.Builder()
         .name("only-on-ground")
-        .description("Use speed only when standing on a block.")
+        .description("Use speed only when standing on a block. (excludes happy ghast)")
         .defaultValue(false)
         .build()
     );


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Separate happy ghast's vertical speed setting.
Bypass onlyOnGround rule for happy ghast.

## Related issues

https://github.com/MeteorDevelopment/meteor-client/issues/5662

# How Has This Been Tested?

<img width="611" height="444" alt="Snipaste_2025-09-01_11-57-44" src="https://github.com/user-attachments/assets/4888f849-9612-40b6-8007-962a2f57f215" />

<img width="1243" height="860" alt="Snipaste_2025-09-01_12-00-03" src="https://github.com/user-attachments/assets/729287c5-5852-4106-b43e-e867c7405bf8" />

<img width="1174" height="888" alt="Snipaste_2025-09-01_12-00-34" src="https://github.com/user-attachments/assets/90cd5cc8-b6d1-4185-8f42-f81406f4f99a" />


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
