### PR TITLE
fix: proper food item check

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Offhand.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Offhand.java
@@ -11,6 +11,7 @@ import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.systems.modules.Modules;
+import meteordevelopment.meteorclient.utils.Utils;
 import meteordevelopment.meteorclient.utils.misc.input.KeyAction;
 import meteordevelopment.meteorclient.utils.player.FindItemResult;
 import meteordevelopment.meteorclient.utils.player.InvUtils;
@@ -250,7 +251,7 @@ public class Offhand extends Module {
         return mc.player.getMainHandItem().getItem() == Items.BOW
             || mc.player.getMainHandItem().getItem() == Items.TRIDENT
             || mc.player.getMainHandItem().getItem() == Items.CROSSBOW
-            || mc.player.getMainHandItem().getItem().components().has(DataComponents.FOOD);
+            || Utils.isFood(mc.player.getMainHandItem());
     }
 
     @Override

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoEat.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoEat.java
@@ -54,7 +54,7 @@ public class AutoEat extends Module {
             Items.SPIDER_EYE,
             Items.SUSPICIOUS_STEW
         )
-        .filter(item -> item.components().get(DataComponents.FOOD) != null)
+        .filter(Utils::isFood)
         .build()
     );
 
@@ -147,7 +147,7 @@ public class AutoEat extends Module {
             }
 
             // Check if the item in current slot is not food anymore
-            if (mc.player.getInventory().getItem(slot).get(DataComponents.FOOD) == null) {
+            if (!Utils.isFood(mc.player.getInventory().getItem(slot))) {
                 int newSlot = findSlot();
 
                 // Stop if no food found
@@ -269,10 +269,11 @@ public class AutoEat extends Module {
         slot = findSlot();
         if (slot == -1) return false;
 
-        FoodProperties food = mc.player.getInventory().getItem(slot).get(DataComponents.FOOD);
-        if (food == null) return false;
+        ItemStack item = mc.player.getInventory().getItem(slot);
+        FoodProperties prop = item.get(DataComponents.FOOD);
+        if (prop == null || !Utils.isFood(item)) return false;
 
-        return (mc.player.getFoodData().needsFood() || food.canAlwaysEat());
+        return (mc.player.getFoodData().needsFood() || prop.canAlwaysEat());
     }
 
     /**
@@ -282,8 +283,7 @@ public class AutoEat extends Module {
     private int findSlot() {
         // prefer offhand
         Item offHandItem = mc.player.getOffhandItem().getItem();
-        FoodProperties offHandFood = offHandItem.components().get(DataComponents.FOOD);
-        if (offHandFood != null && !blacklist.get().contains(offHandItem)) return SlotUtils.OFFHAND;
+        if (Utils.isFood(offHandItem) && !blacklist.get().contains(offHandItem)) return SlotUtils.OFFHAND;
 
         // if offhand empty, prefer best in hotbar
         int slot = findBestFood(SlotUtils.HOTBAR_START, SlotUtils.HOTBAR_END);
@@ -305,6 +305,7 @@ public class AutoEat extends Module {
             // Skip if item isn't food
             ItemStack stack = mc.player.getInventory().getItem(i);
             FoodProperties food = stack.get(DataComponents.FOOD);
+            if (!Utils.isFood(stack)) continue;
             if (food == null) continue;
 
             // Skip if item is in blacklist

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/HighwayBuilder.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/HighwayBuilder.java
@@ -44,7 +44,6 @@ import net.minecraft.client.multiplayer.MultiPlayerGameMode;
 import net.minecraft.client.player.ClientInput;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.protocol.game.ClientboundContainerSetContentPacket;
@@ -1168,7 +1167,7 @@ public class HighwayBuilder extends Module {
                                 eject = false;
                                 break;
                             }
-                            if (stack.has(DataComponents.FOOD) && !Modules.get().get(AutoEat.class).blacklist.get().contains(stack.getItem())) {
+                            if (Utils.isFood(stack) && !Modules.get().get(AutoEat.class).blacklist.get().contains(stack.getItem())) {
                                 eject = false;
                                 break;
                             }
@@ -1431,7 +1430,7 @@ public class HighwayBuilder extends Module {
                                 stop = false;
                                 break;
                             }
-                            if (b.restockTask.food && stack.has(DataComponents.FOOD) && !Modules.get().get(AutoEat.class).blacklist.get().contains(stack.getItem())) {
+                            if (b.restockTask.food && Utils.isFood(stack) && !Modules.get().get(AutoEat.class).blacklist.get().contains(stack.getItem())) {
                                 stop = false;
                                 break;
                             }
@@ -1451,7 +1450,7 @@ public class HighwayBuilder extends Module {
                     boolean restockOccurred = (
                         (b.restockTask.materials && (hasItem(b, stack -> stack.getItem() instanceof BlockItem bi && b.blocksToPlace.get().contains(bi.getBlock())) || b.blocksToPlace.get().contains(Blocks.OBSIDIAN) && countItem(b, itemStack -> itemStack.getItem() == Items.ENDER_CHEST) > b.saveEchests.get())) ||
                             (b.restockTask.pickaxes && countItem(b, itemStack -> itemStack.is(ItemTags.PICKAXES)) > b.savePickaxes.get()) ||
-                            (b.restockTask.food && hasItem(b, itemStack -> itemStack.has(DataComponents.FOOD) && !Modules.get().get(AutoEat.class).blacklist.get().contains(itemStack.getItem())))
+                            (b.restockTask.food && hasItem(b, itemStack -> Utils.isFood(itemStack) && !Modules.get().get(AutoEat.class).blacklist.get().contains(itemStack.getItem())))
                     );
 
                     if (restockOccurred) {
@@ -1529,7 +1528,7 @@ public class HighwayBuilder extends Module {
                 if (b.restockTask.pickaxes)
                     slotsPulled += countSlots(b, itemStack -> itemStack.is(ItemTags.PICKAXES)) - b.savePickaxes.get();
                 if (b.restockTask.food)
-                    slotsPulled += countSlots(b, itemStack -> itemStack.has(DataComponents.FOOD) && !Modules.get().get(AutoEat.class).blacklist.get().contains(itemStack.getItem()));
+                    slotsPulled += countSlots(b, itemStack -> Utils.isFood(itemStack) && !Modules.get().get(AutoEat.class).blacklist.get().contains(itemStack.getItem()));
 
 
                 // whether we have pulled the minimum amount of items we want
@@ -1644,7 +1643,7 @@ public class HighwayBuilder extends Module {
                     if (grabFromInventory(inv, itemStack -> itemStack.is(ItemTags.PICKAXES))) return true;
                 }
                 if (b.restockTask.food) {
-                    return grabFromInventory(inv, itemStack -> itemStack.has(DataComponents.FOOD) && !Modules.get().get(AutoEat.class).blacklist.get().contains(itemStack.getItem()));
+                    return grabFromInventory(inv, itemStack -> Utils.isFood(itemStack) && !Modules.get().get(AutoEat.class).blacklist.get().contains(itemStack.getItem()));
                 }
 
                 return false;
@@ -1673,7 +1672,7 @@ public class HighwayBuilder extends Module {
                                 return true;
                         }
                         if (b.restockTask.pickaxes && stack.is(ItemTags.PICKAXES)) return true;
-                        if (b.restockTask.food && stack.has(DataComponents.FOOD) && !Modules.get().get(AutoEat.class).blacklist.get().contains(stack.getItem()))
+                        if (b.restockTask.food && Utils.isFood(stack) && !Modules.get().get(AutoEat.class).blacklist.get().contains(stack.getItem()))
                             return true;
                     }
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
@@ -196,6 +196,15 @@ public class Utils {
         return false;
     }
 
+    public static boolean isFood(ItemStack stack) {
+        return isFood(stack.getItem());
+    }
+
+    // Not every food item in minecraft is consumable for some reason (e.g. buckets of any fish)
+    public static boolean isFood(Item item) {
+        return item.components().has(DataComponents.FOOD) && item.components().has(DataComponents.CONSUMABLE);
+    }
+
     public static int getRenderDistance() {
         return Math.max(mc.options.renderDistance().get(), ((ClientPacketListenerAccessor) mc.getConnection()).meteor$getServerChunkRadius());
     }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

autoeat and other modules were accounting non-consumable items as food (e.g. Bucket of Cod etc)

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
