### PR TITLE
fix: Minecraft and client hud layering

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/GameRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/GameRendererMixin.java
@@ -15,6 +15,7 @@ import meteordevelopment.meteorclient.events.render.GetFovEvent;
 import meteordevelopment.meteorclient.events.render.Render3DEvent;
 import meteordevelopment.meteorclient.events.render.RenderAfterWorldEvent;
 import meteordevelopment.meteorclient.gui.WidgetScreen;
+import meteordevelopment.meteorclient.mixininterface.IGameRenderer;
 import meteordevelopment.meteorclient.mixininterface.IVec3d;
 import meteordevelopment.meteorclient.renderer.MeteorRenderPipelines;
 import meteordevelopment.meteorclient.renderer.Renderer3D;
@@ -56,7 +57,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Mixin(GameRenderer.class)
-public abstract class GameRendererMixin {
+public abstract class GameRendererMixin implements IGameRenderer {
     @Shadow
     @Final
     private MinecraftClient client;
@@ -173,8 +174,7 @@ public abstract class GameRendererMixin {
             widgetScreen.renderCustom(context, mouseX, mouseY, tickCounter.getDynamicDeltaTicks());
 
             RenderSystem.getDevice().createCommandEncoder().clearDepthTexture(client.getFramebuffer().getDepthAttachment(), 1.0);
-            guiRenderer.render(fogRenderer.getFogBuffer(FogRenderer.FogType.NONE));
-            guiRenderer.incrementFrame();
+            meteor$flushGuiState();
         }
     }
 
@@ -254,5 +254,11 @@ public abstract class GameRendererMixin {
         if (!Modules.get().get(Freecam.class).renderHands() ||
             !Modules.get().get(Zoom.class).renderHands())
             ci.cancel();
+    }
+
+    @Override
+    public void meteor$flushGuiState() {
+        guiRenderer.render(fogRenderer.getFogBuffer(FogRenderer.FogType.NONE));
+        guiRenderer.incrementFrame();
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/mixininterface/IGameRenderer.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixininterface/IGameRenderer.java
@@ -1,0 +1,10 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.mixininterface;
+
+public interface IGameRenderer {
+    void meteor$flushGuiState();
+}

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/HudRenderer.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/HudRenderer.java
@@ -12,6 +12,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.events.meteor.CustomFontChangedEvent;
+import meteordevelopment.meteorclient.mixininterface.IGameRenderer;
 import meteordevelopment.meteorclient.renderer.*;
 import meteordevelopment.meteorclient.renderer.text.CustomTextRenderer;
 import meteordevelopment.meteorclient.renderer.text.Font;
@@ -63,6 +64,8 @@ public class HudRenderer {
     }
 
     public void begin(DrawContext drawContext) {
+        ((IGameRenderer) mc.gameRenderer).meteor$flushGuiState();
+
         Renderer2D.COLOR.begin();
 
         this.drawContext = drawContext;


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

fixes meteor hud being rendered below vanilla minecraft hud. 
you can say that it will tank fps bcs i just split hud rendering and minecraft gui rendering in 2 render calls instead of 1 like in vanilla but on my machine my fps stayed almost the same.

## Related issues

https://github.com/MeteorDevelopment/meteor-client/issues/5868
https://github.com/MeteorDevelopment/meteor-client/issues/6084

# How Has This Been Tested?

Tested on my home pc:
- 418fps - before
- 412fps - after
<img width="1903" height="1015" alt="image" src="https://github.com/user-attachments/assets/87d8c965-745b-41da-b047-e2e7b3f5c3ab" />

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
