### PR TITLE
Show Prefix and Suffix in Nametags

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Nametags.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Nametags.java
@@ -128,8 +128,8 @@ public class Nametags extends Module {
     );
 
     private final Setting<Boolean> displayPrefix = sgPlayers.add(new BoolSetting.Builder()
-        .name("prefix/suffix")
-        .description("Shows the player's prefix/suffix.")
+        .name("use-display-name")
+        .description("Uses the players server display name instead of their account name.")
         .defaultValue(false)
         .build()
     );
@@ -422,7 +422,7 @@ public class Nametags extends Module {
         else {
             if (displayPrefix.get()) name = player.getDisplayName().getString();
             else name = player.getName().getString();
-        };
+        }
 
         // Health
         float absorption = player.getAbsorptionAmount();


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Adding an option to the module nametags, that allows users to toggle if prefix's and suffix's are supposed to be displayed in there nametags. This is for easy checking which rank they have.

## Related issues

Mention any issues that this pr relates to.
#6056

# How Has This Been Tested?

Videos or screenshots of the changes if applicable.

https://github.com/user-attachments/assets/3f1342f4-6cf1-4505-8979-293cd4cf9526

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
