### PR TITLE
render marker armor stands in esp

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/ArmorStandEntityRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ArmorStandEntityRendererMixin.java
@@ -1,0 +1,29 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.mixin;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import meteordevelopment.meteorclient.systems.modules.Modules;
+import meteordevelopment.meteorclient.systems.modules.render.ESP;
+import net.minecraft.client.render.entity.ArmorStandEntityRenderer;
+import net.minecraft.entity.EntityType;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(ArmorStandEntityRenderer.class)
+public class ArmorStandEntityRendererMixin {
+    @Unique
+    private static ESP esp;
+
+    @ModifyExpressionValue(method = "getRenderLayer(Lnet/minecraft/client/render/entity/state/ArmorStandEntityRenderState;ZZZ)Lnet/minecraft/client/render/RenderLayer;", at = @At(value = "FIELD", target = "Lnet/minecraft/client/render/entity/state/ArmorStandEntityRenderState;marker:Z", opcode = Opcodes.GETFIELD))
+    private boolean modifyMarkerValue(boolean original) {
+        if (esp == null) esp = Modules.get().get(ESP.class);
+
+        return original && !(esp.isActive() && !esp.shouldSkip(EntityType.ARMOR_STAND));
+    }
+}

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/ESP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/ESP.java
@@ -355,6 +355,10 @@ public class ESP extends Module {
         return !EntityUtils.isInRenderDistance(entity);
     }
 
+    public boolean shouldSkip(EntityType<?> entityType) {
+        return !entities.get().contains(entityType);
+    }
+
     public Color getColor(Entity entity) {
         Color color;
         double alpha = 1;

--- a/src/main/resources/meteor-client.mixins.json
+++ b/src/main/resources/meteor-client.mixins.json
@@ -16,6 +16,7 @@
     "AbstractSignEditScreenAccessor",
     "AbstractSignEditScreenMixin",
     "ArmorFeatureRendererMixin",
+    "ArmorStandEntityRendererMixin",
     "AttackRangeComponentMixin",
     "BannerBlockEntityRendererMixin",
     "BeaconBlockEntityRendererMixin",


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

renders armor stands with the 'marker' in the esp module

before:
<img width="1920" height="1017" alt="image" src="https://github.com/user-attachments/assets/d6df5759-abea-4d6f-b160-13b88b0da918" />
after:
<img width="1920" height="1017" alt="image" src="https://github.com/user-attachments/assets/affdf143-983c-43e2-ac75-f5acd133d89d" />


## Related issues

none

# How Has This Been Tested?

the J

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
