### PR TITLE
allow themes to change the chat prefix

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/GuiTheme.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/GuiTheme.java
@@ -27,10 +27,12 @@ import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.utils.misc.ISerializable;
 import meteordevelopment.meteorclient.utils.misc.Keybind;
 import meteordevelopment.meteorclient.utils.misc.Names;
+import meteordevelopment.meteorclient.utils.player.ChatUtils;
 import meteordevelopment.meteorclient.utils.render.color.Color;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
+import net.minecraft.text.Text;
 import net.minecraft.util.math.BlockPos;
 
 import java.util.HashMap;
@@ -281,6 +283,10 @@ public abstract class GuiTheme implements ISerializable<GuiTheme> {
     public abstract boolean categoryIcons();
 
     public abstract boolean hideHUD();
+
+    public Text prefix() {
+        return ChatUtils.getMeteorPrefix();
+    }
 
     public double textWidth(String text, int length, boolean title) {
         return scale(textRenderer().getWidth(text, length, false) * (title ? TITLE_TEXT_SCALE : 1));

--- a/src/main/java/meteordevelopment/meteorclient/utils/player/ChatUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/ChatUtils.java
@@ -7,6 +7,7 @@ package meteordevelopment.meteorclient.utils.player;
 
 import com.mojang.brigadier.StringReader;
 import meteordevelopment.meteorclient.MeteorClient;
+import meteordevelopment.meteorclient.gui.GuiThemes;
 import meteordevelopment.meteorclient.mixininterface.IChatHud;
 import meteordevelopment.meteorclient.pathing.BaritoneUtils;
 import meteordevelopment.meteorclient.systems.config.Config;
@@ -182,7 +183,7 @@ public class ChatUtils {
     private static Text getPrefix() {
         if (customPrefixes.isEmpty()) {
             forcedPrefixClassName = null;
-            return PREFIX;
+            return GuiThemes.get().prefix();
         }
 
         boolean foundChatUtils = false;
@@ -204,16 +205,16 @@ public class ChatUtils {
             }
         }
 
-        if (className == null) return PREFIX;
+        if (className == null) return GuiThemes.get().prefix();
 
         for (Pair<String, Supplier<Text>> pair : customPrefixes) {
             if (className.startsWith(pair.getLeft())) {
                 Text prefix = pair.getRight().get();
-                return prefix != null ? prefix : PREFIX;
+                return prefix != null ? prefix : GuiThemes.get().prefix();
             }
         }
 
-        return PREFIX;
+        return GuiThemes.get().prefix();
     }
 
     private static MutableText formatMsg(String message, Formatting defaultColor) {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature

## Description

catpuccin themes would look cooler if it could do this

the reason why i didn't make it `abstract` in `GuiTheme` is because i dont think most themes would (should?) touch it, i dont want to encourage modifying the prefix more than to just recolor it

## Related issues

the J

# How Has This Been Tested?

dose not crash

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
