### PR TITLE
fix view bobbing causing tracers jumping with Iris shaders

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/GameRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/GameRendererMixin.java
@@ -9,8 +9,8 @@ import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.blaze3d.systems.RenderSystem;
-import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.MixinPlugin;
+import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.events.render.GetFovEvent;
 import meteordevelopment.meteorclient.events.render.Render3DEvent;
 import meteordevelopment.meteorclient.events.render.RenderAfterWorldEvent;
@@ -27,7 +27,6 @@ import meteordevelopment.meteorclient.utils.Utils;
 import meteordevelopment.meteorclient.utils.render.CustomBannerGuiElementRenderer;
 import meteordevelopment.meteorclient.utils.render.NametagUtils;
 import meteordevelopment.meteorclient.utils.render.RenderUtils;
-import net.irisshaders.iris.api.v0.IrisApi;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.render.GuiRenderer;
@@ -129,7 +128,8 @@ public abstract class GameRendererMixin {
 
         matrices.push();
         tiltViewWhenHurt(matrices, camera.getLastTickProgress());
-        if (client.options.getBobView().getValue()) bobView(matrices, camera.getLastTickProgress());
+        if (client.options.getBobView().getValue())
+            bobView(matrices, camera.getLastTickProgress());
 
         Matrix4f inverseBob = new Matrix4f(matrices.peek().getPositionMatrix()).invert();
         RenderSystem.getModelViewStack().mul(inverseBob);
@@ -137,7 +137,7 @@ public abstract class GameRendererMixin {
 
         // Call utility classes (apply bob correction when Iris shaders are active)
 
-        Matrix4f correctedPosition = (MixinPlugin.isIrisPresent && IrisApi.getInstance().isShaderPackInUse()) ? new Matrix4f(position).mul(inverseBob) : position;
+        Matrix4f correctedPosition = MixinPlugin.isIrisPresent && RenderUtils.isShaderPackInUse() ? new Matrix4f(position).mul(inverseBob) : position;
         RenderUtils.updateScreenCenter(projection, correctedPosition);
         NametagUtils.onRender(position);
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/RenderUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/RenderUtils.java
@@ -14,6 +14,7 @@ import meteordevelopment.meteorclient.utils.PostInit;
 import meteordevelopment.meteorclient.utils.misc.Pool;
 import meteordevelopment.meteorclient.utils.render.color.Color;
 import meteordevelopment.orbit.EventHandler;
+import net.irisshaders.iris.api.v0.IrisApi;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
@@ -39,6 +40,10 @@ public class RenderUtils {
     @PostInit
     public static void init() {
         MeteorClient.EVENT_BUS.subscribe(RenderUtils.class);
+    }
+
+    public static boolean isShaderPackInUse() {
+        return IrisApi.getInstance().isShaderPackInUse();
     }
 
     // Items


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description
Fixes tracers jumping with Iris shaders when view bobbing is on. tracers would jump/jitter while walking because the view bobbing applied differently than vanilla

## Related issues
Reported on discord https://discord.com/channels/689197705683140636/689197706169942135/1452076550999773226

# How Has This Been Tested?
Tracers doesn't jump/jitter anymore, tested with 11 shaders (ComplementaryReimagined_r5.6.1, ComplementaryUnbound_r5.6.1, Bliss_v2.1.2_(Chocapic13_Shaders_edit), miniature-shader-2.18.6, Mellow v2.2.1, §r§lAstra§4§lLex§r§l_By_LexBoosT_§4§lV93.0§r§l, Pegasus (v0.3.7), FullBright2 V6.0, BVS - Best Vanilla Shader 1.9.2, Body Camera Shader - V1.5.1, Spooklementary_v2.0.4)

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
