### PR TITLE
Make onRender2D protected for better module extensibility

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Nametags.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Nametags.java
@@ -342,7 +342,7 @@ public class Nametags extends Module {
     }
 
     @EventHandler
-    private void onRender2D(Render2DEvent event) {
+    protected void onRender2D(Render2DEvent event) {
         int count = getRenderCount();
         boolean shadow = Config.get().customFont.get();
 


### PR DESCRIPTION
### Summary
This PR changes `onRender2D` in `Nametags.java` from `private` to `protected`.  
No functionality has been changed.

### Why
Making `onRender2D` protected allows addon developers to extend or customize the rendering logic of nametags without copying the entire class.  
Internal helper methods remain private, keeping encapsulation safe and minimizing maintenance risks.