### PR TITLE
fix: use correct configuration kind in jij config

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -118,7 +118,7 @@ java {
 // Source: https://github.com/florianreuth/BaseProject/blob/main/src/main/kotlin/de/florianreuth/baseproject/Fabric.kt
 // Licensed under Apache License 2.0
 val jijExcluded = setOf("org.slf4j", "jsr305")
-listOf("jij", "implementation", "include").forEach { configName ->
+listOf("api", "implementation", "include").forEach { configName ->
     configurations.named(configName).configure {
         defaultDependencies {
             configurations.getByName("jij").incoming.resolutionResult.allComponents


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Fix the build script to properly re-export jij libs.

## Related issues

None.

# How Has This Been Tested?

Local maven publish and usage in the 26.1 addon template.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
