### PR TITLE
sync list setting column widths

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/base/CollectionListSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/base/CollectionListSettingScreen.java
@@ -13,6 +13,7 @@ import meteordevelopment.meteorclient.gui.widgets.containers.WTable;
 import meteordevelopment.meteorclient.gui.widgets.input.WTextBox;
 import meteordevelopment.meteorclient.gui.widgets.pressable.WPressable;
 import meteordevelopment.meteorclient.settings.Setting;
+import meteordevelopment.meteorclient.systems.config.Config;
 
 import java.util.Collection;
 import java.util.function.Consumer;
@@ -76,6 +77,7 @@ public abstract class CollectionListSettingScreen<T> extends WindowScreen {
     private WTable abc(Iterable<T> iterable, boolean isLeft, Consumer<T> buttonAction) {
         // Create
         Cell<WTable> cell = this.table.add(theme.table()).top();
+        if (Config.get().syncListSettingWidths.get()) cell.group("sync-width");
         WTable table = cell.widget();
 
         // Sort

--- a/src/main/java/meteordevelopment/meteorclient/gui/utils/Cell.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/utils/Cell.java
@@ -6,6 +6,7 @@
 package meteordevelopment.meteorclient.gui.utils;
 
 import meteordevelopment.meteorclient.gui.widgets.WWidget;
+import org.jetbrains.annotations.Nullable;
 
 public class Cell<T extends WWidget> {
     private final T widget;
@@ -23,6 +24,8 @@ public class Cell<T extends WWidget> {
     private boolean expandWidgetY;
 
     public boolean expandCellX;
+
+    public @Nullable String group;
 
     public Cell(T widget) {
         this.widget = widget;
@@ -153,6 +156,12 @@ public class Cell<T extends WWidget> {
     }
 
     // Other
+
+    /// Makes this cell's width match the largest cell in the group
+    public Cell<T> group(String group) {
+        this.group = group;
+        return this;
+    }
 
     public void alignWidget() {
         if (expandWidgetX) {

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/containers/WTable.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/containers/WTable.java
@@ -12,9 +12,7 @@ import it.unimi.dsi.fastutil.ints.IntList;
 import meteordevelopment.meteorclient.gui.utils.Cell;
 import meteordevelopment.meteorclient.gui.widgets.WWidget;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 public class WTable extends WContainer {
     public double horizontalSpacing = 3;
@@ -160,6 +158,8 @@ public class WTable extends WContainer {
         columnWidths.clear();
         rowExpandCellXCounts.clear();
 
+        Map<String, IntList> columnGroups = new HashMap<>();
+
         // Loop over rows
         for (List<Cell<?>> row : rows) {
             double rowHeight = 0;
@@ -177,6 +177,8 @@ public class WTable extends WContainer {
                 if (columnWidths.size() <= i) columnWidths.add(cellWidth);
                 else columnWidths.set(i, Math.max(columnWidths.getDouble(i), cellWidth));
 
+                if (cell.group != null) columnGroups.computeIfAbsent(cell.group, k -> new IntArrayList()).add(i);
+
                 // Calculate row expandX count
                 if (cell.expandCellX) rowExpandXCount++;
             }
@@ -185,5 +187,17 @@ public class WTable extends WContainer {
             rowHeights.add(rowHeight);
             rowExpandCellXCounts.add(rowExpandXCount);
         }
+
+        // Normalize group widths
+        columnGroups.values().forEach(columns -> {
+            double maxWidth = Integer.MIN_VALUE;
+            for (int i : columns) {
+                maxWidth = Math.max(maxWidth, columnWidths.getDouble(i));
+            }
+
+            for (int i : columns) {
+                columnWidths.set(i, maxWidth);
+            }
+        });
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/config/Config.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/config/Config.java
@@ -96,6 +96,13 @@ public class Config extends System<Config> {
         .build()
     );
 
+    public final Setting<Boolean> syncListSettingWidths = sgVisual.add(new BoolSetting.Builder()
+        .name("sync-list-setting-widths")
+        .description("Prevents the list setting screens from moving around as you add & remove elements.")
+        .defaultValue(false)
+        .build()
+    );
+
     // Modules
 
     public final Setting<List<Module>> hiddenModules = sgModules.add(new ModuleListSetting.Builder()


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature

## Description

adds an opt-in config option to "normalize" the widths of columns in collection list settings
before:
<img width="623" height="290" alt="image" src="https://github.com/user-attachments/assets/2fd864ce-953a-4df8-971b-ecdf4658ff2d" />

after:
<img width="865" height="365" alt="image" src="https://github.com/user-attachments/assets/013c681e-3a03-4e3f-94df-c6d823f00675" />

## Related issues

this person right here
<img width="673" height="131" alt="one thing i hate about meteor is that all the checkboxes move based on the longest block name. so like whenever you click a lot of blocks, it changes position and i have to move my mouse. pretty annoying, not sure why they don't have a fixed width" src="https://github.com/user-attachments/assets/b6d3addc-b6d5-45c9-92ae-9d80600091bb" />

# How Has This Been Tested?

the J

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
