### PR TITLE
Added `themis` AntiCheat

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/ServerCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/ServerCommand.java
@@ -39,7 +39,7 @@ import java.util.Random;
 import java.util.Set;
 
 public class ServerCommand extends Command {
-    private static final Set<String> ANTICHEAT_LIST = Set.of("nocheatplus", "negativity", "warden", "horizon", "illegalstack", "coreprotect", "exploitsx", "vulcan", "abc", "spartan", "kauri", "anticheatreloaded", "witherac", "godseye", "matrix", "wraith", "antixrayheuristics", "grimac");
+    private static final Set<String> ANTICHEAT_LIST = Set.of("nocheatplus", "negativity", "warden", "horizon", "illegalstack", "coreprotect", "exploitsx", "vulcan", "abc", "spartan", "kauri", "anticheatreloaded", "witherac", "godseye", "matrix", "wraith", "antixrayheuristics", "grimac", "themis");
     private static final Set<String> VERSION_ALIASES = Set.of("version", "ver", "about", "bukkit:version", "bukkit:ver", "bukkit:about"); // aliases for bukkit:version
     private String alias;
     private int ticks = 0;


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Added another AntiCheat to the list: [themis](https://www.spigotmc.org/resources/themis-anti-cheat-1-17-1-21-bedrock-support-paper-compatibility-free-optimized.90766/).

# How Has This Been Tested?

It hasn't. I don't feel the need to test this change. It shows up as 'themis' under `.server plugins` exactly like that, I don't see how it can fail.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [ ] I have tested the code in both development and production environments.
