### PR TITLE
Fixed calculating size larger than screen area in GUI

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/DefaultSettingsWidgetFactory.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/DefaultSettingsWidgetFactory.java
@@ -189,7 +189,10 @@ public class DefaultSettingsWidgetFactory extends SettingsWidgetFactory {
     private void stringW(WTable table, StringSetting setting) {
         CharFilter filter = setting.filter == null ? (text, c) -> true : setting.filter;
         Cell<WTextBox> cell = table.add(theme.textBox(setting.get(), setting.placeholder, filter, setting.renderer));
-        if (setting.wide) cell.minWidth(Utils.getWindowWidth() - Utils.getWindowWidth() / 4.0);
+        if (setting.wide) {
+            double guiWidth = Utils.getGuiWidth();
+            cell.minWidth(Math.max(0, guiWidth * 0.75));
+        }
 
         WTextBox textBox = cell.expandX().widget();
         textBox.action = () -> setting.set(textBox.get());

--- a/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
@@ -211,6 +211,14 @@ public class Utils {
         return mc.getWindow().getFramebufferHeight();
     }
 
+    public static int getGuiWidth() {
+        return mc.getWindow().getScaledWidth();
+    }
+
+    public static int getGuiHeight() {
+        return mc.getWindow().getScaledHeight();
+    }
+
     public static void unscaledProjection() {
         float width = mc.getWindow().getFramebufferWidth();
         float height = mc.getWindow().getFramebufferHeight();


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

Framebuffer can be much larger than the actual usable UI width on some displays. That causes minWidth to be set bigger than the screen, so layouts expand past the window.

(I'm not too familiar with how meteors GUI works, this might not be the best solution to this.)

Fixes: #5632 

# How Has This Been Tested?

Tested on various display sizes on both windows and mac. Issue was resolved

MacOS Before and After:
<img width="1710" height="1107" alt="Screenshot 2026-01-21 at 10 42 54 AM" src="https://github.com/user-attachments/assets/be6b8f9b-82fe-45de-813a-194319a789c7" />

<img width="1710" height="1107" alt="Screenshot 2026-01-21 at 10 44 27 AM" src="https://github.com/user-attachments/assets/209d071a-2dc8-4a6e-b009-af4407372eab" />

Windows Before and After:
<img width="2879" height="1799" alt="Screenshot 2026-01-21 114806" src="https://github.com/user-attachments/assets/d67f827f-076b-46c0-98f2-37f9087966a8" />

<img width="2877" height="1799" alt="Screenshot 2026-01-21 114706" src="https://github.com/user-attachments/assets/b2e1918d-448c-41a1-b045-f15ae0895360" />

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
