### PR TITLE
Add precise mining direction and swing mode options

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/utils/world/BlockUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/world/BlockUtils.java
@@ -358,7 +358,7 @@ public class BlockUtils {
     }
 
     private static Direction getDirectionFromPlayerFacing(BlockPos pos) {
-         Vec3d eyesPos = new Vec3d(mc.player.getX(), mc.player.getY() + mc.player.getEyeHeight(mc.player.getPose()), mc.player.getZ());
+        Vec3d eyesPos = new Vec3d(mc.player.getX(), mc.player.getY() + mc.player.getEyeHeight(mc.player.getPose()), mc.player.getZ());
         if ((double) pos.getY() > eyesPos.y) {
             if (mc.world.getBlockState(pos.add(0, -1, 0)).isReplaceable()) return Direction.DOWN;
             else return mc.player.getHorizontalFacing().getOpposite();


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description
To meet these requirements:
1. More precise mining surfaces for the block
2. No need to send swing packages

Added new public methods:
```
getDirection(BlockPos pos, BlockDirectionFrom mode) 
breakBlock(BlockPos blockPos, SwingMode swing, BlockDirectionFrom directionMode)
```
With the new enum:
```java
    public enum BlockDirectionFrom {
        PlayerFacing,
        PlayerPosition,
    }

    public enum SwingMode {
        None,
        SendPacket,
        Normal
    }
```

Already tested in addons

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
