### PR TITLE
fix duplicate delegates crash in StorageESP

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/utils/render/MeshBuilderVertexConsumerProvider.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/MeshBuilderVertexConsumerProvider.java
@@ -19,7 +19,42 @@ public class MeshBuilderVertexConsumerProvider implements IVertexConsumerProvide
 
     @Override
     public VertexConsumer getBuffer(RenderLayer layer) {
-        return vertexConsumer;
+        return new W(vertexConsumer); // new instance each call to fix duplicate delegates
+    }
+
+    private record W(MeshBuilderVertexConsumer d) implements VertexConsumer {
+        public VertexConsumer vertex(float x, float y, float z) {
+            d.vertex(x, y, z);
+            return this;
+        }
+
+        public VertexConsumer color(int r, int g, int b, int a) {
+            return this;
+        }
+
+        public VertexConsumer color(int c) {
+            return this;
+        }
+
+        public VertexConsumer texture(float u, float v) {
+            return this;
+        }
+
+        public VertexConsumer overlay(int u, int v) {
+            return this;
+        }
+
+        public VertexConsumer light(int u, int v) {
+            return this;
+        }
+
+        public VertexConsumer normal(float x, float y, float z) {
+            return this;
+        }
+
+        public VertexConsumer lineWidth(float w) {
+            return this;
+        }
     }
 
     public void setColor(Color color) {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description
StorageESP was crashing because of duplicate delegates when rendering shulker boxes together with mods that also render items on block entities. That was happening happened because it was returning the same VertexConsumer instance every time.
So i simply return a new lightweight wrapper instance on every getBuffer() call to fix it

## Related issues
#5974 and probably mods working similarly

# How Has This Been Tested?
Tested with Peek mod in singleplayer
<img width="1280" height="696" alt="image" src="https://github.com/user-attachments/assets/232b350b-354b-4d34-8ad7-f1c1d94a5e0c" />


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
