### PR TITLE
Fixed isAboveWater() bug

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/utils/entity/EntityUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/entity/EntityUtils.java
@@ -75,8 +75,9 @@ public class EntityUtils {
     @SuppressWarnings("deprecation") // Use of AbstractBlock.AbstractBlockState#blocksMovement
     public static boolean isAboveWater(Entity entity) {
         BlockPos.Mutable blockPos = entity.getBlockPos().mutableCopy();
+        int bottom = mc.world.getBottomY();
 
-        for (int i = 0; i < 64; i++) {
+        while (blockPos.getY() > bottom) {
             BlockState state = mc.world.getBlockState(blockPos);
 
             if (state.blocksMovement()) break;


### PR DESCRIPTION
Now the method looks for water until the world bottom is found if no intersecting blocks are found.

## Type of change

- [x] Bug fix
- [ ] New feature

## Description

This is just a simple fix where AutoTotem would switch to a totem if water was below the player, but further than 64 blocks away, which is now fixed by checking deeper, up until to the world bottom if no intersecting block is found that could kill the player.

## Related issues

I have described the bug in #5910.

# How Has This Been Tested?

I tested with different heights of water pits, below a fall length of 64 blocks and more than that, AutoTotem still works as expected, now not switching to a totem when water is detected at any length of pit.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas. (No need, just a simple while-loop)
- [x] I have tested the code in both development and production environments.
