### PR TITLE
Fix mob-age-filter not working for some entity variants 

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/KillAura.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/KillAura.java
@@ -28,14 +28,10 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.Tameable;
-import net.minecraft.entity.mob.EndermanEntity;
-import net.minecraft.entity.mob.HoglinEntity;
-import net.minecraft.entity.mob.PiglinEntity;
-import net.minecraft.entity.mob.ZoglinEntity;
-import net.minecraft.entity.mob.ZombieEntity;
-import net.minecraft.entity.mob.ZombifiedPiglinEntity;
-import net.minecraft.entity.passive.AnimalEntity;
-import net.minecraft.entity.passive.VillagerEntity;
+import net.minecraft.entity.mob.*;
+import net.minecraft.entity.passive.FrogEntity;
+import net.minecraft.entity.passive.ParrotEntity;
+import net.minecraft.entity.passive.PassiveEntity;
 import net.minecraft.entity.passive.WolfEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.*;
@@ -419,9 +415,7 @@ public class KillAura extends Module {
         }
         if (ignorePassive.get()) {
             if (entity instanceof EndermanEntity enderman && !enderman.isAngry()) return false;
-            if (entity instanceof PiglinEntity piglin && !piglin.isAttacking()) return false;
-            if (entity instanceof ZombifiedPiglinEntity zombifiedPiglin && !zombifiedPiglin.isAttacking()) return false;
-            if (entity instanceof WolfEntity wolf && !wolf.isAttacking()) return false;
+            if ((entity instanceof PiglinEntity || entity instanceof ZombifiedPiglinEntity || entity instanceof WolfEntity) && !((MobEntity) entity).isAttacking()) return false;
         }
         if (entity instanceof PlayerEntity player) {
             if (player.isCreative()) return false;
@@ -429,24 +423,24 @@ public class KillAura extends Module {
             if (shieldMode.get() == ShieldMode.Ignore && player.isBlocking()) return false;
             if (player instanceof FakePlayerEntity fakePlayer && fakePlayer.noHit) return false;
         }
-        // Passive mobs with baby variants (animals, villagers)
-        if (entity instanceof AnimalEntity || entity instanceof VillagerEntity) {
-            LivingEntity livingEntity = (LivingEntity) entity;
-            return switch (passiveMobAgeFilter.get()) {
-                case Baby -> livingEntity.isBaby();
-                case Adult -> !livingEntity.isBaby();
-                case Both -> true;
-            };
-        }
-        // Hostile mobs with baby variants (zombies, piglins, hoglins, zoglins)
-        if (entity instanceof ZombieEntity || entity instanceof PiglinEntity
-            || entity instanceof HoglinEntity || entity instanceof ZoglinEntity) {
-            LivingEntity livingEntity = (LivingEntity) entity;
-            return switch (hostileMobAgeFilter.get()) {
-                case Baby -> livingEntity.isBaby();
-                case Adult -> !livingEntity.isBaby();
-                case Both -> true;
-            };
+        if (entity instanceof LivingEntity livingEntity) {
+            // Hostile mobs with baby variants (zombies, piglins, hoglins, zoglins)
+            if (entity instanceof ZombieEntity || entity instanceof PiglinEntity
+                || entity instanceof HoglinEntity || entity instanceof ZoglinEntity) {
+                return switch (hostileMobAgeFilter.get()) {
+                    case Baby -> livingEntity.isBaby();
+                    case Adult -> !livingEntity.isBaby();
+                    case Both -> true;
+                };
+            }
+            // Passive mobs with baby variants (animals, villagers)
+            if (entity instanceof PassiveEntity && (!(entity instanceof FrogEntity || entity instanceof ParrotEntity))) {
+                return switch (passiveMobAgeFilter.get()) {
+                    case Baby -> livingEntity.isBaby();
+                    case Adult -> !livingEntity.isBaby();
+                    case Both -> true;
+                };
+            }
         }
         return true;
     }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [x] New feature

## Description
I extended the age filter check to include all entities with baby variants. The filter was only checking AnimalEntit and ignoring other entities that have baby variants (such as villagers, hoglin, zoglin, piglin villager and zombie variants)

Also splitted age filter options for passive & aggressive mobs (user would like to kill baby zombies but ignore baby animals). 

## Related issues
closes #6088 

# How Has This Been Tested?
Tested in singleplayer, works fine 

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
