### PR TITLE
Fix dropdown menus not rendering under certain conditions

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/input/WDropdown.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/input/WDropdown.java
@@ -112,9 +112,9 @@ public abstract class WDropdown<T> extends WPressable {
         animProgress = MathHelper.clamp(animProgress, 0, 1);
 
         WView view = getView();
-        boolean rootInView = view == null || view.isWidgetInView(root);
+        boolean buttonInView = view == null || view.isWidgetInView(this);
 
-        if (!render && animProgress > 0 && rootInView) {
+        if (!render && animProgress > 0 && buttonInView) {
             renderer.absolutePost(() -> {
                 renderer.scissorStart(x, y + height, width, root.height * animProgress);
                 root.render(renderer, mouseX, mouseY, delta);


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Fix dropdown menus with no additional options not rendering when at the bottom of scrollable views

## Related issues

Couldn't find an issue related to this

# How Has This Been Tested?

Before, its still clickable it just doesn't render

https://github.com/user-attachments/assets/eb1a8b24-65cd-40b2-b0a7-81cb18fb54c7


After, renders

https://github.com/user-attachments/assets/9b8f40e9-97b1-4964-bbad-56ae6eb503e1


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
