### PR TITLE
Fix strange conditional in BookBot.java

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BookBot.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BookBot.java
@@ -178,7 +178,7 @@ public class BookBot extends Module {
     private void onTick(TickEvent.Post event) {
         Predicate<ItemStack> bookPredicate = i -> {
             WritableBookContentComponent component = i.get(DataComponentTypes.WRITABLE_BOOK_CONTENT);
-            return i.getItem() == Items.WRITABLE_BOOK && (component != null || component.pages().isEmpty());
+            return i.getItem() == Items.WRITABLE_BOOK && (component == null || component.pages().isEmpty());
         };
 
         FindItemResult writableBook = InvUtils.find(bookPredicate);


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

A summary of the changes along with the reasoning behind the changes.

Fixed a null pointer access warning by changing the condition from
```java
(component != null || component.pages().isEmpty())
```
to
```java
(component == null || component.pages().isEmpty())
```

If you didn't see the difference, changed to `!=` from `==`.

## Related issues

None as far as I am aware.

# How Has This Been Tested?

Videos or screenshots of the changes if applicable.

A patch this small doesn't require testing.. just look at the change.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [ ] I have tested the code in both development and production environments.