### PR TITLE
Fix 2b2t AutoSign

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoSign.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/AutoSign.java
@@ -11,6 +11,7 @@ import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.mixin.AbstractSignEditScreenAccessor;
 import meteordevelopment.meteorclient.settings.IntSetting;
 import meteordevelopment.meteorclient.settings.Setting;
+import meteordevelopment.meteorclient.settings.SettingGroup;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.orbit.EventHandler;
@@ -22,22 +23,23 @@ import java.util.ArrayDeque;
 import java.util.Queue;
 
 public class AutoSign extends Module {
+    private final SettingGroup sgGeneral = settings.getDefaultGroup();
+
+    private final Setting<Integer> delay = sgGeneral.add(new IntSetting.Builder()
+        .name("delay")
+        .description("The tick delay between sign update packets.")
+        .defaultValue(10)
+        .range(0, 100)
+        .sliderRange(0, 100)
+        .build()
+    );
+
     private String[] text;
 
     // Some servers (e.g., 2b2t) don't like the sign packet being sent too soon after the swing or block click packets, so queue them.
     // Delaying by sleeping in the event handler may be fine for a single sign, but would visibly lag the UI at a larger scale.
     private final Queue<UpdateSignC2SPacket> queue = new ArrayDeque<>();
     private int timer = 0;
-
-    private final Setting<Integer> delay = settings.getDefaultGroup().add(new IntSetting.Builder()
-        .name("Delay")
-        .description("Tick delay between sign update packets.")
-        .min(5)
-        .max(100)
-        .sliderRange(5, 100)
-        .defaultValue(10)
-        .build()
-    );
 
     public AutoSign() {
         super(Categories.World, "auto-sign", "Automatically writes signs. The first sign's text will be used.");


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

For a while 2b2t has been rejecting sign_update packets if they're sent too soon after a swing or use_item_on packet (unsure which, but both are always sent together when placing a sign so they're essentially equivalent), delaying the sign packet by 10 ticks works on my machine but I made the delay configurable.

## Related issues

N/A as far as I can tell.

# How Has This Been Tested?

Playing on 2b, I can record it if necessary but it's trivial to reproduce.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
