### PR TITLE
hotfix anchor aura & bed aura

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AnchorAura.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/AnchorAura.java
@@ -35,7 +35,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.RaycastContext;
-import net.minecraft.world.attribute.EnvironmentAttributes;
+import net.minecraft.world.World;
 
 public class AnchorAura extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
@@ -274,7 +274,7 @@ public class AnchorAura extends Module {
 
     @EventHandler
     private void onTick(TickEvent.Pre event) {
-        if (mc.world.getEnvironmentAttributes().getAttributeValue(EnvironmentAttributes.RESPAWN_ANCHOR_WORKS_GAMEPLAY)) {
+        if (mc.world.getRegistryKey() == World.NETHER) {
             error("You can't blow up respawn anchors in this dimension, disabling.");
             toggle();
             return;

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/BedAura.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/BedAura.java
@@ -34,7 +34,7 @@ import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
-import net.minecraft.world.attribute.EnvironmentAttributes;
+import net.minecraft.world.World;
 
 public class BedAura extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
@@ -208,7 +208,7 @@ public class BedAura extends Module {
     @EventHandler
     private void onTick(TickEvent.Post event) {
         // Check if beds can explode here
-        if (!mc.world.getEnvironmentAttributes().getAttributeValue(EnvironmentAttributes.BED_RULE_GAMEPLAY).explodes()) {
+        if (mc.world.getRegistryKey() == World.OVERWORLD) {
             error("You can't blow up beds in this dimension, disabling.");
             toggle();
             return;


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

hotfix to anchor aura & bed aura querying dimension attributes, it is (to my knowledge) not possible to know if a dimension blows up anchors & beds anymore

## Related issues

the J

# How Has This Been Tested?

the J

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
