### PR TITLE
fix typo of color other's name on compass

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CompassHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CompassHud.java
@@ -39,7 +39,7 @@ public class CompassHud extends HudElement {
     );
 
     private final Setting<SettingColor> colorOther = sgGeneral.add(new ColorSetting.Builder()
-        .name("color-north")
+        .name("color-other")
         .description("Color of other directions.")
         .defaultValue(new SettingColor())
         .build()


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description
Color other option's name was set as color north, simply fixed it

## Related issues
None

# How Has This Been Tested?
works fine

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
