### PR TITLE
Bow Aimbot and Bow Spam fixes/improvements

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/BowAimbot.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/BowAimbot.java
@@ -118,11 +118,12 @@ public class BowAimbot extends Module {
             return;
         }
 
-        if (mc.options.useKey.isPressed()) {
+        if (mc.options.useKey.isPressed() && itemInHand()) {
             if (pauseOnCombat.get() && PathManagers.get().isPathing() && !wasPathing) {
                 PathManagers.get().pause();
                 wasPathing = true;
             }
+
             aim();
         }
     }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/BowSpam.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/BowSpam.java
@@ -60,7 +60,7 @@ public class BowSpam extends Module {
             return;
 
         if (!onlyWhenHoldingRightClick.get() || mc.options.useKey.isPressed()) {
-            boolean isBow = mc.player.getMainHandStack().getItem() == Items.BOW || mc.player.getOffHandStack().getItem() == Items.BOW;
+            boolean isBow = InvUtils.testInHands(Items.BOW);
             if (!isBow && wasBow) setPressed(false);
 
             wasBow = isBow;


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

Changed Bow Aimbot to run on tick instead of render, previously it would send a player move packet every frame
Changed Bow Spam to run on TickEvent.Pre instead of TickEvent.Post, which allows bow spam to be a bit faster
Added offhand support to Bow Spam

## Related issues

#3981

# How Has This Been Tested?

Tested in singleplayer and two servers

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
