### PR TITLE
Fix: View widget passing click events and rendering dropdown and tooltips outside the view

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/WWidget.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/WWidget.java
@@ -8,6 +8,7 @@ package meteordevelopment.meteorclient.gui.widgets;
 import meteordevelopment.meteorclient.gui.GuiTheme;
 import meteordevelopment.meteorclient.gui.renderer.GuiRenderer;
 import meteordevelopment.meteorclient.gui.utils.BaseWidget;
+import meteordevelopment.meteorclient.gui.widgets.containers.WView;
 import net.minecraft.client.gui.Click;
 import net.minecraft.client.input.CharInput;
 import net.minecraft.client.input.KeyInput;
@@ -77,7 +78,11 @@ public abstract class WWidget implements BaseWidget {
 
         if (isOver(mouseX, mouseY)) {
             mouseOverTimer += delta;
-            if ((instantTooltips || mouseOverTimer >= 1) && tooltip != null) renderer.tooltip(tooltip);
+
+            if ((instantTooltips || mouseOverTimer >= 1) && tooltip != null) {
+                WView view = getView();
+                if (view == null || view.mouseOver) renderer.tooltip(tooltip);
+            }
         }
         else {
             mouseOverTimer = 0;
@@ -136,6 +141,10 @@ public abstract class WWidget implements BaseWidget {
 
     protected WWidget getRoot() {
         return parent != null ? parent.getRoot() : (this instanceof WRoot ? this : null);
+    }
+
+    protected WView getView() {
+        return this instanceof WView ? (WView) this : (parent != null ? parent.getView() : null);
     }
 
     public boolean isOver(double x, double y) {

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/containers/WContainer.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/containers/WContainer.java
@@ -106,9 +106,12 @@ public abstract class WContainer extends WWidget {
     public boolean render(GuiRenderer renderer, double mouseX, double mouseY, double delta) {
         if (super.render(renderer, mouseX, mouseY, delta)) return true;
 
+        WView view = getView();
+
         for (Cell<?> cell : cells) {
             double y = cell.widget().y;
             if (y > getWindowHeight()) break;
+            if (view != null && !view.isWidgetInView(cell.widget())) continue;
 
             if (y + cell.widget().height > 0) renderWidget(cell.widget(), renderer, mouseX, mouseY, delta);
         }

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/containers/WView.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/containers/WView.java
@@ -164,7 +164,11 @@ public abstract class WView extends WVerticalList {
 
     @Override
     protected boolean propagateEvents(WWidget widget) {
-        return ((widget.y >= y && widget.y <= y + height) || (widget.y + widget.height >= y && widget.y + widget.height <= y + height)) || ((y >= widget.y && y <= widget.y + widget.height) || (y + height >= widget.y && y + height <= widget.y + widget.height));
+        return mouseOver && isWidgetInView(widget);
+    }
+
+    protected boolean isWidgetInView(WWidget widget) {
+        return widget.y < y + height && widget.y + widget.height > y;
     }
 
     protected double handleWidth() {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Prevented click events from propagating to widgets that are not visible (scrolled out of view).

Added culling logic to WWidget and WContainer. This fixes tooltips appearing for off-screen widgets and improves performance by skipping render logic for invisible elements (also fixes Dropdowns rendering outside the view).

## Related issues

Couldn't find any.

# How Has This Been Tested?

Before: https://ctrlv.tv/7rDZ
After: https://ctrlv.tv/z8sj

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
