### PR TITLE
[fix] step: make safe-step smarter

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Step.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/Step.java
@@ -105,15 +105,16 @@ public class Step extends Module {
     }
 
     private boolean isSafe() {
-        return ((getHealth() > stepHealth.get() && getHealth() - getExplosionDamage() > stepHealth.get()));
+        return getHealth() > stepHealth.get() && getHealth() - getExplosionDamage() > stepHealth.get();
     }
 
     private boolean isSaferThanWith(double damage) {
-        return (isSafe() || getExplosionDamage() - damage <= 0);
+        return isSafe() || getExplosionDamage() - damage <= 0;
     }
 
     private double getMaxSafeHeight() {
         if (!safeStep.get()) return height.get();
+
         double max = height.get();
         double h = 0;
         double currentDamage =getExplosionDamage();


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

safe-step no longer:
- fails when step height is greater than 1
- allows running over a single blocks with crystals behind it (and similar scenarios)

## Related issues

none

# How Has This Been Tested?

works.

it's possible to make it better, but that requires moving it to `Tick.Pre`, and this one does not want to test for the side-effects of that

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
