### PR TITLE
Add "Only on ground" setting to AutoEXP module

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AutoEXP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AutoEXP.java
@@ -46,7 +46,6 @@ public class AutoEXP extends Module {
         .build()
     );
 
-
     private final Setting<Integer> slot = sgGeneral.add(new IntSetting.Builder()
         .name("exp-slot")
         .description("The slot to replenish exp into.")
@@ -91,7 +90,7 @@ public class AutoEXP extends Module {
         if (onlyGround.get() && !mc.player.isOnGround()) {
             return;
         }
-        
+
         if (repairingI == -1) {
             if (mode.get() != Mode.Hands) {
                 for (EquipmentSlot slot : AttributeModifierSlot.ARMOR) {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [✅] New feature

## Description

Small change to add a "Only on ground" setting to AutoEXP module to help prevent xp wastage.

## Related issues

None

# How Has This Been Tested?

Tested in game.

# Checklist:

- [✅] My code follows the style guidelines of this project.
- [ N/A] I have added comments to my code in more complex areas.
- [✅] I have tested the code in both development and production environments.
