### PR TITLE
Fix damage in VClipCommand

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/commands/commands/VClipCommand.java
+++ b/src/main/java/meteordevelopment/meteorclient/commands/commands/VClipCommand.java
@@ -49,10 +49,10 @@ public class VClipCommand extends Command {
                 // No vehicle version
                 // For each 10 blocks, send a player move packet with no delta
                 for (int packetNumber = 0; packetNumber < (packetsRequired - 1); packetNumber++) {
-                    mc.player.networkHandler.sendPacket(new PlayerMoveC2SPacket.OnGroundOnly(true, mc.player.horizontalCollision));
+                    mc.player.networkHandler.sendPacket(new PlayerMoveC2SPacket.OnGroundOnly(false, mc.player.horizontalCollision));
                 }
                 // Now send the final player move packet
-                mc.player.networkHandler.sendPacket(new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(), mc.player.getY() + blocks, mc.player.getZ(), true, mc.player.horizontalCollision));
+                mc.player.networkHandler.sendPacket(new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(), mc.player.getY() + blocks, mc.player.getZ(), false, mc.player.horizontalCollision));
                 mc.player.setPosition(mc.player.getX(), mc.player.getY() + blocks, mc.player.getZ());
             }
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Before, the player would take damage when using the VClip Command. Thats because the onGround value in the packets sent was true, so i've changed it to false which fixed it.

## Related issues

None

# How Has This Been Tested?

Singleplayer world before and after

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [ ] I have tested the code in both development and production environments.
