### PR TITLE
Added prefer enchanted setting to Chest Swap

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/ChestSwap.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/ChestSwap.java
@@ -14,11 +14,15 @@ import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.utils.player.InvUtils;
 import net.minecraft.component.DataComponentTypes;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.Enchantments;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.network.packet.c2s.play.CloseHandledScreenC2SPacket;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.entry.RegistryEntry;
 
 public class ChestSwap extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
@@ -27,6 +31,13 @@ public class ChestSwap extends Module {
         .name("chestplate")
         .description("Which type of chestplate to swap to.")
         .defaultValue(Chestplate.PreferNetherite)
+        .build()
+    );
+
+    private final Setting<Boolean> preferEnchanted = sgGeneral.add(new BoolSetting.Builder()
+        .name("prefer-enchanted")
+        .description("Prefers enchanted equipment when swapping")
+        .defaultValue(false)
         .build()
     );
 
@@ -72,44 +83,72 @@ public class ChestSwap extends Module {
     }
 
     private boolean equipChestplate() {
+        assert mc.player != null;
         int bestSlot = -1;
-        boolean breakLoop = false;
+        int bestScore = -1;
+        boolean foundPreferred = false;
 
         for (int i = 0; i < mc.player.getInventory().getMainStacks().size(); i++) {
-            Item item = mc.player.getInventory().getMainStacks().get(i).getItem();
+            ItemStack itemStack = mc.player.getInventory().getMainStacks().get(i);
+            Item item = itemStack.getItem();
 
-            switch (chestplate.get()) {
-                case Diamond:
-                    if (item == Items.DIAMOND_CHESTPLATE) {
-                        bestSlot = i;
-                        breakLoop = true;
-                    }
-                    break;
-                case Netherite:
-                    if (item == Items.NETHERITE_CHESTPLATE) {
-                        bestSlot = i;
-                        breakLoop = true;
-                    }
-                    break;
-                case PreferDiamond:
-                    if (item == Items.DIAMOND_CHESTPLATE) {
-                        bestSlot = i;
-                        breakLoop = true;
-                    } else if (item == Items.NETHERITE_CHESTPLATE) {
-                        bestSlot = i;
-                    }
-                    break;
-                case PreferNetherite:
-                    if (item == Items.DIAMOND_CHESTPLATE) {
-                        bestSlot = i;
-                    } else if (item == Items.NETHERITE_CHESTPLATE) {
-                        bestSlot = i;
-                        breakLoop = true;
-                    }
-                    break;
+            if (!(item == Items.DIAMOND_CHESTPLATE || item == Items.NETHERITE_CHESTPLATE)) continue;
+
+            if (!preferEnchanted.get()) {
+                switch (chestplate.get()) {
+                    case Diamond:
+                        if (item == Items.DIAMOND_CHESTPLATE) {
+                            equip(i);
+                            return true;
+                        }
+                        break;
+                    case Netherite:
+                        if (item == Items.NETHERITE_CHESTPLATE) {
+                            equip(i);
+                            return true;
+                        }
+                        break;
+                    case PreferDiamond:
+                        if (item == Items.DIAMOND_CHESTPLATE) {
+                            equip(i);
+                            return true;
+                        } else if (bestSlot == -1) {
+                            bestSlot = i;
+                        }
+                        break;
+                    case PreferNetherite:
+                        if (item == Items.NETHERITE_CHESTPLATE) {
+                            equip(i);
+                            return true;
+                        } else if (bestSlot == -1) {
+                            bestSlot = i;
+                        }
+                        break;
+                }
+                continue;
             }
 
-            if (breakLoop) break;
+            boolean isPreferred =
+                (chestplate.get() == Chestplate.Diamond && item == Items.DIAMOND_CHESTPLATE) ||
+                    (chestplate.get() == Chestplate.Netherite && item == Items.NETHERITE_CHESTPLATE) ||
+                    (chestplate.get() == Chestplate.PreferDiamond && item == Items.DIAMOND_CHESTPLATE) ||
+                    (chestplate.get() == Chestplate.PreferNetherite && item == Items.NETHERITE_CHESTPLATE);
+
+            int score = rateArmorEnchantments(itemStack);
+
+            if (isPreferred) {
+                // If there is a preferred chestplate ignore all not preferred chesplates
+                if (!foundPreferred || score > bestScore) {
+                    bestScore = score;
+                    bestSlot = i;
+                    foundPreferred = true;
+                }
+            } else if (!foundPreferred) {
+                if (score > bestScore) {
+                    bestScore = score;
+                    bestSlot = i;
+                }
+            }
         }
 
         if (bestSlot != -1) equip(bestSlot);
@@ -117,14 +156,84 @@ public class ChestSwap extends Module {
     }
 
     private void equipElytra() {
+        assert mc.player != null;
+        int bestSlot = -1;
+        int bestScore = -1;
+
         for (int i = 0; i < mc.player.getInventory().getMainStacks().size(); i++) {
             ItemStack item = mc.player.getInventory().getMainStacks().get(i);
 
-            if (item.contains(DataComponentTypes.GLIDER)) {
-                equip(i);
+            if (!item.contains(DataComponentTypes.GLIDER)) {
+                continue;
+            }
+
+            if (!preferEnchanted.get()) {
+                bestSlot = i;
                 break;
             }
+
+            int score = rateElytraEnchantments(item);
+
+            if (score >= bestScore) {
+                bestSlot = i;
+                bestScore = score;
+            }
         }
+
+        if (bestSlot != -1) {
+            equip(bestSlot);
+        }
+    }
+
+    // 2 points for mending, 1 points for each level of unbreaking and any protection enchant
+    private int rateArmorEnchantments(ItemStack item) {
+        int score = 0;
+
+        if (getEnchantmentLevel(item, Enchantments.MENDING) > 0) {
+            score += 2;
+        }
+
+        score += getEnchantmentLevel(item, Enchantments.UNBREAKING);
+
+        int prot = getEnchantmentLevel(item, Enchantments.PROTECTION);
+
+        if (prot == 0) {
+            prot = getEnchantmentLevel(item, Enchantments.BLAST_PROTECTION);
+        }
+
+        if (prot == 0) {
+            prot = getEnchantmentLevel(item, Enchantments.FIRE_PROTECTION);
+        }
+
+        if (prot == 0) {
+            prot = getEnchantmentLevel(item, Enchantments.PROJECTILE_PROTECTION);
+        }
+
+        score += prot;
+
+        return score;
+    }
+
+    // 2 points for mending, 1 point for each level of unbreaking
+    private int rateElytraEnchantments(ItemStack stack) {
+        int score = 0;
+
+        if (getEnchantmentLevel(stack, Enchantments.MENDING) > 0) {
+            score += 2;
+        }
+
+        score += getEnchantmentLevel(stack, Enchantments.UNBREAKING);
+
+        return score;
+    }
+
+    public static int getEnchantmentLevel(ItemStack stack, RegistryKey<Enchantment> enchantment) {
+        for (RegistryEntry<Enchantment> enchantments : stack.getEnchantments().getEnchantments()) {
+            if (enchantments.toString().contains(enchantment.getValue().toString())) {
+                return stack.getEnchantments().getLevel(enchantments);
+            }
+        }
+        return 0;
     }
 
     private void equip(int slot) {


### PR DESCRIPTION
will try to find the elytra/chestplate with the best enchantments when swapping

## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Added a setting to chestswap that will switch to the Elytra/Chestplate with the best enchantments.

# How Has This Been Tested?

I tested this with a variety of chestplates and elytra with various enchantments and it works as intended.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
