### PR TITLE
respect pattern/color of fishes and axolotls while rendering

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BetterTooltips.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BetterTooltips.java
@@ -322,6 +322,7 @@ public class BetterTooltips extends Module {
                     return;
                 }
 
+                entity.copyComponentsFrom(event.itemStack);
                 ((Bucketable) entity).copyDataFromNbt(nbtComponent.copyNbt());
                 ((EntityAccessor) entity).meteor$setInWater(true);
                 event.tooltipData = new EntityTooltipComponent(entity);


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [x] New feature

## Description
Better Tooltips module doesn't respect pattern and color of tropical fishes and axolotls while rendering entities in buckets.

## Related issues
Fixes #5717 

# How Has This Been Tested?
<img width="367" height="344" alt="image" src="https://github.com/user-attachments/assets/5115de57-4715-45e7-9c63-80f5250e2c10" />
<img width="432" height="337" alt="image" src="https://github.com/user-attachments/assets/0d6aa129-ca93-43d7-bf8e-201f8404859a" />
<img width="379" height="346" alt="image" src="https://github.com/user-attachments/assets/11ae445f-161c-4437-b34b-f57db400628d" />
<img width="413" height="350" alt="image" src="https://github.com/user-attachments/assets/8fbed264-6d97-4284-bc58-039e7a7fa987" />

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
