### PR TITLE
hotfix .input hold keybinds not pressing

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/InputCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/InputCommand.java
@@ -133,9 +133,10 @@ public class InputCommand extends Command {
 
         @EventHandler
         private void onTick(TickEvent.Post event) {
+            if (ticks == totalTicks) press(key);
+
             if (ticks-- > 0) {
                 key.setPressed(true);
-                press(key);
             } else {
                 key.setPressed(false);
                 MeteorClient.EVENT_BUS.unsubscribe(this);


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

fix hold keybinds not being pressed in `.input`
make `ticks` parameter optional

## Related issues

the J

# How Has This Been Tested?

`.input attack 1` does not hit entities

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
