### PR TITLE
fix NullPointerException startup crash in autoeat and automend modules

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoEat.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoEat.java
@@ -55,6 +55,7 @@ public class AutoEat extends Module {
             Items.SUSPICIOUS_STEW
         )
         .filter(item -> item.components().get(DataComponents.FOOD) != null)
+        .bypassFilterWhenSavingAndLoading()                                                       
         .build()
     );
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoMend.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoMend.java
@@ -29,6 +29,7 @@ public class AutoMend extends Module {
         .name("blacklist")
         .description("Item blacklist.")
         .filter(item -> item.components().get(DataComponents.DAMAGE) != null)
+        .bypassFilterWhenSavingAndLoading()                                                        
         .build()
     );
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

a simple fix to this crash
this was caused because these modules were missing a flag called `.bypassFilterWhenSavingAndLoading()` in the blacklist setting
which is needed since they are calling `item.components()` because the game is still loading

## Related issues

https://github.com/MeteorDevelopment/meteor-client/issues/6384
https://github.com/MeteorDevelopment/meteor-client/issues/6375

# How Has This Been Tested?

singleplayer by adding and removing items from the blacklist, then close and start the game again
no crash at all

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas. (no needed)
- [x] I have tested the code in both development and production environments.
