### PR TITLE
Add translation blocking to prevent server-side mod detection

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayNetworkHandlerMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayNetworkHandlerMixin.java
@@ -38,6 +38,9 @@ import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.ItemEntity;
 import net.minecraft.network.ClientConnection;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtList;
+import net.minecraft.network.packet.s2c.common.ResourcePackSendS2CPacket;
 import net.minecraft.network.packet.s2c.play.*;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.chunk.WorldChunk;
@@ -132,6 +135,56 @@ public abstract class ClientPlayNetworkHandlerMixin extends ClientCommonNetworkH
 
         if (itemEntity instanceof ItemEntity && entity == client.player) {
             MeteorClient.EVENT_BUS.post(PickItemsEvent.get(((ItemEntity) itemEntity).getStack(), packet.getStackAmount()));
+        }
+    }
+
+    @Inject(method = "onBlockEntityUpdate", at = @At("HEAD"))
+    private void onBlockEntityUpdate(BlockEntityUpdateS2CPacket packet, CallbackInfo ci) {
+        NbtCompound nbt = packet.getNbt();
+        if (nbt != null) {
+            stripTranslateTags(nbt);
+        }
+    }
+
+    @Unique
+    private void stripTranslateTags(NbtCompound nbt) {
+        // Strip translate tags from sign NBT to prevent server-side translation detection
+        // This blocks servers from detecting mods by checking if translation keys of certan mods or clients are present if so they are present they are exposed to the server for having those mods or clients
+        if (nbt.contains("front_text")) {
+            nbt.getCompound("front_text").ifPresent(frontText -> {
+                if (frontText.contains("messages")) {
+                    frontText.getList("messages").ifPresent(messages -> {
+                        for (int i = 0; i < messages.size(); i++) {
+                            messages.getCompound(i).ifPresent(message -> {
+                                if (message.contains("translate")) {
+                                    message.remove("translate");
+                                    message.getString("fallback").ifPresent(fallback -> {
+                                        message.putString("text", fallback);
+                                    });
+                                }
+                            });
+                        }
+                    });
+                }
+            });
+        }
+        if (nbt.contains("back_text")) {
+            nbt.getCompound("back_text").ifPresent(backText -> {
+                if (backText.contains("messages")) {
+                    backText.getList("messages").ifPresent(messages -> {
+                        for (int i = 0; i < messages.size(); i++) {
+                            messages.getCompound(i).ifPresent(message -> {
+                                if (message.contains("translate")) {
+                                    message.remove("translate");
+                                    message.getString("fallback").ifPresent(fallback -> {
+                                        message.putString("text", fallback);
+                                    });
+                                }
+                            });
+                        }
+                    });
+                }
+            });
         }
     }
 


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Servers like Donut SMP check for translation keys on signs to detect mods. So I added a mixin that strips the `translate` tag from sign NBT packets when they come from the server. It replaces them with the `fallback` text instead. This way translation keys like `key.meteor-client.open-gui` don't get resolved, so servers can't detect which mods you have.

It works on all translation keys on signs (front and back), and it's always-on so you don't need to toggle it.

## How It Works

The mixin intercepts `BlockEntityUpdateS2CPacket` packets when they're received from the server. It looks at the NBT data in the packet and checks both `front_text` and `back_text` for `messages` arrays. For each message in the array, if it contains a `translate` tag, the mixin removes that tag and replaces it with a `text` tag set to the `fallback` value. This prevents the client from trying to resolve the translation key, so the server can't detect if the key exists on your client.

The fallback text is the plain text version that servers send as a backup in case translation fails. By using this instead of the translation key, the sign still displays readable text but without exposing which mods or resource packs you have installed.

## What It Works On

- All translation keys on signs (front and back text)
- All mods and resource packs that use translation keys
- Any server that uses translation key checking for mod detection
- Always-on, So you don't have to look or find it So you don't have to deal with accidental getting banned

Since it works at the NBT packet level, it blocks translation keys from anything - mods, resource packs, or any other source that uses translate tags on signs.

## Related issues

None

# How Has This Been Tested?

Built it and went on a server with translation key checks - didn't get detected.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
