### PR TITLE
Fix account & proxy button breaking when resizing the multiplayer screen

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/MultiplayerScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MultiplayerScreenMixin.java
@@ -36,11 +36,17 @@ public abstract class MultiplayerScreenMixin extends Screen {
     @Unique
     private int loggedInAsLength;
 
+    @Unique
+    private ButtonWidget accounts;
+
+    @Unique
+    private ButtonWidget proxies;
+
     public MultiplayerScreenMixin(Text title) {
         super(title);
     }
 
-    @Inject(method = "init", at = @At("TAIL"))
+    @Inject(method = "refreshWidgetPositions", at = @At("TAIL"))
     private void onInit(CallbackInfo info) {
         textColor1 = Color.fromRGBA(255, 255, 255, 255);
         textColor2 = Color.fromRGBA(175, 175, 175, 255);
@@ -48,22 +54,25 @@ public abstract class MultiplayerScreenMixin extends Screen {
         loggedInAs = "Logged in as ";
         loggedInAsLength = textRenderer.getWidth(loggedInAs);
 
-        addDrawableChild(
-            new ButtonWidget.Builder(Text.literal("Accounts"), button -> client.setScreen(GuiThemes.get().accountsScreen()))
-                .position(this.width - 75 - 3, 3)
-                .size(75, 20)
-                .build()
-        );
+        if (accounts == null) {
+            accounts = addDrawableChild(
+                new ButtonWidget.Builder(Text.literal("Accounts"), button -> client.setScreen(GuiThemes.get().accountsScreen()))
+                    .size(75, 20)
+                    .build()
+            );
+        }
+        accounts.setPosition(this.width - 75 - 3, 3);
 
-        addDrawableChild(
-            new ButtonWidget.Builder(Text.literal("Proxies"), button -> client.setScreen(GuiThemes.get().proxiesScreen()))
-                .position(this.width - 75 - 3 - 75 - 2, 3)
-                .size(75, 20)
-                .build()
-        );
+        if (proxies == null) {
+            proxies = addDrawableChild(
+                    new ButtonWidget.Builder(Text.literal("Proxies"), button -> client.setScreen(GuiThemes.get().proxiesScreen()))
+                        .size(75, 20)
+                        .build()
+                );
+        }
+        proxies.setPosition(this.width - 75 - 3 - 75 - 2, 3);
     }
 
-    // todo this is probably an extremely bad way of doing it but it works for now
     @Override
     public void render(DrawContext context, int mouseX, int mouseY, float deltaTicks) {
         super.render(context, mouseX, mouseY, deltaTicks);


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Minecraft now caches the elements added there and only updates positions on resizing. I also removed the comment since this is normal practice when the target class doesn't override a function from the superclass.

## Related issues

There isn't one afaik.

# How Has This Been Tested?

Resize the multiplayer screen.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
