### PR TITLE
fix NPE in Settings.tick with null container

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/settings/Settings.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/Settings.java
@@ -128,6 +128,8 @@ public class Settings implements ISerializable<Settings>, Iterable<SettingGroup>
     }
 
     public void tick(WContainer settings, GuiTheme theme) {
+        if (settings == null) return;
+
         for (SettingGroup group : groups) {
             for (Setting<?> setting : group) {
                 boolean visible = setting.isVisible();


### PR DESCRIPTION
fixes crash when opening settings for modules without settings

## Type of change

- [x] Bug fix
- [ ] New feature

## Description
opening settings menu for modules which doesn't have any settings crashes because Settings.tick() is called with a null container. as a solution, i added an early return in settings.tick() when settings container is null 

## Related issues
#6090

# How Has This Been Tested?
tested on singleplayer, works fine 

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
