### PR TITLE
fix: incorrect gui state flush

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/InGameHudMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/InGameHudMixin.java
@@ -8,6 +8,7 @@ package meteordevelopment.meteorclient.mixin;
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.events.render.Render2DEvent;
+import meteordevelopment.meteorclient.mixininterface.IGameRenderer;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.misc.BetterChat;
 import meteordevelopment.meteorclient.systems.modules.render.Freecam;
@@ -27,12 +28,15 @@ import org.spongepowered.asm.mixin.injection.ModifyArgs;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
 
+import static meteordevelopment.meteorclient.MeteorClient.mc;
+
 @Mixin(InGameHud.class)
 public abstract class InGameHudMixin {
     @Shadow public abstract void clear();
 
     @Inject(method = "render", at = @At("TAIL"))
     private void onRender(DrawContext context, RenderTickCounter tickCounter, CallbackInfo ci) {
+        ((IGameRenderer) mc.gameRenderer).meteor$flushGuiState();
         context.createNewRootLayer();
 
         Profilers.get().push(MeteorClient.MOD_ID + "_render_2d");

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/HudRenderer.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/HudRenderer.java
@@ -64,8 +64,6 @@ public class HudRenderer {
     }
 
     public void begin(DrawContext drawContext) {
-        ((IGameRenderer) mc.gameRenderer).meteor$flushGuiState();
-
         Renderer2D.COLOR.begin();
 
         this.drawContext = drawContext;


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

Fixes vanilla font rendering in hud by moving `meteor$flushGuiState` before posting 2D render event

## Related issues

https://github.com/MeteorDevelopment/meteor-client/issues/6223

# How Has This Been Tested?

<img width="1906" height="1021" alt="image" src="https://github.com/user-attachments/assets/21ec1b64-a2eb-4c19-bb13-f15206012ab8" />

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
