### PR TITLE
Add Weather Changer module in Render category

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
@@ -527,6 +527,7 @@ public class Modules extends System<Modules> {
         add(new VoidESP());
         add(new WallHack());
         add(new WaypointsModule());
+        add(new WeatherChanger());
         add(new Xray());
         add(new Zoom());
     }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/WeatherChanger.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/WeatherChanger.java
@@ -1,0 +1,94 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.systems.modules.render;
+
+import meteordevelopment.meteorclient.events.packets.PacketEvent;
+import meteordevelopment.meteorclient.events.world.TickEvent;
+import meteordevelopment.meteorclient.settings.DoubleSetting;
+import meteordevelopment.meteorclient.settings.Setting;
+import meteordevelopment.meteorclient.settings.SettingGroup;
+import meteordevelopment.meteorclient.systems.modules.Categories;
+import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.orbit.EventHandler;
+import net.minecraft.network.protocol.game.ClientboundGameEventPacket;
+
+public class WeatherChanger extends Module {
+    private final SettingGroup sgGeneral = settings.getDefaultGroup();
+
+    private final Setting<Double> rainLevel = sgGeneral.add(new DoubleSetting.Builder()
+        .name("rain-level")
+        .description("The specified rain level to be set.")
+        .defaultValue(0)
+        .sliderRange(0, 1)
+        .build()
+    );
+
+    private final Setting<Double> thunderLevel = sgGeneral.add(new DoubleSetting.Builder()
+        .name("thunder-level")
+        .description("The specified thunder level to be set.")
+        .defaultValue(0)
+        .sliderRange(0, 1)
+        .build()
+    );
+
+    private float oldThunderLevel;
+    private float oldRainLevel;
+
+    public WeatherChanger() {
+        super(Categories.Render, "weather-changer", "Allows you to override the world's current weather.");
+    }
+
+    @Override
+    public void onActivate() {
+        if (mc.level == null) {
+            return;
+        }
+
+        oldThunderLevel = mc.level.getThunderLevel(1f);
+        oldRainLevel = mc.level.getRainLevel(1f);
+    }
+
+    @Override
+    public void onDeactivate() {
+        if (mc.level == null) {
+            return;
+        }
+
+        mc.level.setRainLevel(oldRainLevel);
+        mc.level.setThunderLevel(oldThunderLevel);
+    }
+
+    @EventHandler
+    private void onPacketReceive(PacketEvent.Receive event) {
+        if (event.packet instanceof ClientboundGameEventPacket packet) {
+            ClientboundGameEventPacket.Type type = packet.getEvent();
+
+            if (type == ClientboundGameEventPacket.START_RAINING
+                || type == ClientboundGameEventPacket.STOP_RAINING
+                || type == ClientboundGameEventPacket.THUNDER_LEVEL_CHANGE
+                || type == ClientboundGameEventPacket.RAIN_LEVEL_CHANGE) {
+
+                if (type == ClientboundGameEventPacket.THUNDER_LEVEL_CHANGE) {
+                    oldThunderLevel = packet.getParam();
+                } else if (type == ClientboundGameEventPacket.RAIN_LEVEL_CHANGE) {
+                    oldRainLevel = packet.getParam();
+                }
+
+                event.cancel();
+            }
+        }
+    }
+
+    @EventHandler
+    private void onTick(TickEvent.Post event) {
+        if (mc.level == null) {
+            return;
+        }
+
+        mc.level.setRainLevel(rainLevel.get().floatValue());
+        mc.level.setThunderLevel(thunderLevel.get().floatValue());
+    }
+}

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/WeatherChanger.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/WeatherChanger.java
@@ -43,9 +43,7 @@ public class WeatherChanger extends Module {
 
     @Override
     public void onActivate() {
-        if (mc.level == null) {
-            return;
-        }
+        if (mc.level == null) return;
 
         oldThunderLevel = mc.level.getThunderLevel(1f);
         oldRainLevel = mc.level.getRainLevel(1f);
@@ -53,9 +51,7 @@ public class WeatherChanger extends Module {
 
     @Override
     public void onDeactivate() {
-        if (mc.level == null) {
-            return;
-        }
+        if (mc.level == null) return;
 
         mc.level.setRainLevel(oldRainLevel);
         mc.level.setThunderLevel(oldThunderLevel);
@@ -63,30 +59,30 @@ public class WeatherChanger extends Module {
 
     @EventHandler
     private void onPacketReceive(PacketEvent.Receive event) {
-        if (event.packet instanceof ClientboundGameEventPacket packet) {
-            ClientboundGameEventPacket.Type type = packet.getEvent();
+        if (!(event.packet instanceof ClientboundGameEventPacket packet)) return;
 
-            if (type == ClientboundGameEventPacket.START_RAINING
-                || type == ClientboundGameEventPacket.STOP_RAINING
-                || type == ClientboundGameEventPacket.THUNDER_LEVEL_CHANGE
-                || type == ClientboundGameEventPacket.RAIN_LEVEL_CHANGE) {
+        ClientboundGameEventPacket.Type type = packet.getEvent();
+        if (!isWeatherPacket(type)) return;
 
-                if (type == ClientboundGameEventPacket.THUNDER_LEVEL_CHANGE) {
-                    oldThunderLevel = packet.getParam();
-                } else if (type == ClientboundGameEventPacket.RAIN_LEVEL_CHANGE) {
-                    oldRainLevel = packet.getParam();
-                }
-
-                event.cancel();
-            }
+        if (type == ClientboundGameEventPacket.THUNDER_LEVEL_CHANGE) {
+            oldThunderLevel = packet.getParam();
+        } else if (type == ClientboundGameEventPacket.RAIN_LEVEL_CHANGE) {
+            oldRainLevel = packet.getParam();
         }
+
+        event.cancel();
+    }
+
+    private boolean isWeatherPacket(ClientboundGameEventPacket.Type type) {
+        return type == ClientboundGameEventPacket.START_RAINING
+            || type == ClientboundGameEventPacket.STOP_RAINING
+            || type == ClientboundGameEventPacket.THUNDER_LEVEL_CHANGE
+            || type == ClientboundGameEventPacket.RAIN_LEVEL_CHANGE;
     }
 
     @EventHandler
     private void onTick(TickEvent.Post event) {
-        if (mc.level == null) {
-            return;
-        }
+        if (mc.level == null) return;
 
         mc.level.setRainLevel(rainLevel.get().floatValue());
         mc.level.setThunderLevel(thunderLevel.get().floatValue());


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description
Added a new module "Weather Changer" in the Render category. It has two settings for the thunder level and rain level which are used to modify the `ClientLevel`. Works very similarly to Time Changer.

## Related issues
Closes #5706

# How Has This Been Tested?
Example 1: Rain level is set to a fractional value, the weather appears to be in a "halfway" state.
<details><summary>expand</summary><img width="1917" height="1030" alt="image" src="https://github.com/user-attachments/assets/5aa90323-f0fd-4305-9c5a-7e312d82e1f3" /></details>

Example 2: Rain level is set all the way to 1, and the rain appears vanilla.
<details><summary>expand</summary><img width="1916" height="1031" alt="image" src="https://github.com/user-attachments/assets/3cba3f5a-0568-41d5-a18b-02c8089ee5a0" /></details>

Example 3: The thunder level is also set to 1, the sky dims even darker as if there was a thunderstorm.
<details><summary>expand</summary><img width="1918" height="1030" alt="image" src="https://github.com/user-attachments/assets/5f06e10d-2f1b-4110-86f2-7c1ab82801c3" /></details>

Has also been tested in multiplayer.

# Checklist:
- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
