### PR TITLE
[WIP] refactor: unbloated color scheme settings for block ESP.

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/StorageESP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/StorageESP.java
@@ -32,6 +32,7 @@ import meteordevelopment.orbit.EventHandler;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.ChestBlock;
+import net.minecraft.block.MapColor;
 import net.minecraft.block.entity.*;
 import net.minecraft.block.enums.ChestType;
 import net.minecraft.util.math.BlockPos;
@@ -105,48 +106,6 @@ public class StorageESP extends Module {
         .build()
     );
 
-    private final Setting<SettingColor> chest = sgGeneral.add(new ColorSetting.Builder()
-        .name("chest")
-        .description("The color of chests.")
-        .defaultValue(new SettingColor(255, 160, 0, 255))
-        .build()
-    );
-
-    private final Setting<SettingColor> trappedChest = sgGeneral.add(new ColorSetting.Builder()
-        .name("trapped-chest")
-        .description("The color of trapped chests.")
-        .defaultValue(new SettingColor(255, 0, 0, 255))
-        .build()
-    );
-
-    private final Setting<SettingColor> barrel = sgGeneral.add(new ColorSetting.Builder()
-        .name("barrel")
-        .description("The color of barrels.")
-        .defaultValue(new SettingColor(255, 160, 0, 255))
-        .build()
-    );
-
-    private final Setting<SettingColor> shulker = sgGeneral.add(new ColorSetting.Builder()
-        .name("shulker")
-        .description("The color of Shulker Boxes.")
-        .defaultValue(new SettingColor(255, 160, 0, 255))
-        .build()
-    );
-
-    private final Setting<SettingColor> enderChest = sgGeneral.add(new ColorSetting.Builder()
-        .name("ender-chest")
-        .description("The color of Ender Chests.")
-        .defaultValue(new SettingColor(120, 0, 255, 255))
-        .build()
-    );
-
-    private final Setting<SettingColor> other = sgGeneral.add(new ColorSetting.Builder()
-        .name("other")
-        .description("The color of furnaces, dispensers, droppers and hoppers.")
-        .defaultValue(new SettingColor(140, 140, 140, 255))
-        .build()
-    );
-
     private final Setting<Double> fadeDistance = sgGeneral.add(new DoubleSetting.Builder()
         .name("fade-distance")
         .description("The distance at which the color will fade.")
@@ -191,20 +150,14 @@ public class StorageESP extends Module {
 
         if (!storageBlocks.get().contains(blockEntity.getType())) return;
 
-        if (blockEntity instanceof TrappedChestBlockEntity) lineColor.set(trappedChest.get()); // Must come before ChestBlockEntity as it is the superclass of TrappedChestBlockEntity
-        else if (blockEntity instanceof ChestBlockEntity) lineColor.set(chest.get());
-        else if (blockEntity instanceof BarrelBlockEntity) lineColor.set(barrel.get());
-        else if (blockEntity instanceof ShulkerBoxBlockEntity) lineColor.set(shulker.get());
-        else if (blockEntity instanceof EnderChestBlockEntity) lineColor.set(enderChest.get());
-        else if (blockEntity instanceof AbstractFurnaceBlockEntity || blockEntity instanceof BrewingStandBlockEntity || blockEntity instanceof ChiseledBookshelfBlockEntity || blockEntity instanceof CrafterBlockEntity || blockEntity instanceof DispenserBlockEntity || blockEntity instanceof DecoratedPotBlockEntity || blockEntity instanceof HopperBlockEntity) lineColor.set(other.get());
-        else return;
-
-        render = true;
+        Color c = new Color(blockEntity.getCachedState().getBlock().getDefaultMapColor().getRenderColor(MapColor.Brightness.NORMAL));
+        lineColor.set(c);
 
         if (shapeMode.get() == ShapeMode.Sides || shapeMode.get() == ShapeMode.Both) {
-            sideColor.set(lineColor);
+            sideColor.set(c);
             sideColor.a = fillOpacity.get();
         }
+        render = true;
     }
 
     @Override

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/BlockESP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/BlockESP.java
@@ -21,6 +21,7 @@ import meteordevelopment.meteorclient.utils.render.color.RainbowColors;
 import meteordevelopment.meteorclient.utils.render.color.SettingColor;
 import meteordevelopment.orbit.EventHandler;
 import net.minecraft.block.Block;
+import net.minecraft.util.Colors;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.chunk.Chunk;
@@ -53,10 +54,7 @@ public class BlockESP extends Module {
         .defaultValue(
             new ESPBlockData(
                 ShapeMode.Lines,
-                new SettingColor(0, 255, 200),
-                new SettingColor(0, 255, 200, 25),
-                true,
-                new SettingColor(0, 255, 200, 125)
+                true
             )
         )
         .build()
@@ -86,8 +84,6 @@ public class BlockESP extends Module {
 
     public BlockESP() {
         super(Categories.Render, "block-esp", "Renders specified blocks through walls.", "search");
-
-        RainbowColors.register(this::onTickRainbow);
     }
 
     @Override
@@ -110,13 +106,6 @@ public class BlockESP extends Module {
             chunks.clear();
             groups.clear();
         }
-    }
-
-    private void onTickRainbow() {
-        if (!isActive()) return;
-
-        defaultBlockConfig.get().tickRainbow();
-        for (ESPBlockData blockData : blockConfigs.get().values()) blockData.tickRainbow();
     }
 
     ESPBlockData getBlockData(Block block) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPBlock.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPBlock.java
@@ -47,7 +47,7 @@ public class ESPBlock {
     public final int x, y, z;
     private BlockState state;
     public int neighbours;
-
+    public int color;
     public ESPGroup group;
 
     public boolean loaded = true;
@@ -190,8 +190,15 @@ public class ESPBlock {
         ESPBlockData blockData = blockEsp.getBlockData(state.getBlock());
 
         ShapeMode shapeMode = blockData.shapeMode;
-        Color lineColor = blockData.lineColor;
-        Color sideColor = blockData.sideColor;
+        int c = this.color;
+
+        Color lineColor = new Color(c);
+        Color sideColor = new Color(
+            (c >> 16) & 255,
+            (c >> 8) & 255,
+            c & 255,
+            50
+        );
 
         if (neighbours == 0) {
             event.renderer.box(x1, y1, z1, x2, y2, z2, sideColor, lineColor, shapeMode, 0);

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPBlockData.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPBlockData.java
@@ -1,8 +1,3 @@
-/*
- * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
- * Copyright (c) Meteor Development.
- */
-
 package meteordevelopment.meteorclient.systems.modules.render.blockesp;
 
 import meteordevelopment.meteorclient.gui.GuiTheme;
@@ -13,27 +8,17 @@ import meteordevelopment.meteorclient.settings.GenericSetting;
 import meteordevelopment.meteorclient.settings.IBlockData;
 import meteordevelopment.meteorclient.settings.IGeneric;
 import meteordevelopment.meteorclient.utils.misc.IChangeable;
-import meteordevelopment.meteorclient.utils.render.color.SettingColor;
 import net.minecraft.block.Block;
 import net.minecraft.nbt.NbtCompound;
 
 public class ESPBlockData implements IGeneric<ESPBlockData>, IChangeable, IBlockData<ESPBlockData> {
     public ShapeMode shapeMode;
-    public SettingColor lineColor;
-    public SettingColor sideColor;
-
     public boolean tracer;
-    public SettingColor tracerColor;
+    public boolean changed;
 
-    private boolean changed;
-
-    public ESPBlockData(ShapeMode shapeMode, SettingColor lineColor, SettingColor sideColor, boolean tracer, SettingColor tracerColor) {
+    public ESPBlockData(ShapeMode shapeMode, boolean tracer) {
         this.shapeMode = shapeMode;
-        this.lineColor = lineColor;
-        this.sideColor = sideColor;
-
         this.tracer = tracer;
-        this.tracerColor = tracerColor;
     }
 
     @Override
@@ -55,42 +40,24 @@ public class ESPBlockData implements IGeneric<ESPBlockData>, IChangeable, IBlock
         changed = true;
     }
 
-    public void tickRainbow() {
-        lineColor.update();
-        sideColor.update();
-        tracerColor.update();
-    }
-
     @Override
     public ESPBlockData set(ESPBlockData value) {
         shapeMode = value.shapeMode;
-        lineColor.set(value.lineColor);
-        sideColor.set(value.sideColor);
-
         tracer = value.tracer;
-        tracerColor.set(value.tracerColor);
-
         changed = value.changed;
-
         return this;
     }
 
     @Override
     public ESPBlockData copy() {
-        return new ESPBlockData(shapeMode, new SettingColor(lineColor), new SettingColor(sideColor), tracer, new SettingColor(tracerColor));
+        return new ESPBlockData(shapeMode, tracer);
     }
 
     @Override
     public NbtCompound toTag() {
         NbtCompound tag = new NbtCompound();
-
         tag.putString("shapeMode", shapeMode.name());
-        tag.put("lineColor", lineColor.toTag());
-        tag.put("sideColor", sideColor.toTag());
-
         tag.putBoolean("tracer", tracer);
-        tag.put("tracerColor", tracerColor.toTag());
-
         tag.putBoolean("changed", changed);
 
         return tag;
@@ -99,12 +66,7 @@ public class ESPBlockData implements IGeneric<ESPBlockData>, IChangeable, IBlock
     @Override
     public ESPBlockData fromTag(NbtCompound tag) {
         shapeMode = ShapeMode.valueOf(tag.getString("shapeMode", ""));
-        lineColor.fromTag(tag.getCompoundOrEmpty("lineColor"));
-        sideColor.fromTag(tag.getCompoundOrEmpty("sideColor"));
-
         tracer = tag.getBoolean("tracer", false);
-        tracerColor.fromTag(tag.getCompoundOrEmpty("tracerColor"));
-
         changed = tag.getBoolean("changed", false);
 
         return this;

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPBlockDataScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPBlockDataScreen.java
@@ -54,34 +54,6 @@ public class ESPBlockDataScreen extends WindowScreen {
             .build()
         );
 
-        sgGeneral.add(new ColorSetting.Builder()
-            .name("line-color")
-            .description("Color of lines.")
-            .defaultValue(new SettingColor(0, 255, 200))
-            .onModuleActivated(settingColorSetting -> settingColorSetting.get().set(blockData.lineColor))
-            .onChanged(settingColor -> {
-                if (!blockData.lineColor.equals(settingColor)) {
-                    blockData.lineColor.set(settingColor);
-                    onChanged();
-                }
-            })
-            .build()
-        );
-
-        sgGeneral.add(new ColorSetting.Builder()
-            .name("side-color")
-            .description("Color of sides.")
-            .defaultValue(new SettingColor(0, 255, 200, 25))
-            .onModuleActivated(settingColorSetting -> settingColorSetting.get().set(blockData.sideColor))
-            .onChanged(settingColor -> {
-                if (!blockData.sideColor.equals(settingColor)) {
-                    blockData.sideColor.set(settingColor);
-                    onChanged();
-                }
-            })
-            .build()
-        );
-
         sgTracer.add(new BoolSetting.Builder()
             .name("tracer")
             .description("If tracer line is allowed to this block.")
@@ -90,20 +62,6 @@ public class ESPBlockDataScreen extends WindowScreen {
             .onChanged(aBoolean -> {
                 if (blockData.tracer != aBoolean) {
                     blockData.tracer = aBoolean;
-                    onChanged();
-                }
-            })
-            .build()
-        );
-
-        sgTracer.add(new ColorSetting.Builder()
-            .name("tracer-color")
-            .description("Color of tracer line.")
-            .defaultValue(new SettingColor(0, 255, 200, 125))
-            .onModuleActivated(settingColorSetting -> settingColorSetting.get().set(blockData.tracerColor))
-            .onChanged(settingColor -> {
-                if (!blockData.tracerColor.equals(settingColor)) {
-                    blockData.tracerColor.set(settingColor);
                     onChanged();
                 }
             })

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPChunk.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPChunk.java
@@ -10,6 +10,7 @@ import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import meteordevelopment.meteorclient.events.render.Render3DEvent;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.MapColor;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkSectionPos;
 import net.minecraft.world.Heightmap;
@@ -36,6 +37,10 @@ public class ESPChunk {
 
     public void add(BlockPos blockPos, boolean update) {
         ESPBlock block = new ESPBlock(blockPos.getX(), blockPos.getY(), blockPos.getZ());
+
+        BlockState state = mc.world.getBlockState(blockPos);
+
+        block.color = state.getBlock().getDefaultMapColor().getRenderColor(MapColor.Brightness.NORMAL);
 
         if (blocks == null) blocks = new Long2ObjectOpenHashMap<>(64);
         blocks.put(ESPBlock.getKey(blockPos), block);

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPGroup.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/blockesp/ESPGroup.java
@@ -10,6 +10,7 @@ import meteordevelopment.meteorclient.events.render.Render3DEvent;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.utils.misc.UnorderedArrayList;
 import meteordevelopment.meteorclient.utils.render.RenderUtils;
+import meteordevelopment.meteorclient.utils.render.color.Color;
 import net.minecraft.block.Block;
 
 import java.util.ArrayDeque;
@@ -141,8 +142,12 @@ public class ESPGroup {
     public void render(Render3DEvent event) {
         ESPBlockData blockData = blockEsp.getBlockData(block);
 
-        if (blockData.tracer) {
-            event.renderer.line(RenderUtils.center.x, RenderUtils.center.y, RenderUtils.center.z, sumX / blocks.size() + 0.5, sumY / blocks.size() + 0.5, sumZ / blocks.size() + 0.5, blockData.tracerColor);
+        if (blockData.tracer && !blocks.isEmpty()) {
+            ESPBlock b = blocks.getFirst();
+
+            int c = b.color;
+
+            event.renderer.line(RenderUtils.center.x, RenderUtils.center.y, RenderUtils.center.z, sumX / blocks.size() + 0.5, sumY / blocks.size() + 0.5, sumZ / blocks.size() + 0.5, new Color(c));
         }
     }
 }


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

there is _1364 survival obtainable items, and around 850-900 survival obtainable blocks for your museum, depending on what type of blocks youre going for_ in minecraft, and configuration of color scheme for each block is the most bloated thing i ever saw in minecraft clinets. 

This PR removes color scheme configuration from both `StorageESP` and `BlockESP ` and uses MC API to get block color instead.

## Related issues

I didnt saw any

# How Has This Been Tested?

<img width="1920" height="1080" alt="2026-03-23_12 19 42" src="https://github.com/user-attachments/assets/ed15ddca-d5b2-4ae1-9f68-3044e249fb53" />

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
