### PR TITLE
fix player-heads doesn't fade out on chat 

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterChat.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterChat.java
@@ -468,7 +468,7 @@ public class BetterChat extends Module {
         PlayerListEntry entry = mc.getNetworkHandler().getPlayerListEntry(sender.id());
         if (entry == null) return;
 
-        PlayerSkinDrawer.draw(context, entry.getSkinTextures(), 0, y, 8);
+        PlayerSkinDrawer.draw(context, entry.getSkinTextures(), 0, y, 8, color);
     }
 
     private GameProfile getSender(IChatHudLine line, String text) {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
## Description
Fixes a bug where player heads doesn't fade out with message when Better Chat module's player head feature is on 

## Related issues
#5830

# How Has This Been Tested?
<img width="265" height="63" alt="image" src="https://github.com/user-attachments/assets/64ebd8a0-0964-43c5-84d1-8d275b246c69" />

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
