### PR TITLE
Fix: Add missing ServerboundAttackPacket to PacketUtils

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/utils/network/PacketUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/network/PacketUtils.java
@@ -35,6 +35,8 @@ public class PacketUtils {
         C2S_PACKETS_R.put("ServerboundAcceptCodeOfConductPacket", net.minecraft.network.protocol.configuration.ServerboundAcceptCodeOfConductPacket.class);
         C2S_PACKETS.put(net.minecraft.network.protocol.game.ServerboundAcceptTeleportationPacket.class, "ServerboundAcceptTeleportationPacket");
         C2S_PACKETS_R.put("ServerboundAcceptTeleportationPacket", net.minecraft.network.protocol.game.ServerboundAcceptTeleportationPacket.class);
+        C2S_PACKETS.put(net.minecraft.network.protocol.game.ServerboundAttackPacket.class, "ServerboundAttackPacket");
+        C2S_PACKETS_R.put("ServerboundAttackPacket", net.minecraft.network.protocol.game.ServerboundAttackPacket.class);
         C2S_PACKETS.put(net.minecraft.network.protocol.game.ServerboundBlockEntityTagQueryPacket.class, "ServerboundBlockEntityTagQueryPacket");
         C2S_PACKETS_R.put("ServerboundBlockEntityTagQueryPacket", net.minecraft.network.protocol.game.ServerboundBlockEntityTagQueryPacket.class);
         C2S_PACKETS.put(net.minecraft.network.protocol.game.ServerboundChangeDifficultyPacket.class, "ServerboundChangeDifficultyPacket");


### PR DESCRIPTION
### Description
Added `ServerboundAttackPacket` to `PacketUtils` maps (`C2S_PACKETS` and `C2S_PACKETS_R`). 

Since Mojang split the old interact packet into interaction and attack in recent versions, `ServerboundAttackPacket` was completely missing from the internal PacketUtils list. This caused issues where users couldn't select or filter this packet in the UI (e.g., inside the `PacketListSetting` used by modules like `PacketDelay` or `PacketCancel`), making it impossible to cancel or delay attacks via the GUI.

### Guidelines
- [x] The license header is preserved.
- [x] No IDE/system-related files are included.
- [x] Code style matches the existing project structure.