### PR TITLE
Solve fake logout and implement coordinate-based auto logout in AutoLog module

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AutoLog.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AutoLog.java
@@ -70,14 +70,14 @@ public class AutoLog extends Module {
     );
 
     private final Setting<Boolean> onlyTrusted = sgGeneral.add(new BoolSetting.Builder()
-        .name("friends-only")
+        .name("only-trusted")
         .description("Disconnects when a player not on your friends list appears in render distance.")
         .defaultValue(false)
         .build()
     );
 
     private final Setting<Boolean> instantDeath = sgGeneral.add(new BoolSetting.Builder()
-        .name("threat-of-instant-death")
+        .name("32K")
         .description("Disconnects when a player near you can instantly kill you.")
         .defaultValue(false)
         .build()


### PR DESCRIPTION
Added position checking settings to AutoLog module.

## Type of change

- [X] Bug fix
- [x] New feature

## Description

Added new function to AutoLog module: now player can auto logout when certain coordinate reached.

## Related issues

[[Suggestion] AutoLog: support logout when certain coordinate reached #5827](https://github.com/MeteorDevelopment/meteor-client/issues/5827)
[[BUG] AutoLog: fake logout #5828
](https://github.com/MeteorDevelopment/meteor-client/issues/5828)

# How Has This Been Tested?

Videos or screenshots of the changes if applicable.
1. Coordinate based logout
![Screenshot From 2025-11-05 08-28-04](https://github.com/user-attachments/assets/4b7aa97f-b9d5-4097-ae7b-13041f6f7aab)
2. Fake logout seems to be solved because i could not reproduce it again, so I'm not able to take a screenshot.

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
