### PR TITLE
Replace Shadow JAR with proper JiJ implementation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     id("fabric-loom") version "1.11-SNAPSHOT"
     id("maven-publish")
-    id("com.gradleup.shadow") version "9.2.2"
 }
 
 base {
@@ -50,7 +49,7 @@ repositories {
 }
 
 val modInclude: Configuration by configurations.creating
-val library: Configuration by configurations.creating
+val jij: Configuration by configurations.creating
 
 configurations {
     // include mods
@@ -61,12 +60,12 @@ configurations {
         extendsFrom(modInclude)
     }
 
-    // include libraries
+    // include libraries (jar-in-jar)
     implementation.configure {
-        extendsFrom(library)
+        extendsFrom(jij)
     }
-    shadow.configure {
-        extendsFrom(library)
+    include.configure {
+        extendsFrom(jij)
     }
 }
 
@@ -93,16 +92,35 @@ dependencies {
     modCompileOnly("com.terraformersmc:modmenu:${properties["modmenu_version"] as String}")
 
     // Libraries
-    library("meteordevelopment:orbit:${properties["orbit_version"] as String}")
-    library("org.meteordev:starscript:${properties["starscript_version"] as String}")
-    library("meteordevelopment:discord-ipc:${properties["discordipc_version"] as String}")
-    library("org.reflections:reflections:${properties["reflections_version"] as String}")
-    library("io.netty:netty-handler-proxy:${properties["netty_version"] as String}") { isTransitive = false }
-    library("io.netty:netty-codec-socks:${properties["netty_version"] as String}") { isTransitive = false }
-    library("de.florianmichael:WaybackAuthLib:${properties["waybackauthlib_version"] as String}")
+    jij("meteordevelopment:orbit:${properties["orbit_version"] as String}")
+    jij("org.meteordev:starscript:${properties["starscript_version"] as String}")
+    jij("meteordevelopment:discord-ipc:${properties["discordipc_version"] as String}")
+    jij("org.reflections:reflections:${properties["reflections_version"] as String}")
+    jij("io.netty:netty-handler-proxy:${properties["netty_version"] as String}") { isTransitive = false }
+    jij("io.netty:netty-codec-socks:${properties["netty_version"] as String}") { isTransitive = false }
+    jij("de.florianmichael:WaybackAuthLib:${properties["waybackauthlib_version"] as String}")
+}
 
-    // Launch sub project
-    shadow(project(":launch"))
+// Handle transitive dependencies for jar-in-jar
+// Based on implementation from BaseProject by FlorianMichael/EnZaXD
+// Source: https://github.com/FlorianMichael/BaseProject/blob/main/src/main/kotlin/de/florianmichael/baseproject/Fabric.kt
+// Licensed under Apache License 2.0
+afterEvaluate {
+    val jijConfig = configurations.findByName("jij") ?: return@afterEvaluate
+
+    jijConfig.incoming.resolutionResult.allDependencies.forEach { dep ->
+        val requested = dep.requested.displayName
+
+        val compileOnlyDep = dependencies.create(requested) {
+            isTransitive = false
+        }
+
+        val implDep = dependencies.create(compileOnlyDep)
+
+        dependencies.add("compileOnlyApi", compileOnlyDep)
+        dependencies.add("implementation", implDep)
+        dependencies.add("include", compileOnlyDep)
+    }
 }
 
 loom {
@@ -141,6 +159,10 @@ tasks {
             rename { "${it}_${inputs.properties["archivesName"]}" }
         }
 
+        // Launch sub project
+        dependsOn(":launch:compileJava")
+        from(project(":launch").layout.buildDirectory.dir("classes/java/main"))
+
         manifest {
             attributes["Main-Class"] = "meteordevelopment.meteorclient.Main"
         }
@@ -160,27 +182,6 @@ tasks {
         options.release = 21
         options.compilerArgs.add("-Xlint:deprecation")
         options.compilerArgs.add("-Xlint:unchecked")
-    }
-
-    shadowJar {
-        configurations = listOf(project.configurations.shadow.get())
-
-        inputs.property("archivesName", project.base.archivesName.get())
-
-        from("LICENSE") {
-            rename { "${it}_${inputs.properties["archivesName"]}" }
-        }
-
-        dependencies {
-            exclude {
-                it.moduleGroup == "org.slf4j"
-            }
-        }
-    }
-
-    remapJar {
-        dependsOn(shadowJar)
-        inputFile.set(shadowJar.get().archiveFile)
     }
 
     javadoc {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Replace Shadow JAR with proper JiJ implementation.
This is a rewrite of the now closed #5330 PR, updated to the new 1.21.9 branch.
The implementation relies on [this](https://github.com/FlorianMichael/BaseProject/blob/main/src/main/kotlin/de/florianmichael/baseproject/Fabric.kt) source for its transitive dependency handling.

## Related issues

None.

# How Has This Been Tested?

Tested by loading the produced JAR in a fresh Fabric instance via PrismLauncher.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
