### PR TITLE
fix: entity interactions in various modules

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoBreed.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoBreed.java
@@ -16,6 +16,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.passive.AnimalEntity;
 import net.minecraft.util.Hand;
+import net.minecraft.util.hit.EntityHitResult;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -85,6 +86,8 @@ public class AutoBreed extends Module {
                 continue;
 
             Rotations.rotate(Rotations.getYaw(entity), Rotations.getPitch(entity), -100, () -> {
+                EntityHitResult location = new EntityHitResult(animal, animal.getBoundingBox().getCenter());
+                mc.interactionManager.interactEntityAtLocation(mc.player, animal, location, hand.get());
                 mc.interactionManager.interactEntity(mc.player, animal, hand.get());
                 mc.player.swingHand(hand.get());
                 animalsFed.add(animal);

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoMount.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoMount.java
@@ -24,6 +24,7 @@ import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.entity.passive.LlamaEntity;
 import net.minecraft.item.SpawnEggItem;
 import net.minecraft.util.Hand;
+import net.minecraft.util.hit.EntityHitResult;
 
 import java.util.Set;
 
@@ -66,13 +67,22 @@ public class AutoMount extends Module {
             if (!PlayerUtils.isWithin(entity, 4)) continue;
             if ((entity instanceof MobEntity mobEntity) && !(mobEntity.hasSaddleEquipped())) continue;
             if (!(entity instanceof LlamaEntity) && entity instanceof MobEntity mobEntity && checkSaddle.get() && !mobEntity.hasSaddleEquipped()) continue;
-            interact(entity);
+            interact(entity, rotate.get());
             return;
         }
     }
 
+    private void interact(Entity entity, boolean rotate) {
+        if (rotate) {
+            Rotations.rotate(Rotations.getYaw(entity), Rotations.getPitch(entity), -100, () -> interact(entity));
+        } else {
+            interact(entity);
+        }
+    }
+
     private void interact(Entity entity) {
-        if (rotate.get()) Rotations.rotate(Rotations.getYaw(entity), Rotations.getPitch(entity), -100, () -> mc.interactionManager.interactEntity(mc.player, entity, Hand.MAIN_HAND));
-        else mc.interactionManager.interactEntity(mc.player, entity, Hand.MAIN_HAND);
+        EntityHitResult location = new EntityHitResult(entity, entity.getBoundingBox().getCenter());
+        mc.interactionManager.interactEntityAtLocation(mc.player, entity, location, Hand.MAIN_HAND);
+        mc.interactionManager.interactEntity(mc.player, entity, Hand.MAIN_HAND);
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoNametag.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoNametag.java
@@ -22,6 +22,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.item.Items;
 import net.minecraft.util.Hand;
+import net.minecraft.util.hit.EntityHitResult;
 
 import java.util.Iterator;
 import java.util.Set;
@@ -126,7 +127,10 @@ public class AutoNametag extends Module {
     }
 
     private void interact() {
-        mc.interactionManager.interactEntity(mc.player, target, offHand ? Hand.OFF_HAND : Hand.MAIN_HAND);
+        Hand hand = offHand ? Hand.OFF_HAND : Hand.MAIN_HAND;
+        EntityHitResult location = new EntityHitResult(target, target.getBoundingBox().getCenter());
+        mc.interactionManager.interactEntityAtLocation(mc.player, target, location, hand);
+        mc.interactionManager.interactEntity(mc.player, target, hand);
         InvUtils.swapBack();
 
         entityCooldowns.put(target, 20);

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoShearer.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoShearer.java
@@ -21,6 +21,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.passive.SheepEntity;
 import net.minecraft.item.Items;
 import net.minecraft.util.Hand;
+import net.minecraft.util.hit.EntityHitResult;
 
 public class AutoShearer extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
@@ -80,6 +81,8 @@ public class AutoShearer extends Module {
     }
 
     private void interact() {
+        EntityHitResult location = new EntityHitResult(entity, entity.getBoundingBox().getCenter());
+        mc.interactionManager.interactEntityAtLocation(mc.player, entity, location, hand);
         mc.interactionManager.interactEntity(mc.player, entity, hand);
         InvUtils.swapBack();
     }


### PR DESCRIPTION
uses entity interaction like in `MinecraftClient.doItemUse`

## Type of change

- [X] Bug fix
- [ ] New feature

## Description

Added support for `PlayerInteractEntityC2SPacket.interactAt` packet.

## Related issues

https://github.com/MeteorDevelopment/meteor-client/issues/5635

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
