### PR TITLE
Respect sign translation fallbacks for Meteor key spoofing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ logs
 .idea/*
 !.idea/copyright/*
 !.idea/scopes/*
+.vscode/*
+.idea/*

--- a/src/main/java/meteordevelopment/meteorclient/mixin/AbstractSignEditScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/AbstractSignEditScreenMixin.java
@@ -34,7 +34,10 @@ public abstract class AbstractSignEditScreenMixin {
         if (message.getContent() instanceof TranslatableTextContent content) {
             String key = content.getKey();
 
-            if (key.contains("meteor-client")) modified = MutableText.of(new PlainTextContent.Literal(key));
+            if (key.contains("meteor-client")) {
+                String fallback = content.getFallback();
+                modified = MutableText.of(new PlainTextContent.Literal(fallback != null ? fallback : key));
+            }
         }
 
         modified.setStyle(message.getStyle());


### PR DESCRIPTION
## Type of change

- [x ] Bug fix
- [ ] New feature 

AbstractSignEditScreenMixin was turning Meteor translation keys on signs into the raw key string every time. Which broke vanilla behavior for signs that include a fallback. Vanilla returns the fallback when the key can’t be resolved.

This change keeps the existing key protection. But if the sign text is translatable and includes a fallback, it uses that fallback instead. If there isn’t one, it still uses the raw key. This makes Meteor behave like vanilla for fallback-based sign checks and fixes the detection issue.

# How Has This Been Tested?

Gone on a server with a detection and not detected

# Checklist:

- [ x] My code follows the style guidelines of this project.
- [ Not Needed] I have added comments to my code in more complex areas.
- [ x] I have tested the code in both development and production environments.
