### PR TITLE
fix crash and broken jump mode in criticals module

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Criticals.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/Criticals.java
@@ -17,7 +17,6 @@ import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.utils.entity.EntityUtils;
 import meteordevelopment.orbit.EventHandler;
 import net.minecraft.network.protocol.game.ServerboundAttackPacket;
-import net.minecraft.network.protocol.game.ServerboundInteractPacket;
 import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket;
 import net.minecraft.network.protocol.game.ServerboundSwingPacket;
 import net.minecraft.world.entity.Entity;
@@ -61,7 +60,7 @@ public class Criticals extends Module {
         .build()
     );
 
-    private ServerboundInteractPacket attackPacket;
+    private ServerboundAttackPacket attackPacket;
     private ServerboundSwingPacket swingPacket;
     private boolean sendPackets;
     private int sendTimer;
@@ -116,10 +115,10 @@ public class Criticals extends Module {
                     case Jump, MiniJump -> {
                         if (!sendPackets) {
                             sendPackets = true;
-                            attackPacket = (ServerboundInteractPacket) event.packet;
+                            attackPacket = (ServerboundAttackPacket) event.packet;
 
                             if (mode.get() == Mode.Jump) {
-                                mc.player.isJumping();
+                                mc.player.jumpFromGround();
                                 waitingForPeak = true;
                                 lastY = mc.player.getY();
                             } else {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

fixes a `ClassCastException` crash when using minijump or jump mode in criticals

the issue: ServerboundInteractPacket was declared here

```java
private ServerboundInteractPacket attackPacket;
```

but incoming packet was `ServerboundAttackPacket`

so when casting here detects wrong class and crash
```java
attackPacket = (ServerboundInteractPacket) event.packet;
```

the fix is just change class to `ServerboundAttackPacket` and cast it

```java
private ServerboundAttackPacket attackPacket;
```
```java
attackPacket = (ServerboundAttackPacket) event.packet;
```

and jump mode wasnt actually jumping because wrong method was used here
```java
mc.player.isJumping();
```
actual method is
```java
mc.player.jumpFromGround();
```

## Related issues

closes #6379

# How Has This Been Tested?

singleplayer and multiplayer, every mode works fine

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas. (no needed)
- [x] I have tested the code in both development and production environments.
