### PR TITLE
Fix opening GUI outside of worlds

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/DefaultSettingsWidgetFactory.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/DefaultSettingsWidgetFactory.java
@@ -24,6 +24,7 @@ import meteordevelopment.meteorclient.renderer.Fonts;
 import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.hud.elements.keyboard.KeyboardHud;
 import meteordevelopment.meteorclient.utils.Utils;
+import meteordevelopment.meteorclient.utils.render.DisplayItemUtils;
 import meteordevelopment.meteorclient.utils.render.color.SettingColor;
 import net.minecraft.client.resources.language.I18n;
 import org.apache.commons.lang3.Strings;
@@ -251,17 +252,17 @@ public class DefaultSettingsWidgetFactory extends SettingsWidgetFactory {
     private void blockW(WTable table, BlockSetting setting) {
         WHorizontalList list = table.add(theme.horizontalList()).expandX().widget();
 
-        WItem item = list.add(theme.item(setting.get().asItem().getDefaultInstance())).widget();
+        WItem item = list.add(theme.item(DisplayItemUtils.toStack(setting.get().asItem()))).widget();
 
         WButton select = list.add(theme.button("Select")).widget();
         select.action = () -> {
             BlockSettingScreen screen = new BlockSettingScreen(theme, setting);
-            screen.onClosed(() -> item.set(setting.get().asItem().getDefaultInstance()));
+            screen.onClosed(() -> item.set(DisplayItemUtils.toStack(setting.get().asItem())));
 
             mc.setScreen(screen);
         };
 
-        reset(table, setting, () -> item.set(setting.get().asItem().getDefaultInstance()));
+        reset(table, setting, () -> item.set(DisplayItemUtils.toStack(setting.get().asItem())));
     }
 
     private void blockPosW(WTable table, BlockPosSetting setting) {
@@ -281,17 +282,17 @@ public class DefaultSettingsWidgetFactory extends SettingsWidgetFactory {
     private void itemW(WTable table, ItemSetting setting) {
         WHorizontalList list = table.add(theme.horizontalList()).expandX().widget();
 
-        WItem item = list.add(theme.item(setting.get().asItem().getDefaultInstance())).widget();
+        WItem item = list.add(theme.item(DisplayItemUtils.toStack(setting.get()))).widget();
 
         WButton select = list.add(theme.button("Select")).widget();
         select.action = () -> {
             ItemSettingScreen screen = new ItemSettingScreen(theme, setting);
-            screen.onClosed(() -> item.set(setting.get().getDefaultInstance()));
+            screen.onClosed(() -> item.set(DisplayItemUtils.toStack(setting.get())));
 
             mc.setScreen(screen);
         };
 
-        reset(table, setting, () -> item.set(setting.get().getDefaultInstance()));
+        reset(table, setting, () -> item.set(DisplayItemUtils.toStack(setting.get())));
     }
 
     private void itemListW(WTable table, ItemListSetting setting) {

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/ModulesScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/ModulesScreen.java
@@ -20,6 +20,7 @@ import meteordevelopment.meteorclient.systems.modules.Category;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.utils.misc.NbtUtils;
+import meteordevelopment.meteorclient.utils.render.DisplayItemUtils;
 import net.minecraft.client.input.KeyEvent;
 import net.minecraft.util.Tuple;
 import net.minecraft.world.item.Items;
@@ -123,7 +124,7 @@ public class ModulesScreen extends TabScreen {
         searchWindow = w;
 
         if (theme.categoryIcons()) {
-            w.beforeHeaderInit = wContainer -> wContainer.add(theme.item(Items.COMPASS.getDefaultInstance())).pad(2);
+            w.beforeHeaderInit = wContainer -> wContainer.add(theme.item(DisplayItemUtils.toStack(Items.COMPASS))).pad(2);
         }
 
         c.add(w);
@@ -178,7 +179,7 @@ public class ModulesScreen extends TabScreen {
         w.spacing = 0;
 
         if (theme.categoryIcons()) {
-            w.beforeHeaderInit = wContainer -> wContainer.add(theme.item(Items.NETHER_STAR.getDefaultInstance())).pad(2);
+            w.beforeHeaderInit = wContainer -> wContainer.add(theme.item(DisplayItemUtils.toStack(Items.NETHER_STAR))).pad(2);
         }
 
         Cell<WWindow> cell = c.add(w);

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/BlockDataSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/BlockDataSettingScreen.java
@@ -13,6 +13,7 @@ import meteordevelopment.meteorclient.gui.widgets.pressable.WButton;
 import meteordevelopment.meteorclient.settings.BlockDataSetting;
 import meteordevelopment.meteorclient.settings.IBlockData;
 import meteordevelopment.meteorclient.utils.misc.IChangeable;
+import meteordevelopment.meteorclient.utils.render.DisplayItemUtils;
 import meteordevelopment.meteorclient.utils.misc.ICopyable;
 import meteordevelopment.meteorclient.utils.misc.ISerializable;
 import meteordevelopment.meteorclient.utils.misc.Names;
@@ -41,7 +42,7 @@ public class BlockDataSettingScreen<T extends ICopyable<T> & ISerializable<T> & 
 
     @Override
     protected WWidget getValueWidget(Block block) {
-        return theme.itemWithLabel(block.asItem().getDefaultInstance(), Names.get(block));
+        return theme.itemWithLabel(DisplayItemUtils.toStack(block), Names.get(block));
     }
 
     @Override

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/BlockListSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/BlockListSettingScreen.java
@@ -10,6 +10,7 @@ import meteordevelopment.meteorclient.gui.screens.settings.base.CollectionListSe
 import meteordevelopment.meteorclient.gui.widgets.WWidget;
 import meteordevelopment.meteorclient.settings.BlockListSetting;
 import meteordevelopment.meteorclient.utils.misc.Names;
+import meteordevelopment.meteorclient.utils.render.DisplayItemUtils;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.level.block.Block;
@@ -36,7 +37,7 @@ public class BlockListSettingScreen extends CollectionListSettingScreen<Block> {
 
     @Override
     protected WWidget getValueWidget(Block value) {
-        return theme.itemWithLabel(value.asItem().getDefaultInstance(), Names.get(value));
+        return theme.itemWithLabel(DisplayItemUtils.toStack(value), Names.get(value));
     }
 
     @Override

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/BlockSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/BlockSettingScreen.java
@@ -13,6 +13,7 @@ import meteordevelopment.meteorclient.gui.widgets.input.WTextBox;
 import meteordevelopment.meteorclient.gui.widgets.pressable.WButton;
 import meteordevelopment.meteorclient.settings.BlockSetting;
 import meteordevelopment.meteorclient.utils.misc.Names;
+import meteordevelopment.meteorclient.utils.render.DisplayItemUtils;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
@@ -53,7 +54,7 @@ public class BlockSettingScreen extends WindowScreen {
             if (setting.filter != null && !setting.filter.test(block)) continue;
             if (skipValue(block)) continue;
 
-            WItemWithLabel item = theme.itemWithLabel(block.asItem().getDefaultInstance(), Names.get(block));
+            WItemWithLabel item = theme.itemWithLabel(DisplayItemUtils.toStack(block), Names.get(block));
             if (!filterText.isEmpty() && !Strings.CI.contains(item.getLabelText(), filterText)) continue;
             table.add(item);
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/EntityTypeListSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/EntityTypeListSettingScreen.java
@@ -19,6 +19,7 @@ import meteordevelopment.meteorclient.renderer.Texture;
 import meteordevelopment.meteorclient.settings.EntityTypeListSetting;
 import meteordevelopment.meteorclient.utils.Utils;
 import meteordevelopment.meteorclient.utils.misc.Names;
+import meteordevelopment.meteorclient.utils.render.DisplayItemUtils;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.util.Tuple;
@@ -238,7 +239,7 @@ public class EntityTypeListSettingScreen extends WindowScreen {
 
             //noinspection DataFlowIssue
             if (component.type() == entityType) {
-                stack = item.getDefaultInstance();
+                stack = DisplayItemUtils.toStack(item);
                 break;
             }
         }

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/ItemListSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/ItemListSettingScreen.java
@@ -10,6 +10,7 @@ import meteordevelopment.meteorclient.gui.screens.settings.base.CollectionListSe
 import meteordevelopment.meteorclient.gui.widgets.WWidget;
 import meteordevelopment.meteorclient.settings.ItemListSetting;
 import meteordevelopment.meteorclient.utils.misc.Names;
+import meteordevelopment.meteorclient.utils.render.DisplayItemUtils;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
@@ -31,7 +32,7 @@ public class ItemListSettingScreen extends CollectionListSettingScreen<Item> {
 
     @Override
     protected WWidget getValueWidget(Item value) {
-        return theme.itemWithLabel(value.getDefaultInstance());
+        return theme.itemWithLabel(DisplayItemUtils.toStack(value));
     }
 
     @Override

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/ItemSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/ItemSettingScreen.java
@@ -13,6 +13,7 @@ import meteordevelopment.meteorclient.gui.widgets.input.WTextBox;
 import meteordevelopment.meteorclient.gui.widgets.pressable.WButton;
 import meteordevelopment.meteorclient.settings.ItemSetting;
 import meteordevelopment.meteorclient.utils.misc.Names;
+import meteordevelopment.meteorclient.utils.render.DisplayItemUtils;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
@@ -52,7 +53,7 @@ public class ItemSettingScreen extends WindowScreen {
             if (setting.filter != null && !setting.filter.test(item)) continue;
             if (item == Items.AIR) continue;
 
-            WItemWithLabel itemLabel = theme.itemWithLabel(item.getDefaultInstance(), Names.get(item));
+            WItemWithLabel itemLabel = theme.itemWithLabel(DisplayItemUtils.toStack(item), Names.get(item));
             if (!filterText.isEmpty() && !Strings.CI.contains(itemLabel.getLabelText(), filterText)) continue;
             table.add(itemLabel);
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/StatusEffectAmplifierMapSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/StatusEffectAmplifierMapSettingScreen.java
@@ -13,6 +13,7 @@ import meteordevelopment.meteorclient.gui.widgets.input.WIntEdit;
 import meteordevelopment.meteorclient.gui.widgets.input.WTextBox;
 import meteordevelopment.meteorclient.settings.Setting;
 import meteordevelopment.meteorclient.utils.misc.Names;
+import meteordevelopment.meteorclient.utils.render.DisplayItemUtils;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.item.ItemStack;
@@ -76,14 +77,14 @@ public class StatusEffectAmplifierMapSettingScreen extends WindowScreen {
     }
 
     private ItemStack getPotionStack(MobEffect effect) {
-        ItemStack potion = Items.POTION.getDefaultInstance();
+        ItemStack potion = DisplayItemUtils.toStack(Items.POTION);
 
         potion.set(
             DataComponents.POTION_CONTENTS,
             new PotionContents(
-                potion.get(DataComponents.POTION_CONTENTS).potion(),
+                Optional.empty(),
                 Optional.of(effect.getColor()),
-                potion.get(DataComponents.POTION_CONTENTS).customEffects(),
+                List.of(),
                 Optional.empty()
             )
         );

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/StatusEffectListSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/StatusEffectListSettingScreen.java
@@ -10,6 +10,7 @@ import meteordevelopment.meteorclient.gui.screens.settings.base.CollectionListSe
 import meteordevelopment.meteorclient.gui.widgets.WWidget;
 import meteordevelopment.meteorclient.settings.Setting;
 import meteordevelopment.meteorclient.utils.misc.Names;
+import meteordevelopment.meteorclient.utils.render.DisplayItemUtils;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.effect.MobEffect;
@@ -39,14 +40,14 @@ public class StatusEffectListSettingScreen extends CollectionListSettingScreen<M
     }
 
     private ItemStack getPotionStack(MobEffect effect) {
-        ItemStack potion = Items.POTION.getDefaultInstance();
+        ItemStack potion = DisplayItemUtils.toStack(Items.POTION);
 
         potion.set(
             DataComponents.POTION_CONTENTS,
             new PotionContents(
-                potion.get(DataComponents.POTION_CONTENTS).potion(),
+                Optional.empty(),
                 Optional.of(effect.getColor()),
-                potion.get(DataComponents.POTION_CONTENTS).customEffects(),
+                List.of(),
                 Optional.empty()
             )
         );

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/StorageBlockListSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/StorageBlockListSettingScreen.java
@@ -11,6 +11,7 @@ import meteordevelopment.meteorclient.gui.screens.settings.base.CollectionListSe
 import meteordevelopment.meteorclient.gui.widgets.WWidget;
 import meteordevelopment.meteorclient.settings.Setting;
 import meteordevelopment.meteorclient.settings.StorageBlockListSetting;
+import meteordevelopment.meteorclient.utils.render.DisplayItemUtils;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
@@ -50,7 +51,7 @@ public class StorageBlockListSettingScreen extends CollectionListSettingScreen<B
     @Override
     protected WWidget getValueWidget(BlockEntityType<?> value) {
         BlockEntityTypeInfo info = BLOCK_ENTITY_TYPE_INFO_MAP.getOrDefault(value, UNKNOWN);
-        return theme.itemWithLabel(info.item().getDefaultInstance(), info.name());
+        return theme.itemWithLabel(DisplayItemUtils.toStack(info.item()), info.name());
     }
 
     @Override

--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/WItemWithLabel.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/WItemWithLabel.java
@@ -12,6 +12,7 @@ import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffectUtil;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.alchemy.PotionContents;
 
 import java.util.Iterator;
 
@@ -39,7 +40,10 @@ public class WItemWithLabel extends WHorizontalList {
         String str = "";
 
         if (itemStack.getItem() == Items.POTION) {
-            Iterator<MobEffectInstance> effects = itemStack.getItem().components().get(DataComponents.POTION_CONTENTS).getAllEffects().iterator();
+            PotionContents potionContents = itemStack.get(DataComponents.POTION_CONTENTS);
+            if (potionContents == null) return str;
+            
+            Iterator<MobEffectInstance> effects = potionContents.getAllEffects().iterator();
             if (!effects.hasNext()) return str;
 
             str += " ";

--- a/src/main/java/meteordevelopment/meteorclient/mixin/GuiRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/GuiRendererMixin.java
@@ -9,6 +9,7 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.events.render.Render2DEvent;
 import meteordevelopment.meteorclient.gui.WidgetScreen;
+import meteordevelopment.meteorclient.systems.hud.screens.HudEditorScreen;
 import meteordevelopment.meteorclient.utils.Utils;
 import meteordevelopment.meteorclient.utils.render.MeteorMcGuiRenderer;
 import net.minecraft.client.Minecraft;
@@ -63,7 +64,7 @@ public abstract class GuiRendererMixin {
         var fogRenderer = ((GameRendererAccessor) mc.gameRenderer).meteor$fogRenderer();
         var delta = mc.getDeltaTracker().getGameTimeDeltaTicks();
 
-        if (Utils.canUpdate()) {
+        if (Utils.canUpdate() || HudEditorScreen.isOpen()) {
             Profiler.get().push(MeteorClient.MOD_ID + "_render_2d");
 
             Utils.unscaledProjection();

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/Hud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/Hud.java
@@ -230,7 +230,7 @@ public class Hud extends System<Hud> implements Iterable<HudElement> {
     private void onRender(Render2DEvent event) {
         if (Utils.isLoading()) return;
 
-        if (!active || shouldHideHud()) return;
+        if (!(active || HudEditorScreen.isOpen()) || shouldHideHud()) return;
         if ((mc.options.hideGui || mc.debugEntries.isOverlayVisible()) && !HudEditorScreen.isOpen()) return;
 
         HudRenderer.INSTANCE.begin(event.graphics);

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ArmorHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ArmorHud.java
@@ -11,6 +11,7 @@ import meteordevelopment.meteorclient.systems.hud.Hud;
 import meteordevelopment.meteorclient.systems.hud.HudElement;
 import meteordevelopment.meteorclient.systems.hud.HudElementInfo;
 import meteordevelopment.meteorclient.systems.hud.HudRenderer;
+import meteordevelopment.meteorclient.utils.render.DisplayItemUtils;
 import meteordevelopment.meteorclient.utils.render.color.SettingColor;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.ItemStack;
@@ -191,15 +192,15 @@ public class ArmorHud extends HudElement {
     private ItemStack getItem(EquipmentSlot slot) {
         if (isInEditor()) {
             return switch (slot.getIndex()) {
-                case 3 -> Items.NETHERITE_HELMET.getDefaultInstance();
-                case 2 -> Items.NETHERITE_CHESTPLATE.getDefaultInstance();
-                case 1 -> Items.NETHERITE_LEGGINGS.getDefaultInstance();
-                default -> Items.NETHERITE_BOOTS.getDefaultInstance();
+                case 3 -> DisplayItemUtils.toStack(Items.NETHERITE_HELMET);
+                case 2 -> DisplayItemUtils.toStack(Items.NETHERITE_CHESTPLATE);
+                case 1 -> DisplayItemUtils.toStack(Items.NETHERITE_LEGGINGS);
+                default -> DisplayItemUtils.toStack(Items.NETHERITE_BOOTS);
             };
         }
 
         ItemStack stack = mc.player.getItemBySlot(slot);
-        return stack.isEmpty() && showEmpty.get() ? Items.BARRIER.getDefaultInstance() : stack;
+        return stack.isEmpty() && showEmpty.get() ? DisplayItemUtils.toStack(Items.BARRIER) : stack;
     }
 
     private float getScale() {

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CombatHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/CombatHud.java
@@ -23,6 +23,7 @@ import meteordevelopment.meteorclient.utils.entity.EntityUtils;
 import meteordevelopment.meteorclient.utils.entity.SortPriority;
 import meteordevelopment.meteorclient.utils.entity.TargetUtils;
 import meteordevelopment.meteorclient.utils.player.PlayerUtils;
+import meteordevelopment.meteorclient.utils.render.DisplayItemUtils;
 import meteordevelopment.meteorclient.utils.render.color.Color;
 import meteordevelopment.meteorclient.utils.render.color.SettingColor;
 import net.minecraft.core.Holder;
@@ -455,12 +456,12 @@ public class CombatHud extends HudElement {
     private ItemStack getItem(int i) {
         if (isInEditor()) {
             return switch (i) {
-                case 0 -> Items.NETHERITE_BOOTS.getDefaultInstance();
-                case 1 -> Items.NETHERITE_LEGGINGS.getDefaultInstance();
-                case 2 -> Items.NETHERITE_CHESTPLATE.getDefaultInstance();
-                case 3 -> Items.NETHERITE_HELMET.getDefaultInstance();
-                case 4 -> Items.TOTEM_OF_UNDYING.getDefaultInstance();
-                case 5 -> Items.END_CRYSTAL.getDefaultInstance();
+                case 0 -> DisplayItemUtils.toStack(Items.NETHERITE_BOOTS);
+                case 1 -> DisplayItemUtils.toStack(Items.NETHERITE_LEGGINGS);
+                case 2 -> DisplayItemUtils.toStack(Items.NETHERITE_CHESTPLATE);
+                case 3 -> DisplayItemUtils.toStack(Items.NETHERITE_HELMET);
+                case 4 -> DisplayItemUtils.toStack(Items.TOTEM_OF_UNDYING);
+                case 5 -> DisplayItemUtils.toStack(Items.END_CRYSTAL);
                 default -> ItemStack.EMPTY;
             };
         }

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/HoleHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/HoleHud.java
@@ -11,6 +11,7 @@ import meteordevelopment.meteorclient.systems.hud.Hud;
 import meteordevelopment.meteorclient.systems.hud.HudElement;
 import meteordevelopment.meteorclient.systems.hud.HudElementInfo;
 import meteordevelopment.meteorclient.systems.hud.HudRenderer;
+import meteordevelopment.meteorclient.utils.render.DisplayItemUtils;
 import meteordevelopment.meteorclient.utils.render.color.Color;
 import meteordevelopment.meteorclient.utils.render.color.SettingColor;
 import net.minecraft.core.Direction;
@@ -112,7 +113,7 @@ public class HoleHud extends HudElement {
         Block block = dir == Direction.DOWN ? Blocks.OBSIDIAN : mc.level.getBlockState(mc.player.blockPosition().relative(dir)).getBlock();
         if (!safe.get().contains(block)) return;
 
-        renderer.item(block.asItem().getDefaultInstance(), (int) x, (int) y, getScale(), false);
+        renderer.item(DisplayItemUtils.toStack(block.asItem()), (int) x, (int) y, getScale(), false);
 
         if (dir == Direction.DOWN) return;
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/InventoryHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/InventoryHud.java
@@ -12,6 +12,7 @@ import meteordevelopment.meteorclient.systems.hud.HudElement;
 import meteordevelopment.meteorclient.systems.hud.HudElementInfo;
 import meteordevelopment.meteorclient.systems.hud.HudRenderer;
 import meteordevelopment.meteorclient.utils.Utils;
+import meteordevelopment.meteorclient.utils.render.DisplayItemUtils;
 import meteordevelopment.meteorclient.utils.render.color.Color;
 import meteordevelopment.meteorclient.utils.render.color.SettingColor;
 import net.minecraft.resources.Identifier;
@@ -76,6 +77,12 @@ public class InventoryHud extends HudElement {
         .build()
     );
 
+    private static final ItemStack[] PREVIEW_ITEMS = {
+        DisplayItemUtils.toStack(Items.OBSIDIAN, 64),
+        DisplayItemUtils.toStack(Items.END_CRYSTAL, 64),
+        DisplayItemUtils.toStack(Items.GOLDEN_APPLE, 64)
+    };
+
     private final ItemStack[] containerItems = new ItemStack[9 * 3];
 
     private InventoryHud() {
@@ -97,13 +104,18 @@ public class InventoryHud extends HudElement {
             drawBackground(renderer, (int) x, (int) y, drawColor);
         }
 
-        if (mc.player == null) return;
-
         renderer.post(() -> {
             for (int row = 0; row < 3; row++) {
                 for (int i = 0; i < 9; i++) {
                     int index = row * 9 + i;
-                    ItemStack stack = hasContainer ? containerItems[index] : mc.player.getInventory().getItem(index + 9);
+                    ItemStack stack;
+
+                    if (mc.player == null) {
+                        stack = index < PREVIEW_ITEMS.length ? PREVIEW_ITEMS[index] : null;
+                    } else {
+                        stack = hasContainer ? containerItems[index] : mc.player.getInventory().getItem(index + 9);
+                    }
+
                     if (stack == null) continue;
 
                     int itemX = background.get() == Background.Texture ? (int) (x + (8 + i * 18) * getScale()) : (int) (x + (1 + i * 18) * getScale());

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ItemHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ItemHud.java
@@ -11,6 +11,7 @@ import meteordevelopment.meteorclient.systems.hud.HudElement;
 import meteordevelopment.meteorclient.systems.hud.HudElementInfo;
 import meteordevelopment.meteorclient.systems.hud.HudRenderer;
 import meteordevelopment.meteorclient.utils.player.InvUtils;
+import meteordevelopment.meteorclient.utils.render.DisplayItemUtils;
 import meteordevelopment.meteorclient.utils.render.color.Color;
 import meteordevelopment.meteorclient.utils.render.color.SettingColor;
 import net.minecraft.world.item.Item;
@@ -90,7 +91,7 @@ public class ItemHud extends HudElement {
 
     @Override
     public void render(HudRenderer renderer) {
-        ItemStack itemStack = new ItemStack(item.get(), InvUtils.find(item.get()).count());
+        ItemStack itemStack = DisplayItemUtils.toStack(item.get(), InvUtils.find(item.get()).count());
 
         if (noneMode.get() == NoneMode.HideItem && itemStack.isEmpty()) {
             if (isInEditor()) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Categories.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Categories.java
@@ -7,15 +7,16 @@ package meteordevelopment.meteorclient.systems.modules;
 
 import meteordevelopment.meteorclient.addons.AddonManager;
 import meteordevelopment.meteorclient.addons.MeteorAddon;
+import meteordevelopment.meteorclient.utils.render.DisplayItemUtils;
 import net.minecraft.world.item.Items;
 
 public class Categories {
-    public static final Category Combat = new Category("Combat", Items.GOLDEN_SWORD::getDefaultInstance);
-    public static final Category Player = new Category("Player", Items.ARMOR_STAND::getDefaultInstance);
-    public static final Category Movement = new Category("Movement", Items.DIAMOND_BOOTS::getDefaultInstance);
-    public static final Category Render = new Category("Render", Items.GLASS::getDefaultInstance);
-    public static final Category World = new Category("World", Items.GRASS_BLOCK::getDefaultInstance);
-    public static final Category Misc = new Category("Misc", Items.LAVA_BUCKET::getDefaultInstance);
+    public static final Category Combat = new Category("Combat", () -> DisplayItemUtils.toStack(Items.GOLDEN_SWORD));
+    public static final Category Player = new Category("Player", () -> DisplayItemUtils.toStack(Items.ARMOR_STAND));
+    public static final Category Movement = new Category("Movement", () -> DisplayItemUtils.toStack(Items.DIAMOND_BOOTS));
+    public static final Category Render = new Category("Render", () -> DisplayItemUtils.toStack(Items.GLASS));
+    public static final Category World = new Category("World", () -> DisplayItemUtils.toStack(Items.GRASS_BLOCK));
+    public static final Category Misc = new Category("Misc", () -> DisplayItemUtils.toStack(Items.LAVA_BUCKET));
 
     public static boolean REGISTERING;
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Category.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Category.java
@@ -6,7 +6,6 @@
 package meteordevelopment.meteorclient.systems.modules;
 
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 
 import java.util.function.Supplier;
 
@@ -18,7 +17,7 @@ public class Category {
     public Category(String name, Supplier<ItemStack> icon) {
         this.name = name;
         this.nameHash = name.hashCode();
-        this.icon = icon == null ? Items.AIR::getDefaultInstance : icon;
+        this.icon = icon == null ? () -> ItemStack.EMPTY : icon;
     }
 
     public Category(String name) {

--- a/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
@@ -28,6 +28,9 @@ import meteordevelopment.meteorclient.utils.world.ChunkIterator;
 import meteordevelopment.orbit.EventHandler;
 import net.minecraft.client.ResourceLoadStateTracker;
 import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.TitleScreen;
+import net.minecraft.client.gui.screens.multiplayer.JoinMultiplayerScreen;
+import net.minecraft.client.gui.screens.worldselection.SelectWorldScreen;
 import net.minecraft.client.renderer.Projection;
 import net.minecraft.client.renderer.ProjectionMatrixBuffer;
 import net.minecraft.core.BlockPos;
@@ -531,7 +534,10 @@ public class Utils {
     }
 
     public static boolean canOpenGui() {
-        return canUpdate() && mc.screen == null;
+        if (canUpdate()) return mc.screen == null;
+        return mc.screen instanceof TitleScreen
+            || mc.screen instanceof JoinMultiplayerScreen
+            || mc.screen instanceof SelectWorldScreen;
     }
 
     public static boolean canCloseGui() {

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/MyPotion.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/MyPotion.java
@@ -5,7 +5,9 @@
 
 package meteordevelopment.meteorclient.utils.misc;
 
+import meteordevelopment.meteorclient.utils.render.DisplayItemUtils;
 import net.minecraft.core.Holder;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
@@ -72,7 +74,11 @@ public enum MyPotion {
     public final Item[] ingredients;
 
     MyPotion(Holder<Potion> potion, Item... ingredients) {
-        this.potion = () -> PotionContents.createItemStack(Items.POTION, potion);
+        this.potion = () -> {
+            ItemStack stack = DisplayItemUtils.toStack(Items.POTION);
+            stack.set(DataComponents.POTION_CONTENTS, new PotionContents(potion));
+            return stack;
+        };
         this.ingredients = ingredients;
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/DisplayItemUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/DisplayItemUtils.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.utils.render;
+
+import net.minecraft.core.Holder;
+import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.block.Block;
+
+/**
+ * Creates display-only {@link ItemStack}s that can be used for rendering
+ * before item components are bound (i.e. before joining a world).
+ */
+public class DisplayItemUtils {
+    private DisplayItemUtils() {}
+
+    public static ItemStack toStack(Item item) {
+        if (item == Items.AIR) return ItemStack.EMPTY;
+        return new ItemStack(directHolder(item));
+    }
+
+    public static ItemStack toStack(Block block) {
+        return toStack(block.asItem());
+    }
+
+    public static ItemStack toStack(Item item, int count) {
+        if (item == Items.AIR) return ItemStack.EMPTY;
+        return new ItemStack(directHolder(item), count);
+    }
+
+    @SuppressWarnings("deprecation")
+    private static Holder<Item> directHolder(Item item) {
+        DataComponentMap components = DataComponentMap.builder()
+            .addAll(DataComponents.COMMON_ITEM_COMPONENTS)
+            .set(DataComponents.ITEM_MODEL, item.builtInRegistryHolder().key().identifier())
+            .set(DataComponents.ITEM_NAME, Component.translatable(item.getDescriptionId()))
+            .build();
+        return Holder.direct(item, components);
+    }
+}

--- a/src/main/java/meteordevelopment/meteorclient/utils/render/MeteorToast.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/render/MeteorToast.java
@@ -5,6 +5,7 @@
 
 package meteordevelopment.meteorclient.utils.render;
 
+import meteordevelopment.meteorclient.utils.render.DisplayItemUtils;
 import meteordevelopment.meteorclient.utils.render.color.Color;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
@@ -70,7 +71,7 @@ public class MeteorToast implements Toast {
         }
 
         public Builder icon(@Nullable Item item) {
-            this.icon = item != null ? item.getDefaultInstance() : null;
+            this.icon = item != null ? DisplayItemUtils.toStack(item) : null;
             return this;
         }
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [x] New feature

## Description

In 26.1 Itemstacks now require components to be loaded from registry entries that are only provided when we join a world, however since we only need a few specific components that are stored client-side we can simply construct our own stacks for rendering that contain only those.

Implemented utils/DisplayItemUtils which creates these stacks and replaced all getDefaultInstance() calls in rendering contexts with DisplayItemUtils#toStack(Item item)

**Breaking for addons**, any addon that defines category icons will need to do so using the new util as well or NPE

Also added a few placeholder items in inventoryhud that show while outside of a world

## Related issues

#6361 

# How Has This Been Tested?

https://github.com/user-attachments/assets/9da1d635-6cf0-4abe-8bce-a44c4d95d1e8

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
