### PR TITLE
Fix scrolling for nested views

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/FontFaceSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/FontFaceSettingScreen.java
@@ -61,7 +61,10 @@ public class FontFaceSettingScreen extends WindowScreen {
         };
 
         WView view = add(theme.view()).expandX().widget();
+        // Prevents double scrolling for view-in-view scenario
+        view.maxHeight = window.view.maxHeight - 128;
         view.scrollOnlyWhenMouseOver = false;
+
         table = view.add(theme.table()).expandX().widget();
 
         initTable();

--- a/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/WMeteorView.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/WMeteorView.java
@@ -13,7 +13,7 @@ public class WMeteorView extends WView implements MeteorWidget {
     @Override
     protected void onRender(GuiRenderer renderer, double mouseX, double mouseY, double delta) {
         if (canScroll && hasScrollBar) {
-            renderer.quad(handleX(), handleY(), handleWidth(), handleHeight(), theme().scrollbarColor.get(handlePressed, handleMouseOver));
+            renderer.quad(handleX(), handleY(), handleWidth(), handleHeight(), theme().scrollbarColor.get(focused, handleMouseOver));
         }
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/containers/WContainer.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/containers/WContainer.java
@@ -64,7 +64,13 @@ public abstract class WContainer extends WWidget {
 
     @Override
     public boolean isFocused() {
-        for (Cell<?> cell : cells) if (cell.widget().isFocused()) return true;
+        if (focused) return true;
+
+        for (Cell<?> cell : cells) {
+            if (cell.widget().isFocused())
+                return true;
+        }
+
         return false;
     }
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

### Context / Scenario
There are 2 views, one nested inside the other, and both have `scrollOnlyWhenMouseOver = false`. The user attempts to scroll while not hovering directly over any of the views.

### Changes

**Old logic:**
  The outer view took priority. `propagateEvents` for the inner view returned `false` because the check `(mouseOver && isWidgetInView(widget)) || widget.isFocused()` failed (since `mouseOver` was false).
  Result: `onMouseScrolled` was never called for the inner view, so only the outer view scrolled. (See vid1)

**New logic:**
  The inner view now takes priority.
  1. `propagateEvents` now checks if the widget is a `WView`. If so, it bypasses the strict `mouseOver` check and only validates `isWidgetInView(widget)` (checking for intersection to prevent scrolling invisible/off-screen views).
  2. The inner view handles `onMouseScrolled`. It returns `true` (consuming the event) *only if* it actually scrolled.
  3. If the inner view hits the bounds (top or bottom), it returns `false`, allowing the outer view to handle the scroll event. (See vid2)

### Additional Fixes
In `FontFaceSettingScreen`, I changed the view's max height to be smaller than the window's view max height. This prevents unintended double scrolling in this specific case. (See vid3)

I have also removed `boolean handlePressed` from `WView`, since it could be replace with `focused`. (Epic memory save moment)

## Related issues

fih 🐟

# How Has This Been Tested?

Old view-in-view logic: [vid1](https://ctrlv.tv/08is)
Fixed view-in-view logic: [vid2](https://ctrlv.tv/lUej) <- this is just the view logic showcased
New single scroll font selection: [vid3](https://ctrlv.tv/CUc3) <- this is actually how it looks ingame (without double scroll)

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
