### PR TITLE
Fix Auto Eat and Auto Log conflict

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoEat.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoEat.java
@@ -177,6 +177,11 @@ public class AutoEat extends Module {
 
     private void startEating() {
         prevSlot = mc.player.getInventory().getSelectedSlot();
+
+        if (mc.player.age < 20) {
+            return;
+        }
+
         eat();
 
         // Pause auras


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

When you enable Auto Eat and Auto Log both on HealthThreshold. After hitting the Healththreshold on both, you get kicked like usual. Then after rejoin you get stuck in an infinte loop of eating.

## Related issues

#6140

# How Has This Been Tested?

Before:

https://github.com/user-attachments/assets/bcb46256-8632-4b03-b817-add17cf59fe1

After

https://github.com/user-attachments/assets/fd161b3f-0ba9-4803-a891-f4aab611f9a0


# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
