### PR TITLE
fix spear's stab animation doesn't display because old animations option 

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/HeldItemRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/HeldItemRendererMixin.java
@@ -71,7 +71,7 @@ public abstract class HeldItemRendererMixin {
 
     @ModifyArg(method = "updateHeldItems", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/math/MathHelper;clamp(FFF)F", ordinal = 2), index = 0)
     private float modifyEquipProgressMainhand(float value) {
-        float f = mc.player.getAttackCooldownProgress(1f);
+        float f = mc.player.getHandEquippingProgress(1f);
         float modified = Modules.get().get(HandView.class).oldAnimations() ? 1 : f * f * f;
 
         return (shouldSkipHandAnimationOnSwap(mainHand, mc.player.getMainHandStack()) ? modified : 0) - equipProgressMainHand;


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description
Uses #getHandEquippingProgress() instead of using wrong #getAttackCooldownProgress() which caused spear's stab animation to not play  

## Related issues
Fixes #5953

# How Has This Been Tested?
Works fine

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
