### PR TITLE
make BlockUtils.getDirection() not just check against the bottom side

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/utils/world/BlockUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/world/BlockUtils.java
@@ -339,9 +339,10 @@ public class BlockUtils {
     public static Direction getDirection(BlockPos pos) {
         double eyePos = mc.player.getY() + mc.player.getEyeHeight(mc.player.getPose());
         VoxelShape outline = mc.world.getBlockState(pos).getCollisionShape(mc.world, pos);
-        if (eyePos > pos.getY() + outline.getMax(Direction.Axis.Y) && mc.world.getBlockState(pos.add(0, 1, 0)).isReplaceable()) {
+
+        if (eyePos > pos.getY() + outline.getMax(Direction.Axis.Y) && mc.world.getBlockState(pos.up()).isReplaceable()) {
             return Direction.UP;
-        } else if (eyePos < pos.getY() + outline.getMin(Direction.Axis.Y) && mc.world.getBlockState(pos.add(0, -1, 0)).isReplaceable()) {
+        } else if (eyePos < pos.getY() + outline.getMin(Direction.Axis.Y) && mc.world.getBlockState(pos.down()).isReplaceable()) {
             return Direction.DOWN;
         } else {
             BlockPos difference = pos.subtract(mc.player.getBlockPos());


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Constantiam.net today started up a test server and it's running GrimAC.
Nuker wouldn't work because the direction to break the block from isn't accurately calculated.
It was checking only against the bottom side of the block. 
It wasn't taking the block height into account.

As an example, if the player pos is Y=70, block to break is Y=71, the eye position is Y=71.62000000476837, in that scenario, it would still try breaking the block from the top because it's comparing 71.62000000476837 to 71, not taking block height into account.

While this worked with the server's previous anticheat, Grim likes to bitch and moan about minutiae like this. So I fixed it.

## Related issues

Cant find 

# How Has This Been Tested?

I tested it. Videos attached. 

before:
https://github.com/user-attachments/assets/5d22928a-b496-4ec8-a77a-95454bd53865

after:
https://github.com/user-attachments/assets/38faa663-cb41-4951-9a3e-6400927a4907


# Checklist:

- [x] My code follows the style guidelines of this project. (let me know if it doesnt)
- [x] I have added comments to my code in more complex areas. (not relevant)
- [x] I have tested the code in both development and production environments.
