### PR TITLE
Fix GenericSetting and Vector3dSetting not calling onChanged

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/DefaultSettingsWidgetFactory.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/DefaultSettingsWidgetFactory.java
@@ -450,9 +450,15 @@ public class DefaultSettingsWidgetFactory extends SettingsWidgetFactory {
 
         WDoubleEdit component = table.add(theme.doubleEdit(value, setting.min, setting.max, setting.sliderMin, setting.sliderMax, setting.decimalPlaces, setting.noSlider)).expandX().widget();
         if (setting.onSliderRelease) {
-            component.actionOnRelease = () -> update.accept(component.get());
+            component.actionOnRelease = () -> {
+                update.accept(component.get());
+                setting.onChanged();
+            };
         } else {
-            component.action = () -> update.accept(component.get());
+            component.action = () -> {
+                update.accept(component.get());
+                setting.onChanged();
+            };
         }
 
         table.row();


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

- Added `screen.onClosed()` callback in `genericW()` to call `setting.onChanged()`
- Fixed `addVectorComponent()` to call `setting.onChanged()`
- Fixed `ESPBlockDataScreen.onChanged()` to always call `setting.onChanged()`, not just on first edit

# How Has This Been Tested?

Logging to verify `onChanged()` callbacks fire correctly.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
