### PR TITLE
Add warnings for incompatible active modules in Highway Builder

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/HighwayBuilder.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/HighwayBuilder.java
@@ -452,7 +452,7 @@ public class HighwayBuilder extends Module {
     public Vec3d start;
     public int blocksBroken, blocksPlaced;
     private final MBlockPos lastBreakingPos = new MBlockPos();
-    private boolean displayInfo;
+    private boolean displayInfo, warned;
     private boolean suspended = true, inventory = true;
     private int placeTimer, breakTimer, count, syncId;
     private final RestockTask restockTask = new RestockTask(this);
@@ -499,14 +499,14 @@ public class HighwayBuilder extends Module {
 
         if (blocksPerTick.get() > 1 && rotation.get().mine) warning("With rotations enabled, you can break at most 1 block per tick.");
         if (placementsPerTick.get() > 1 && rotation.get().place) warning("With rotations enabled, you can place at most 1 block per tick.");
-        //all modules that may cause error now print errors/warnings
+
         if (Modules.get().get(InstantRebreak.class).isActive()) warning("It's recommended to disable the Instant Rebreak module and instead use the 'instantly-rebreak-echests' setting to avoid errors.");
-        if (Modules.get().get(SpeedMine.class).isActive()) warning("It's recommended to disable the Speedmine module and instead use the 'fast-break' setting to avoid errors.");
         if (Modules.get().get(Speed.class).isActive() && dir.diagonal) warning("It's recommended to disable the Speed module to avoid misalignment on diagonals.");
-        if (Modules.get().get(Timer.class).isActive() && dir.diagonal) warning("It's recommended to disable the Timer module to avoid misalignment on diagonals.");
-        if (!Modules.get().get(Velocity.class).isActive()) warning("It's recommended to enable the Velocity module to avoid misalignment.");
-        //it could be tested to print different warnings depending on the amount of blocks being broken per tick but that would need much testing and wouldn't be reliable
-        if (Modules.get().get(NoGhostBlocks.class).isActive()) warning("It's recommended to disable the NoGhostBlocks module to avoid packet kicks and wrong statistics.");
+        if (!Modules.get().get(Velocity.class).isActive()) warning("It's recommended to enable the Velocity module to avoid misalignment (entity pushing, liquid movement).");
+        if (!warned && Modules.get().get(NoGhostBlocks.class).isActive()) {
+            info("The No Ghost Blocks module is useful to prevent desyncs on laggy servers. However, it will also slow Highway Builder down, and comes with the risks of incorrect statistics and packet kicks.");
+            warned = true;
+        }
     }
 
     @Override


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Added checks for incompatible active modules in HighwayBuilder and display clear warning messages when they are enabled.

The module now warns the user if the following modules are active, as they can cause errors or misalignment during building:

- **InstantRebreak** – recommends using `instantly-rebreak-echests` instead  
- **SpeedMine** – recommends using the `fast-break` setting instead  
- **Speed** – warns about diagonal misalignment  
- **Timer** – warns about diagonal misalignment  
- **NoGhostBlocks** – warns about potential block desync errors  

These warnings help prevent common issues and make misconfiguration easier to diagnose.

## Related issues

None

## How Has This Been Tested?

- Tested in IntelliJ
- Tested on 6b6t  

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
