### PR TITLE
use uuids for lookup and update usernames

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/FriendsTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/FriendsTab.java
@@ -80,7 +80,6 @@ public class FriendsTab extends Tab {
                 MeteorExecutor.execute(() -> {
                     if (friend.headTextureNeedsUpdate()) {
                         friend.updateInfo();
-                        reload();
                     }
                 })
             );

--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/FriendsTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/FriendsTab.java
@@ -20,6 +20,8 @@ import meteordevelopment.meteorclient.utils.misc.NbtUtils;
 import meteordevelopment.meteorclient.utils.network.MeteorExecutor;
 import net.minecraft.client.gui.screen.Screen;
 
+import static meteordevelopment.meteorclient.MeteorClient.mc;
+
 public class FriendsTab extends Tab {
     public FriendsTab() {
         super("Friends");
@@ -64,7 +66,7 @@ public class FriendsTab extends Tab {
 
                     MeteorExecutor.execute(() -> {
                         friend.updateInfo();
-                        reload();
+                        mc.execute(this::reload);
                     });
                 }
             };

--- a/src/main/java/meteordevelopment/meteorclient/systems/config/Config.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/config/Config.java
@@ -159,13 +159,6 @@ public class Config extends System<Config> {
         .build()
     );
 
-    public final Setting<Boolean> useUUIDsForLookup = sgMisc.add(new BoolSetting.Builder()
-        .name("use-uuids-to-lookup")
-        .description("Uses UUIDs to lookup for friends when available.")
-        .defaultValue(true)
-        .build()
-    );
-
     public List<String> dontShowAgainPrompts = new ArrayList<>();
 
     public Config() {

--- a/src/main/java/meteordevelopment/meteorclient/systems/config/Config.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/config/Config.java
@@ -159,6 +159,13 @@ public class Config extends System<Config> {
         .build()
     );
 
+    public final Setting<Boolean> useUUIDsForLookup = sgMisc.add(new BoolSetting.Builder()
+        .name("use-uuids-to-lookup")
+        .description("Uses UUIDs to lookup for friends when available.")
+        .defaultValue(true)
+        .build()
+    );
+
     public List<String> dontShowAgainPrompts = new ArrayList<>();
 
     public Config() {

--- a/src/main/java/meteordevelopment/meteorclient/systems/friends/Friend.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/friends/Friend.java
@@ -6,7 +6,6 @@
 package meteordevelopment.meteorclient.systems.friends;
 
 import com.mojang.util.UndashedUuid;
-import meteordevelopment.meteorclient.systems.config.Config;
 import meteordevelopment.meteorclient.utils.misc.ISerializable;
 import meteordevelopment.meteorclient.utils.network.Http;
 import meteordevelopment.meteorclient.utils.render.PlayerHeadTexture;
@@ -53,8 +52,7 @@ public class Friend implements ISerializable<Friend>, Comparable<Friend> {
 
         APIResponse res = null;
 
-        // Prefer UUID-based lookup when configured and UUID is known
-        if (Config.get().useUUIDsForLookup.get() && id != null) {
+        if (id != null) {
             res = Http.get("https://sessionserver.mojang.com/session/minecraft/profile/" + UndashedUuid.toString(id)).sendJson(APIResponse.class);
         }
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/friends/Friend.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/friends/Friend.java
@@ -6,7 +6,9 @@
 package meteordevelopment.meteorclient.systems.friends;
 
 import com.mojang.util.UndashedUuid;
+import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.utils.misc.ISerializable;
+import meteordevelopment.meteorclient.utils.network.FailedHttpResponse;
 import meteordevelopment.meteorclient.utils.network.Http;
 import meteordevelopment.meteorclient.utils.render.PlayerHeadTexture;
 import meteordevelopment.meteorclient.utils.render.PlayerHeadUtils;
@@ -15,6 +17,7 @@ import net.minecraft.nbt.NbtCompound;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
+import java.net.http.HttpResponse;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -49,22 +52,30 @@ public class Friend implements ISerializable<Friend>, Comparable<Friend> {
 
     public void updateInfo() {
         updating = true;
-
-        APIResponse res = null;
+        HttpResponse<APIResponse> res = null;
 
         if (id != null) {
-            res = Http.get("https://sessionserver.mojang.com/session/minecraft/profile/" + UndashedUuid.toString(id)).sendJson(APIResponse.class);
+            res = Http.get("https://sessionserver.mojang.com/session/minecraft/profile/" + UndashedUuid.toString(id))
+                .exceptionHandler(e -> MeteorClient.LOG.error("Error while trying to connect session server for friend '{}'", name))
+                .sendJsonResponse(APIResponse.class);
         }
 
         // Fallback to name-based lookup
-        if (res == null || res.name == null || res.id == null) {
-            res = Http.get("https://api.mojang.com/users/profiles/minecraft/" + name).sendJson(APIResponse.class);
+        if (res == null || res.statusCode() != 200) {
+            res = Http.get("https://api.mojang.com/users/profiles/minecraft/" + name)
+                .exceptionHandler(e -> MeteorClient.LOG.error("Error while trying to update info for friend '{}'", name))
+                .sendJsonResponse(APIResponse.class);
         }
 
-        if (res != null && res.name != null && res.id != null) {
-            name = res.name;
-            id = UndashedUuid.fromStringLenient(res.id);
+        if (res != null && res.statusCode() == 200) {
+            name = res.body().name;
+            id = UndashedUuid.fromStringLenient(res.body().id);
             mc.execute(() -> headTexture = PlayerHeadUtils.fetchHead(id));
+        }
+
+        // cracked accounts shouldn't be assigned ids
+        else if (!(res instanceof FailedHttpResponse)) {
+            id = null;
         }
 
         updating = false;
@@ -104,7 +115,7 @@ public class Friend implements ISerializable<Friend>, Comparable<Friend> {
 
     @Override
     public int compareTo(@NotNull Friend friend) {
-        return name.compareTo(friend.name);
+        return name.compareToIgnoreCase(friend.name);
     }
 
     private static class APIResponse {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [x] New feature

## Description
Uses UUIDs instead of usernames for friends info update/lookup 

Configuration to keep username lookup kept for offline mode environments

## Related issues
#5687 

# How Has This Been Tested?
https://youtu.be/gQRDZIzlGQs

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
