### PR TITLE
allow making keybindless macros

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/MacrosTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/MacrosTab.java
@@ -98,7 +98,6 @@ public class MacrosTab extends Tab {
         public boolean save() {
             if (value.name.get().isBlank()
                 || value.messages.get().isEmpty()
-                || !value.keybind.get().isSet()
             ) return false;
 
             if (isNew) {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature

## Description

allow making macros with no keys bound
i often want to make a test macro, but not have it bound to a key (i need my keys for other things), having it only be triggered via command would be cool

## Related issues

the J

# How Has This Been Tested?

the J

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
