### PR TITLE
fix: elytrafly bounce crash

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/modes/Bounce.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/elytrafly/modes/Bounce.java
@@ -9,10 +9,10 @@
 
 package meteordevelopment.meteorclient.systems.modules.movement.elytrafly.modes;
 
+import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.events.packets.PacketEvent;
 import meteordevelopment.meteorclient.systems.modules.movement.elytrafly.ElytraFlightMode;
 import meteordevelopment.meteorclient.systems.modules.movement.elytrafly.ElytraFlightModes;
-import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.entity.EquipmentSlot;
@@ -110,7 +110,7 @@ public class Bounce extends ElytraFlightMode {
         if (!player.isTouchingWater() && !player.hasStatusEffect(StatusEffects.LEVITATION)) {
             ItemStack itemStack = player.getEquippedStack(EquipmentSlot.CHEST);
             if (itemStack.contains(DataComponentTypes.GLIDER) && !itemStack.willBreakNextUse()) {
-                MinecraftClient.getInstance().executeSync(player::startGliding);
+                MeteorClient.mc.executeSync(player::startGliding);
                 return true;
             } else return false;
         } else return false;


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

The `PlayerEntity.startGliding` method is not thread safe. It invokes `ClientPlayerEntity.onTrackedDataSet` that meanwhile adds a sound to sound manager queue causing `ConcurrentModificationException` if executed not on the main thread.

## Related issues

https://github.com/MeteorDevelopment/meteor-client/issues/4389

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
