### PR TITLE
fix: packet sneak and noslow airstrict

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayerEntityMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayerEntityMixin.java
@@ -20,6 +20,7 @@ import net.minecraft.client.input.Input;
 import net.minecraft.client.network.AbstractClientPlayerEntity;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.world.ClientWorld;
+import net.minecraft.util.PlayerInput;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -80,12 +81,21 @@ public abstract class ClientPlayerEntityMixin extends AbstractClientPlayerEntity
         return constant;
     }
 
-    /*
-    @ModifyExpressionValue(method = "sendSneakingPacket", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerEntity;isSneaking()Z"))
-    private boolean isSneaking(boolean sneaking) {
-        return Modules.get().get(Sneak.class).doPacket() || Modules.get().get(NoSlow.class).airStrict() || sneaking;
+    @ModifyExpressionValue(method = "tick", at = @At(value = "FIELD", target = "Lnet/minecraft/client/input/Input;playerInput:Lnet/minecraft/util/PlayerInput;"))
+    private PlayerInput isSneaking(PlayerInput original) {
+        if (Modules.get().get(Sneak.class).doPacket() || Modules.get().get(NoSlow.class).airStrict()) {
+            return new PlayerInput(
+                original.forward(),
+                original.backward(),
+                original.left(),
+                original.right(),
+                original.jump(),
+                true,
+                original.sprint()
+            );
+        }
+        return original;
     }
-     */
 
     @Inject(method = "tickMovement", at = @At("HEAD"))
     private void preTickMovement(CallbackInfo ci) {


### PR DESCRIPTION
## Type of change

- [x] Bug fix

## Description

Fixed Sneak mode packet and NoSlow setting AirStrict not working after 1.21.6 update

## Related issues

closes https://github.com/MeteorDevelopment/meteor-client/issues/5604

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
