### PR TITLE
Fix: disable freecam on dimension change

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Freecam.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Freecam.java
@@ -453,7 +453,7 @@ public class Freecam extends Module {
         else if (event.packet instanceof PlayerRespawnS2CPacket) {
             if (isActive()) {
                 toggle();
-                info("Toggled off because the dimension was changed.");
+                info("Toggled off because you changed dimensions.");
             }
         }
     }


### PR DESCRIPTION
## Type of change

- [x] Bug fix

## Description

Added handling for PlayerRespawnS2CPacket in onPacketReceive to automatically deactivate the Freecam module when the player changes dimension (e.g. entering the nether). This prevents a hard freeze caused by conflicts between Freecam logic and world reinitialization during teleportation.

## Related issues

Fixes a bug where the game would freeze when teleporting through a portal with Freecam enabled.

# Checklist:

- [x] I have tested the code in both development and production environments.
