### PR TITLE
Fix auto-fish connect unknown world crashing occur

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoFish.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoFish.java
@@ -100,6 +100,7 @@ public class AutoFish extends Module {
 
     @EventHandler
     private void onTick(TickEvent.Pre event) {
+        if (mc.player == null || mc.world == null) return;
         int bestRodSlot = findBestRod();
 
         if (autoSwitch.get() && bestRodSlot != -1 && mc.player.getInventory().getSelectedSlot() != bestRodSlot) {


### PR DESCRIPTION
Fix crash when user joins a server and autofish tries to fish (because of a different module calls it, but it lags due to slow connection).

## Type of change

- [x] Bug fix
- [ ] New feature

## Description
Fixes a bug where if the auto fish module is called before the world loads, Meteor crashes. This can occur due to an addon calling the auto fish module before the world loads.

This PR fixes this bug and crash from my crash log.
```
[20:26:19] [Render thread/ERROR]: Unreported exception thrown!
java.lang.NullPointerException: Cannot invoke "net.minecraft.class_746.method_31548()" because "this.mc.field_1724" is null
	at knot//meteordevelopment.meteorclient.systems.modules.player.AutoFish.findBestRod(AutoFish.java:165)
	at knot//meteordevelopment.meteorclient.systems.modules.player.AutoFish.onTick(AutoFish.java:103)
	at knot//meteordevelopment.orbit.listeners.LambdaListener.call(LambdaListener.java:83)
	at knot//meteordevelopment.orbit.EventBus.post(EventBus.java:53)
	at knot//net.minecraft.class_310.handler$dep000$meteor-client$onPreTick(class_310.java:23714)
	at knot//net.minecraft.class_310.method_1574(class_310.java)
	at knot//net.minecraft.class_310.method_1523(class_310.java:1354)
	at knot//net.minecraft.class_310.method_1514(class_310.java:966)
	at knot//net.minecraft.client.main.Main.main(Main.java:250)
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:514)
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:72)
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)
	at org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:115)
	at org.prismlauncher.EntryPoint.listen(EntryPoint.java:129)
	at org.prismlauncher.EntryPoint.main(EntryPoint.java:70)
---- Minecraft Crash Report ----
// I let you down. Sorry :(
Time: 2026-04-09 20:26:21
Description: Unexpected error
java.lang.NullPointerException: Cannot invoke "net.minecraft.class_746.method_31548()" because "this.mc.field_1724" is null
	at knot//meteordevelopment.meteorclient.systems.modules.player.AutoFish.findBestRod(AutoFish.java:165)
	at knot//meteordevelopment.meteorclient.systems.modules.player.AutoFish.onTick(AutoFish.java:103)
	at knot//meteordevelopment.orbit.listeners.LambdaListener.call(LambdaListener.java:83)
	at knot//meteordevelopment.orbit.EventBus.post(EventBus.java:53)
	at knot//net.minecraft.class_310.handler$dep000$meteor-client$onPreTick(class_310.java:23714)
	at knot//net.minecraft.class_310.method_1574(class_310.java)
	at knot//net.minecraft.class_310.method_1523(class_310.java:1354)
	at knot//net.minecraft.class_310.method_1514(class_310.java:966)
	at knot//net.minecraft.client.main.Main.main(Main.java:250)
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:514)
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:72)
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)
	at org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:115)
	at org.prismlauncher.EntryPoint.listen(EntryPoint.java:129)
	at org.prismlauncher.EntryPoint.main(EntryPoint.java:70)
```
## Related issues

Mention any issues that this pr relates to.

# How Has This Been Tested?

This PR has been tested on a singleplayer world and on the same condtions that the bug occured on in a mutli-player server (Minehut)

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
