### PR TITLE
Fix fall damage when clipping downward.

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/VClipCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/VClipCommand.java
@@ -37,7 +37,7 @@ public class VClipCommand extends Command {
             }
 
             if (mc.player.hasVehicle()) {
-                // Vehicle version
+                // Vehicle version, no fall damage anyways
                 // For each 10 blocks, send a vehicle move packet with no delta
                 for (int packetNumber = 0; packetNumber < (packetsRequired - 1); packetNumber++) {
                     mc.player.networkHandler.sendPacket(VehicleMoveC2SPacket.fromVehicle(mc.player.getVehicle()));
@@ -52,8 +52,11 @@ public class VClipCommand extends Command {
                     mc.player.networkHandler.sendPacket(new PlayerMoveC2SPacket.OnGroundOnly(true, mc.player.horizontalCollision));
                 }
                 // Now send the final player move packet
-                mc.player.networkHandler.sendPacket(new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(), mc.player.getY() + blocks, mc.player.getZ(), true, mc.player.horizontalCollision));
-                mc.player.setPosition(mc.player.getX(), mc.player.getY() + blocks, mc.player.getZ());
+                double y = mc.player.getY() + blocks;
+                mc.player.networkHandler.sendPacket(new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(), y, mc.player.getZ(), false, mc.player.horizontalCollision));
+                mc.player.setPosition(mc.player.getX(), y, mc.player.getZ());
+                mc.player.networkHandler.sendPacket(new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(), y + 0.0000000001, mc.player.getZ(), false, mc.player.horizontalCollision)); // we are slightly higher, resets fall distance to 0
+                mc.player.setPosition(mc.player.getX(), y + 0.0000000001, mc.player.getZ());
             }
 
             return SINGLE_SUCCESS;


### PR DESCRIPTION
## Type of change

- [+ ] Bug fix

## Description

I hate when I vclip downwards and die because of fall damage. I decided to fix that.

## Related issues

https://github.com/MeteorDevelopment/meteor-client/issues/5620

# How Has This Been Tested?

Joined a singleplayer world, did vclip -7, took no fall damage.
Joined a multiplayer paper server which was 1.21.8, vclipped down into a spawner room, took no fall damage.

# Checklist:

- [ +] My code follows the style guidelines of this project.
- [ +] I have added comments to my code in more complex areas.
- [ +] I have tested the code in both development and production environments.
