### PR TITLE
Fix sodium compatibility for no render's fog option

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumWorldRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/sodium/SodiumWorldRendererMixin.java
@@ -10,16 +10,20 @@ import meteordevelopment.meteorclient.systems.modules.render.NoRender;
 import net.caffeinemc.mods.sodium.client.render.SodiumWorldRenderer;
 import net.caffeinemc.mods.sodium.client.util.FogParameters;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 @Mixin(SodiumWorldRenderer.class)
 public class SodiumWorldRendererMixin {
+    @Unique
+    private static final FogParameters DISABLED_FOG = new FogParameters(0, 0, 0, 0, Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE);
+
     @ModifyVariable(method = "setupTerrain", at = @At("HEAD"), argsOnly = true)
     private FogParameters modifyFogParameters(FogParameters fogParameters) {
         if (Modules.get() == null) return fogParameters;
 
-        if (Modules.get().get(NoRender.class).noFog()) return FogParameters.NONE;
+        if (Modules.get().get(NoRender.class).noFog()) return DISABLED_FOG;
 
         return fogParameters;
     }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description
Fixes Sodium's compatibility for no render module's fog option 

## Related issues
Fixes #5940 

# How Has This Been Tested?
Tried in singleplayer, works fine

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
