### PR TITLE
Show nearby players in the friends menu

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/FriendsTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/FriendsTab.java
@@ -21,21 +21,16 @@ import meteordevelopment.meteorclient.systems.friends.Friends;
 import meteordevelopment.meteorclient.utils.entity.EntityUtils;
 import meteordevelopment.meteorclient.utils.misc.NbtUtils;
 import meteordevelopment.meteorclient.utils.network.MeteorExecutor;
-import meteordevelopment.meteorclient.utils.player.PlayerUtils;
+
 import net.minecraft.client.gui.screen.Screen;
-import meteordevelopment.meteorclient.gui.widgets.WAccount;
-import net.minecraft.client.gui.widget.TextIconButtonWidget;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.player.PlayerEntity;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class FriendsTab extends Tab {
 
-    private static final Logger log = LoggerFactory.getLogger(FriendsTab.class);
 
     public FriendsTab() {
         super("Friends");


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Add an button in the friends, that displays all players in render distance as possible friends were you can chose any player and add them as an new friend, allowing for easy adding friends without typos in there names.

## Related issues

Mention any issues that this pr relates to.
#6180 

# How Has This Been Tested?

<img width="1920" height="1080" alt="Screenshot 2026-03-05 155326" src="https://github.com/user-attachments/assets/484543e7-24b5-493c-ab33-365aa5b11405" />
<img width="1920" height="1080" alt="Screenshot 2026-03-05 155336" src="https://github.com/user-attachments/assets/df4c5204-bb03-42a4-a5ad-71c5d01faad6" />
<img width="1920" height="1080" alt="Screenshot 2026-03-05 155356" src="https://github.com/user-attachments/assets/8239cd1b-5d6a-4586-a11e-f7999691c2d0" />


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
