### PR TITLE
Fix no fall disconnect crashing occur

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/NoFall.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/NoFall.java
@@ -114,6 +114,7 @@ public class NoFall extends Module {
 
     @EventHandler
     private void onSendPacket(PacketEvent.Send event) {
+        if (mc.player == null) return;
         if (pauseOnMace.get() && mc.player.getMainHandStack().getItem() instanceof MaceItem) return;
         if (mc.player.getAbilities().creativeMode
             || !(event.packet instanceof PlayerMoveC2SPacket)


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Fixes bug where if the user goes through with a server disconnect or reconnect, mc.player may be null when using NoFall module, crashing the client. This can occur when other modules from other plugins use nofall and tries to use nofall on server disconnect; crashing the client. This error is caused by Meteor, and not these clients and is just because of there being no check. This just fixes the error that I encountered in crash.

Crash log can be seen here:
```[12:39:43] [Render thread/ERROR]: Failed to handle packet net.minecraft.class_8588@63ecd7cf, disconnecting
java.lang.NullPointerException: Cannot invoke "net.minecraft.class_746.method_6047()" because "this.mc.field_1724" is null
	at knot//meteordevelopment.meteorclient.systems.modules.movement.NoFall.onSendPacket(NoFall.java:117)
	at knot//meteordevelopment.orbit.listeners.LambdaListener.call(LambdaListener.java:83)
	at knot//meteordevelopment.orbit.EventBus.post(EventBus.java:67)
	at knot//net.minecraft.class_2535.handler$dbc000$meteor-client$onSendPacketHead(class_2535.java:3766)
	at knot//net.minecraft.class_2535.method_10752(class_2535.java)
	at knot//net.minecraft.class_2535.method_10743(class_2535.java:288)
	at knot//net.minecraft.class_8673.method_52787(class_8673.java:386)
	at knot//net.minecraft.class_634.method_52798(class_634.java:1004)
	at knot//net.minecraft.class_8588.method_52272(class_8588.java:26)
	at knot//net.minecraft.class_8588.method_65081(class_8588.java:12)
	at knot//net.minecraft.class_11980$class_11981.method_74450(class_11980.java:55)
	at knot//net.minecraft.class_11980.method_74449(class_11980.java:38)
	at knot//net.minecraft.class_310.method_1523(class_310.java:1337)
	at knot//net.minecraft.class_310.method_1514(class_310.java:966)
	at knot//net.minecraft.client.main.Main.main(Main.java:250)
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:514)
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:72)
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)
	at org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:115)
	at org.prismlauncher.EntryPoint.listen(EntryPoint.java:129)
	at org.prismlauncher.EntryPoint.main(EntryPoint.java:70)
[12:39:43] [Render thread/WARN]: Client disconnected with reason: Network Protocol Error
[12:39:44] [Render thread/INFO]: Connecting to mc.minehut.gg, 25565
[12:39:44] [Server Connector #19/ERROR]: Couldn't connect to server
java.lang.NullPointerException: Cannot invoke "net.minecraft.class_746.method_6047()" because "this.mc.field_1724" is null
	at knot//meteordevelopment.meteorclient.systems.modules.movement.NoFall.onSendPacket(NoFall.java:117)
	at knot//meteordevelopment.orbit.listeners.LambdaListener.call(LambdaListener.java:83)
	at knot//meteordevelopment.orbit.EventBus.post(EventBus.java:67)
	at knot//net.minecraft.class_2535.handler$dbc000$meteor-client$onSendPacketHead(class_2535.java:3766)
	at knot//net.minecraft.class_2535.method_10752(class_2535.java)
	at knot//net.minecraft.class_2535.method_10743(class_2535.java:288)
	at knot//net.minecraft.class_412$1.run(class_412.java:133)
[12:39:45] [Render thread/INFO]: Connecting to mc.minehut.gg, 25565
[12:39:45] [Server Connector #20/ERROR]: Couldn't connect to server
java.lang.NullPointerException: Cannot invoke "net.minecraft.class_746.method_6047()" because "this.mc.field_1724" is null
	at knot//meteordevelopment.meteorclient.systems.modules.movement.NoFall.onSendPacket(NoFall.java:117)
	at knot//meteordevelopment.orbit.listeners.LambdaListener.call(LambdaListener.java:83)
	at knot//meteordevelopment.orbit.EventBus.post(EventBus.java:67)
	at knot//net.minecraft.class_2535.handler$dbc000$meteor-client$onSendPacketHead(class_2535.java:3766)
	at knot//net.minecraft.class_2535.method_10752(class_2535.java)
	at knot//net.minecraft.class_2535.method_10743(class_2535.java:288)
	at knot//net.minecraft.class_412$1.run(class_412.java:133)
[12:39:46] [Server Pinger #2/ERROR]: Failed to ping server mc.minehut.gg:25565
java.lang.NullPointerException: Cannot invoke "net.minecraft.class_746.method_6047()" because "this.mc.field_1724" is null
	at knot//meteordevelopment.meteorclient.systems.modules.movement.NoFall.onSendPacket(NoFall.java:117)
	at knot//meteordevelopment.orbit.listeners.LambdaListener.call(LambdaListener.java:83)
	at knot//meteordevelopment.orbit.EventBus.post(EventBus.java:67)
	at knot//net.minecraft.class_2535.handler$dbc000$meteor-client$onSendPacketHead(class_2535.java:3766)
	at knot//net.minecraft.class_2535.method_10752(class_2535.java)
	at knot//net.minecraft.class_2535.method_10743(class_2535.java:288)
	at knot//net.minecraft.class_644.method_3003(class_644.java:154)
	at knot//net.minecraft.class_4267$class_4270.method_73437(class_4267.java:280)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
[12:39:46] [Server Pinger #1/ERROR]: Can't ping neo-3.arqonara.com:25243: Unknown host
[12:39:47] [Render thread/INFO]: Connecting to mc.minehut.gg, 25565
[12:39:47] [Server Connector #21/ERROR]: Couldn't connect to server
java.lang.NullPointerException: Cannot invoke "net.minecraft.class_746.method_6047()" because "this.mc.field_1724" is null
	at knot//meteordevelopment.meteorclient.systems.modules.movement.NoFall.onSendPacket(NoFall.java:117)
	at knot//meteordevelopment.orbit.listeners.LambdaListener.call(LambdaListener.java:83)
	at knot//meteordevelopment.orbit.EventBus.post(EventBus.java:67)
	at knot//net.minecraft.class_2535.handler$dbc000$meteor-client$onSendPacketHead(class_2535.java:3766)
	at knot//net.minecraft.class_2535.method_10752(class_2535.java)
	at knot//net.minecraft.class_2535.method_10743(class_2535.java:288)
	at knot//net.minecraft.class_412$1.run(class_412.java:133)
[12:39:48] [Server Pinger #3/ERROR]: Failed to ping server play.navelya.net:25565
java.lang.NullPointerException: Cannot invoke "net.minecraft.class_746.method_6047()" because "this.mc.field_1724" is null
	at knot//meteordevelopment.meteorclient.systems.modules.movement.NoFall.onSendPacket(NoFall.java:117)
	at knot//meteordevelopment.orbit.listeners.LambdaListener.call(LambdaListener.java:83)
	at knot//meteordevelopment.orbit.EventBus.post(EventBus.java:67)
	at knot//net.minecraft.class_2535.handler$dbc000$meteor-client$onSendPacketHead(class_2535.java:3766)
	at knot//net.minecraft.class_2535.method_10752(class_2535.java)
	at knot//net.minecraft.class_2535.method_10743(class_2535.java:288)
	at knot//net.minecraft.class_644.method_3003(class_644.java:154)
	at knot//net.minecraft.class_4267$class_4270.method_73437(class_4267.java:280)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
[12:39:51] [Render thread/INFO]: Loaded 1470 recipes
[12:39:51] [Render thread/INFO]: Loaded 1584 advancements
[12:39:51] [Render thread/INFO]: Applied 0 biome modifications to 0 of 65 new biomes in 5.176 ms
[12:39:51] [Server thread/INFO]: Starting integrated minecraft server version 1.21.11
[12:39:51] [Server thread/INFO]: Generating keypair
[12:39:53] [Server thread/INFO]: [STDOUT]: Density function compilation finished in 592.0 ms
[12:39:53] [Server thread/INFO]: Using TheSpeedyObjectFactory with Unsafe
[12:39:53] [Server thread/INFO]: [STDOUT]: Density function compilation finished in 10.82 ms
[12:39:53] [Server thread/INFO]: [STDOUT]: Density function compilation finished in 10.94 ms
[12:39:53] [Server thread/INFO]: Loading 0 persistent chunks...
[12:39:53] [Server thread/INFO]: Preparing spawn area: 16%
---- Minecraft Crash Report ----
// Shall we play a game?
Time: 2026-03-28 12:39:54
Description: Load world
java.lang.NullPointerException: Cannot invoke "net.minecraft.class_746.method_6047()" because "this.mc.field_1724" is null
	at knot//meteordevelopment.meteorclient.systems.modules.movement.NoFall.onSendPacket(NoFall.java:117)
	at knot//meteordevelopment.orbit.listeners.LambdaListener.call(LambdaListener.java:83)
	at knot//meteordevelopment.orbit.EventBus.post(EventBus.java:67)
	at knot//net.minecraft.class_2535.handler$dbc000$meteor-client$onSendPacketHead(class_2535.java:3766)
	at knot//net.minecraft.class_2535.method_10752(class_2535.java)
	at knot//net.minecraft.class_2535.method_10743(class_2535.java:288)
	at knot//net.minecraft.class_310.method_29610(class_310.java:2208)
	at knot//net.minecraft.class_7196.method_57773(class_7196.java:411)
	at knot//net.minecraft.class_7196.method_57776(class_7196.java:406)
	at knot//net.minecraft.class_7196.method_57777(class_7196.java:373)
	at java.base/java.util.concurrent.CompletableFuture$UniAccept.tryFire(CompletableFuture.java:718)
	at java.base/java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:482)
	at knot//net.minecraft.class_1255.method_18859(class_1255.java:169)
	at knot//net.minecraft.class_4093.method_18859(class_4093.java:23)
	at knot//net.minecraft.class_1255.method_16075(class_1255.java:143)
	at knot//net.minecraft.class_1255.method_5383(class_1255.java:124)
	at knot//net.minecraft.class_310.method_1523(class_310.java:1339)
	at knot//net.minecraft.class_310.method_1514(class_310.java:966)
	at knot//net.minecraft.client.main.Main.main(Main.java:250)
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:514)
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:72)
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)
	at org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:115)
	at org.prismlauncher.EntryPoint.listen(EntryPoint.java:129)
	at org.prismlauncher.EntryPoint.main(EntryPoint.java:70)
A detailed walkthrough of the error, its code path and all known details is as follows:
---------------------------------------------------------------------------------------
-- Head --
Thread: Render thread
Stacktrace:
```
## Related issues

Mention any issues that this pr relates to.

# How Has This Been Tested?

On a singleplayer world, and on a multiplayer world (Minehut), when force-disconnecting while NoFall is active.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
