### PR TITLE
build(deps): Remove deprecated `fabric-resource-loader-v0` module

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,7 +77,6 @@ dependencies {
 
     val fapiVersion = libs.versions.fabric.api.get()
     modInclude(fabricApi.module("fabric-api-base", fapiVersion))
-    modInclude(fabricApi.module("fabric-resource-loader-v0", fapiVersion))
     modInclude(fabricApi.module("fabric-resource-loader-v1", fapiVersion))
 
     // Compat fixes


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Fabric API's 1.21.11 branch effectively integrated all of `v0` in the `v1` module instead.

## Related issues

None.

# How Has This Been Tested?

Singleplayer testing.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
