### PR TITLE
Don't sleep on all items

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/InventoryTweaks.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/InventoryTweaks.java
@@ -404,19 +404,6 @@ public class InventoryTweaks extends Module {
         for (int i = start; i < end; i++) {
             if (!handler.getSlot(i).hasStack()) continue;
 
-            int sleep;
-            if (initial) {
-                sleep = autoStealInitDelay.get();
-                initial = false;
-            } else sleep = getSleepTime();
-            if (sleep > 0) {
-                try {
-                    Thread.sleep(sleep);
-                } catch (InterruptedException e) {
-                    MeteorClient.LOG.error("Error when sleeping the slot mover", e);
-                }
-            }
-
             // Exit if user closes screen or exit world
             if (mc.currentScreen == null || !Utils.canUpdate()) break;
 
@@ -432,6 +419,22 @@ public class InventoryTweaks extends Module {
                 if (dumpFilter.get() == ListMode.Blacklist && dumpItems.get().contains(item))
                     continue;
             }
+
+            int sleep;
+            if (initial) {
+                sleep = autoStealInitDelay.get();
+                initial = false;
+            } else sleep = getSleepTime();
+            if (sleep > 0) {
+                try {
+                    Thread.sleep(sleep);
+                } catch (InterruptedException e) {
+                    MeteorClient.LOG.error("Error when sleeping the slot mover", e);
+                }
+            }
+
+            // Exit if user closes screen or exit world
+            if (mc.currentScreen == null || !Utils.canUpdate()) break;
 
             if (steal && stealDrop.get()) {
                 if (dropBackwards.get()) {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

In my Meteor instance, I whitelisted only stone, and when it was at the bottom of the chest filled with other things, there would be a big delay in the chest-stealing.

## Related issues

Mention any issues that this pr relates to.

# How Has This Been Tested?

I used the built in test game instance.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [ ] I have tested the code in both development and production environments.
