### PR TITLE
add registry support for commands

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/commands/Command.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/Command.java
@@ -23,7 +23,7 @@ import net.minecraft.text.Text;
 import java.util.List;
 
 public abstract class Command {
-    protected static final CommandRegistryAccess REGISTRY_ACCESS = CommandManager.createRegistryAccess(BuiltinRegistries.createWrapperLookup());
+    protected static CommandRegistryAccess REGISTRY_ACCESS = CommandManager.createRegistryAccess(BuiltinRegistries.createWrapperLookup());
     protected static final int SINGLE_SUCCESS = com.mojang.brigadier.Command.SINGLE_SUCCESS;
     protected static final MinecraftClient mc = MeteorClient.mc;
 

--- a/src/main/java/meteordevelopment/meteorclient/commands/Commands.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/Commands.java
@@ -7,9 +7,14 @@ package meteordevelopment.meteorclient.commands;
 
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.commands.commands.*;
+import meteordevelopment.meteorclient.events.game.GameJoinedEvent;
 import meteordevelopment.meteorclient.pathing.PathManagers;
 import meteordevelopment.meteorclient.utils.PostInit;
+import meteordevelopment.orbit.EventHandler;
+import net.minecraft.client.network.ClientPlayNetworkHandler;
+import net.minecraft.command.CommandRegistryAccess;
 import net.minecraft.command.CommandSource;
 
 import java.util.ArrayList;
@@ -19,8 +24,8 @@ import java.util.List;
 import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class Commands {
-    public static final CommandDispatcher<CommandSource> DISPATCHER = new CommandDispatcher<>();
     public static final List<Command> COMMANDS = new ArrayList<>();
+    public static CommandDispatcher<CommandSource> DISPATCHER = new CommandDispatcher<>();
 
     @PostInit(dependencies = PathManagers.class)
     public static void init() {
@@ -64,11 +69,12 @@ public class Commands {
         add(new LocateCommand());
 
         COMMANDS.sort(Comparator.comparing(Command::getName));
+
+        MeteorClient.EVENT_BUS.subscribe(Commands.class);
     }
 
     public static void add(Command command) {
         COMMANDS.removeIf(existing -> existing.getName().equals(command.getName()));
-        command.registerTo(DISPATCHER);
         COMMANDS.add(command);
     }
 
@@ -84,5 +90,33 @@ public class Commands {
         }
 
         return null;
+    }
+
+    /**
+     * Argument types that rely on Minecraft registries access those registries through a {@link CommandRegistryAccess}
+     * object. Since dynamic registries are specific to each server, we need to make a new CommandRegistryAccess object
+     * every time we join a server.
+     * <p>
+     * The command tree and by extension the {@link CommandDispatcher} also have to be rebuilt because:
+     * <ol>
+     * <li>Argument types that require registries use a registry wrapper object that is created and stored in the
+     *     argument type objects when the command tree is built.
+     * <li>Registry entries and keys are compared using referential equality. Even if the data encoded is the same,
+     *     registry wrapper objects' dynamic data becomes stale after joining another server.
+     * <li>The CommandDispatcher's node merging only adds missing children, it cannot replace stale argument type
+     *     objects.
+     * </ol>
+     *
+     * @author Crosby
+     */
+    @EventHandler
+    private static void onJoin(GameJoinedEvent event) {
+        ClientPlayNetworkHandler networkHandler = mc.getNetworkHandler();
+        Command.REGISTRY_ACCESS = CommandRegistryAccess.of(networkHandler.getRegistryManager(), networkHandler.getEnabledFeatures());
+
+        DISPATCHER = new CommandDispatcher<>();
+        for (Command command : COMMANDS) {
+            command.registerTo(DISPATCHER);
+        }
     }
 }


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature

## Description

allows using argument types that reference registries in commands

## Related pull requests

#5036 

# How Has This Been Tested?

the J

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
