### PR TITLE
Allowed controlling the position and visibility of accounts and proxies button

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/MultiplayerScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MultiplayerScreenMixin.java
@@ -6,6 +6,7 @@
 package meteordevelopment.meteorclient.mixin;
 
 import meteordevelopment.meteorclient.gui.GuiThemes;
+import meteordevelopment.meteorclient.systems.config.Config;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.player.NameProtect;
 import meteordevelopment.meteorclient.systems.proxies.Proxies;
@@ -42,6 +43,15 @@ public abstract class MultiplayerScreenMixin extends Screen {
     @Unique
     private ButtonWidget proxies;
 
+    @Unique
+    private static final int BUTTON_WIDTH = 75;
+    @Unique
+    private static final int BUTTON_HEIGHT = 20;
+    @Unique
+    private static final int MARGIN = 3;
+    @Unique
+    private static final int GAP = 2;
+
     public MultiplayerScreenMixin(Text title) {
         super(title);
     }
@@ -57,28 +67,60 @@ public abstract class MultiplayerScreenMixin extends Screen {
         if (accounts == null) {
             accounts = addDrawableChild(
                 new ButtonWidget.Builder(Text.literal("Accounts"), button -> client.setScreen(GuiThemes.get().accountsScreen()))
-                    .size(75, 20)
+                    .size(BUTTON_WIDTH, BUTTON_HEIGHT)
                     .build()
             );
         }
-        accounts.setPosition(this.width - 75 - 3, 3);
 
         if (proxies == null) {
             proxies = addDrawableChild(
-                    new ButtonWidget.Builder(Text.literal("Proxies"), button -> client.setScreen(GuiThemes.get().proxiesScreen()))
-                        .size(75, 20)
-                        .build()
-                );
+                new ButtonWidget.Builder(Text.literal("Proxies"), button -> client.setScreen(GuiThemes.get().proxiesScreen()))
+                    .size(BUTTON_WIDTH, BUTTON_HEIGHT)
+                    .build()
+            );
         }
-        proxies.setPosition(this.width - 75 - 3 - 75 - 2, 3);
+
+        Config config = Config.get();
+        boolean accountsVisible = config.showAccountButton.get();
+        boolean proxiesVisible = config.showProxiesButton.get();
+        Config.ButtonAnchor accountAnchor = config.accountButtonAnchor.get();
+        Config.ButtonAnchor proxiesAnchor = config.proxiesButtonAnchor.get();
+
+        accounts.visible = accountsVisible;
+        proxies.visible = proxiesVisible;
+
+        positionButton(accounts, accountAnchor, proxiesVisible && proxiesAnchor == accountAnchor, true);
+        positionButton(proxies, proxiesAnchor, accountsVisible && accountAnchor == proxiesAnchor, false);
+    }
+
+    @Unique
+    private void positionButton(ButtonWidget button, Config.ButtonAnchor anchor, boolean sharingCorner, boolean isAccounts) {
+        int leftOffset  = sharingCorner && isAccounts  ? BUTTON_WIDTH + GAP : 0;
+        int rightOffset = sharingCorner && !isAccounts ? BUTTON_WIDTH + GAP : 0;
+
+        switch (anchor) {
+            case TopRight    -> button.setPosition(this.width  - MARGIN - BUTTON_WIDTH - rightOffset, MARGIN);
+            case TopLeft     -> button.setPosition(MARGIN + leftOffset, MARGIN);
+            case BottomLeft  -> button.setPosition(MARGIN + leftOffset, this.height - MARGIN - BUTTON_HEIGHT);
+            case BottomRight -> button.setPosition(this.width  - MARGIN - BUTTON_WIDTH - rightOffset, this.height - MARGIN - BUTTON_HEIGHT);
+        }
     }
 
     @Override
     public void render(DrawContext context, int mouseX, int mouseY, float deltaTicks) {
         super.render(context, mouseX, mouseY, deltaTicks);
 
-        int x = 3;
-        int y = 3;
+        // Shifts the top left account and proxy text to right if buttons are also top left
+        Config config = Config.get();
+        int x = MARGIN;
+        if (config.showProxiesButton.get() && config.proxiesButtonAnchor.get() == Config.ButtonAnchor.TopLeft) {
+            x += BUTTON_WIDTH + GAP;
+        }
+        if (config.showAccountButton.get() && config.accountButtonAnchor.get() == Config.ButtonAnchor.TopLeft) {
+            x += BUTTON_WIDTH + GAP;
+        }
+
+        int y = MARGIN;
 
         // Logged in as
         context.drawTextWithShadow(mc.textRenderer, loggedInAs, x, y, textColor1);

--- a/src/main/java/meteordevelopment/meteorclient/mixin/MultiplayerScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MultiplayerScreenMixin.java
@@ -110,8 +110,13 @@ public abstract class MultiplayerScreenMixin extends Screen {
     public void render(DrawContext context, int mouseX, int mouseY, float deltaTicks) {
         super.render(context, mouseX, mouseY, deltaTicks);
 
-        // Shifts the top left account and proxy text to right if buttons are also top left
         Config config = Config.get();
+
+        if (!config.showAccountStatus.get() && !config.showProxiesStatus.get()) {
+            return;
+        }
+
+        // Shifts the top left account and proxy text to right if buttons are also top left
         int x = MARGIN;
         if (config.showProxiesButton.get() && config.proxiesButtonAnchor.get() == Config.ButtonAnchor.TopLeft) {
             x += BUTTON_WIDTH + GAP;
@@ -123,10 +128,16 @@ public abstract class MultiplayerScreenMixin extends Screen {
         int y = MARGIN;
 
         // Logged in as
-        context.drawTextWithShadow(mc.textRenderer, loggedInAs, x, y, textColor1);
-        context.drawTextWithShadow(mc.textRenderer, Modules.get().get(NameProtect.class).getName(client.getSession().getUsername()), x + loggedInAsLength, y, textColor2);
+        if (config.showAccountStatus.get()) {
+            context.drawTextWithShadow(mc.textRenderer, loggedInAs, x, y, textColor1);
+            context.drawTextWithShadow(mc.textRenderer, Modules.get().get(NameProtect.class).getName(client.getSession().getUsername()), x + loggedInAsLength, y, textColor2);
 
-        y += textRenderer.fontHeight + 2;
+            y += textRenderer.fontHeight + 2;
+        }
+
+        if (!config.showProxiesStatus.get()) {
+            return;
+        }
 
         // Proxy
         Proxy proxy = Proxies.get().getEnabled();

--- a/src/main/java/meteordevelopment/meteorclient/mixin/MultiplayerScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/MultiplayerScreenMixin.java
@@ -81,20 +81,20 @@ public abstract class MultiplayerScreenMixin extends Screen {
         }
 
         Config config = Config.get();
-        boolean accountsVisible = config.showAccountButton.get();
-        boolean proxiesVisible = config.showProxiesButton.get();
-        Config.ButtonAnchor accountAnchor = config.accountButtonAnchor.get();
-        Config.ButtonAnchor proxiesAnchor = config.proxiesButtonAnchor.get();
+        Config.ButtonPosition accountPos = config.accountButtonAnchor.get();
+        Config.ButtonPosition proxiesPos = config.proxiesButtonAnchor.get();
+        boolean accountsVisible = accountPos != Config.ButtonPosition.Hidden;
+        boolean proxiesVisible = proxiesPos != Config.ButtonPosition.Hidden;
 
         accounts.visible = accountsVisible;
         proxies.visible = proxiesVisible;
 
-        positionButton(accounts, accountAnchor, proxiesVisible && proxiesAnchor == accountAnchor, true);
-        positionButton(proxies, proxiesAnchor, accountsVisible && accountAnchor == proxiesAnchor, false);
+        positionButton(accounts, accountPos, proxiesVisible && proxiesPos == accountPos, true);
+        positionButton(proxies, proxiesPos, accountsVisible && accountPos == proxiesPos, false);
     }
 
     @Unique
-    private void positionButton(ButtonWidget button, Config.ButtonAnchor anchor, boolean sharingCorner, boolean isAccounts) {
+    private void positionButton(ButtonWidget button, Config.ButtonPosition anchor, boolean sharingCorner, boolean isAccounts) {
         int leftOffset  = sharingCorner && isAccounts  ? BUTTON_WIDTH + GAP : 0;
         int rightOffset = sharingCorner && !isAccounts ? BUTTON_WIDTH + GAP : 0;
 
@@ -103,6 +103,7 @@ public abstract class MultiplayerScreenMixin extends Screen {
             case TopLeft     -> button.setPosition(MARGIN + leftOffset, MARGIN);
             case BottomLeft  -> button.setPosition(MARGIN + leftOffset, this.height - MARGIN - BUTTON_HEIGHT);
             case BottomRight -> button.setPosition(this.width  - MARGIN - BUTTON_WIDTH - rightOffset, this.height - MARGIN - BUTTON_HEIGHT);
+            default -> button.setPosition(this.width  - MARGIN - BUTTON_WIDTH - rightOffset, MARGIN); // Top right
         }
     }
 
@@ -118,10 +119,10 @@ public abstract class MultiplayerScreenMixin extends Screen {
 
         // Shifts the top left account and proxy text to right if buttons are also top left
         int x = MARGIN;
-        if (config.showProxiesButton.get() && config.proxiesButtonAnchor.get() == Config.ButtonAnchor.TopLeft) {
+        if (config.proxiesButtonAnchor.get() != Config.ButtonPosition.Hidden && config.proxiesButtonAnchor.get() == Config.ButtonPosition.TopLeft) {
             x += BUTTON_WIDTH + GAP;
         }
-        if (config.showAccountButton.get() && config.accountButtonAnchor.get() == Config.ButtonAnchor.TopLeft) {
+        if (config.accountButtonAnchor.get() != Config.ButtonPosition.Hidden && config.accountButtonAnchor.get() == Config.ButtonPosition.TopLeft) {
             x += BUTTON_WIDTH + GAP;
         }
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/config/Config.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/config/Config.java
@@ -118,6 +118,13 @@ public class Config extends System<Config> {
         .build()
     );
 
+    public final Setting<Boolean> showAccountStatus = sgVisual.add(new BoolSetting.Builder()
+        .name("account-status")
+        .description("Shows information about the current account in the multiplayer screen.")
+        .defaultValue(true)
+        .build()
+    );
+
     public final Setting<Boolean> showProxiesButton = sgVisual.add(new BoolSetting.Builder()
         .name("proxies-button")
         .description("Shows the proxies button in the multiplayer screen.")
@@ -130,6 +137,13 @@ public class Config extends System<Config> {
         .description("Where the proxies button is displayed")
         .defaultValue(ButtonAnchor.TopRight)
         .visible(showProxiesButton::get)
+        .build()
+    );
+
+    public final Setting<Boolean> showProxiesStatus = sgVisual.add(new BoolSetting.Builder()
+        .name("proxy-status")
+        .description("Shows information about the current proxy in the multiplayer screen.")
+        .defaultValue(true)
         .build()
     );
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/config/Config.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/config/Config.java
@@ -103,18 +103,10 @@ public class Config extends System<Config> {
         .build()
     );
 
-    public final Setting<Boolean> showAccountButton = sgVisual.add(new BoolSetting.Builder()
+    public final Setting<ButtonPosition> accountButtonAnchor = sgVisual.add(new EnumSetting.Builder<ButtonPosition>()
         .name("accounts-button")
-        .description("Shows the accounts button in the multiplayer screen.")
-        .defaultValue(true)
-        .build()
-    );
-
-    public final Setting<ButtonAnchor> accountButtonAnchor = sgVisual.add(new EnumSetting.Builder<ButtonAnchor>()
-        .name("accounts-button-position")
-        .description("Where the accounts button is displayed")
-        .defaultValue(ButtonAnchor.TopRight)
-        .visible(showAccountButton::get)
+        .description("Controls the position and visibility of the accounts button in the multiplayer screen.")
+        .defaultValue(ButtonPosition.TopRight)
         .build()
     );
 
@@ -125,18 +117,10 @@ public class Config extends System<Config> {
         .build()
     );
 
-    public final Setting<Boolean> showProxiesButton = sgVisual.add(new BoolSetting.Builder()
+    public final Setting<ButtonPosition> proxiesButtonAnchor = sgVisual.add(new EnumSetting.Builder<ButtonPosition>()
         .name("proxies-button")
-        .description("Shows the proxies button in the multiplayer screen.")
-        .defaultValue(true)
-        .build()
-    );
-
-    public final Setting<ButtonAnchor> proxiesButtonAnchor = sgVisual.add(new EnumSetting.Builder<ButtonAnchor>()
-        .name("proxies-button-position")
-        .description("Where the proxies button is displayed")
-        .defaultValue(ButtonAnchor.TopRight)
-        .visible(showProxiesButton::get)
+        .description("Controls the position and visibility of the proxies button in the multiplayer screen.")
+        .defaultValue(ButtonPosition.TopRight)
         .build()
     );
 
@@ -251,10 +235,11 @@ public class Config extends System<Config> {
         return list;
     }
 
-    public enum ButtonAnchor {
+    public enum ButtonPosition {
         TopLeft,
         TopRight,
         BottomLeft,
         BottomRight,
+        Hidden,
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/config/Config.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/config/Config.java
@@ -103,6 +103,36 @@ public class Config extends System<Config> {
         .build()
     );
 
+    public final Setting<Boolean> showAccountButton = sgVisual.add(new BoolSetting.Builder()
+        .name("accounts-button")
+        .description("Shows the accounts button in the multiplayer screen.")
+        .defaultValue(true)
+        .build()
+    );
+
+    public final Setting<ButtonAnchor> accountButtonAnchor = sgVisual.add(new EnumSetting.Builder<ButtonAnchor>()
+        .name("accounts-button-position")
+        .description("Where the accounts button is displayed")
+        .defaultValue(ButtonAnchor.TopRight)
+        .visible(showAccountButton::get)
+        .build()
+    );
+
+    public final Setting<Boolean> showProxiesButton = sgVisual.add(new BoolSetting.Builder()
+        .name("proxies-button")
+        .description("Shows the proxies button in the multiplayer screen.")
+        .defaultValue(true)
+        .build()
+    );
+
+    public final Setting<ButtonAnchor> proxiesButtonAnchor = sgVisual.add(new EnumSetting.Builder<ButtonAnchor>()
+        .name("proxies-button-position")
+        .description("Where the proxies button is displayed")
+        .defaultValue(ButtonAnchor.TopRight)
+        .visible(showProxiesButton::get)
+        .build()
+    );
+
     // Modules
 
     public final Setting<List<Module>> hiddenModules = sgModules.add(new ModuleListSetting.Builder()
@@ -205,5 +235,12 @@ public class Config extends System<Config> {
         List<String> list = new ArrayList<>();
         for (NbtElement item : tag.getListOrEmpty(key)) list.add(item.asString().orElse(""));
         return list;
+    }
+
+    public enum ButtonAnchor {
+        TopLeft,
+        TopRight,
+        BottomLeft,
+        BottomRight,
     }
 }


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Allowed controlling the position and visibility of accounts and proxies button as well as the visibility of accounts and proxies status in multiplayer screen.

# Related issues

https://discord.com/channels/689197705683140636/1494232273577312346

# How Has This Been Tested?

<img width="1710" height="1107" alt="Screenshot 2026-04-16 at 5 19 16 PM" src="https://github.com/user-attachments/assets/5417ba54-59b9-4c96-a9cb-1253e8dd8372" />
<img width="1710" height="1107" alt="Screenshot 2026-04-16 at 5 19 28 PM" src="https://github.com/user-attachments/assets/a799c447-bb2c-4cff-87ec-c4ed91e772a1" />
<img width="1710" height="1107" alt="Screenshot 2026-04-16 at 5 19 53 PM" src="https://github.com/user-attachments/assets/29fa1934-bf8e-4724-a1e6-14865338c6ec" />
<img width="1710" height="1107" alt="Screenshot 2026-04-16 at 5 33 15 PM" src="https://github.com/user-attachments/assets/d0d96a11-e500-448e-bb49-139c2874722b" />
<img width="1710" height="1107" alt="Screenshot 2026-04-16 at 5 33 27 PM" src="https://github.com/user-attachments/assets/1e1d6982-800c-496a-8390-faa716b68ff6" />
<img width="1184" height="549" alt="Screenshot 2026-04-16 at 5 42 32 PM" src="https://github.com/user-attachments/assets/c4ba91e7-154d-4cee-90a3-e98120622305" />

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
