### PR TITLE
catch more exceptions in `Waypoints#init`

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/waypoints/Waypoints.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/waypoints/Waypoints.java
@@ -29,7 +29,6 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Iterator;
@@ -75,7 +74,7 @@ public class Waypoints extends System<Waypoints> implements Iterable<Waypoint> {
                     AbstractTexture texture = new NativeImageBackedTexture(() -> name, NativeImage.read(inputStream));
                     icons.put(name, texture);
                 }
-                catch (IOException e) {
+                catch (Exception e) {
                     MeteorClient.LOG.error("Failed to read a waypoint icon", e);
                 }
             }


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

turns out loading a png can throw:
- `IOException`
- `IndexOutOfBoundsException`
- `UnsupportedOperationException`
- `IllegalArgumentException`

who would've thunk

## Related issues

#6002 

# How Has This Been Tested?

the J

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
