### PR TITLE
Hud fixes

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/MeteorClient.java
+++ b/src/main/java/meteordevelopment/meteorclient/MeteorClient.java
@@ -16,7 +16,9 @@ import meteordevelopment.meteorclient.gui.WidgetScreen;
 import meteordevelopment.meteorclient.gui.tabs.Tabs;
 import meteordevelopment.meteorclient.systems.Systems;
 import meteordevelopment.meteorclient.systems.config.Config;
+import meteordevelopment.meteorclient.systems.hud.screens.AddHudElementScreen;
 import meteordevelopment.meteorclient.systems.hud.screens.HudEditorScreen;
+import meteordevelopment.meteorclient.systems.hud.screens.HudElementScreen;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.misc.DiscordPresence;
@@ -184,7 +186,9 @@ public class MeteorClient implements ClientModInitializer {
             if (GuiThemes.get().hideHUD() || wasHudHiddenRoot) {
                 // Always show the MC HUD in the HUD editor screen since people like
                 // to align some items with the hotbar or chat
-                mc.options.hideGui = !(event.screen instanceof HudEditorScreen);
+                mc.options.hideGui = !(event.screen instanceof HudEditorScreen)
+                    && !(event.screen instanceof AddHudElementScreen)
+                    && !(event.screen instanceof HudElementScreen);
             }
         } else {
             if (wasWidgetScreen) mc.options.hideGui = wasHudHiddenRoot;

--- a/src/main/java/meteordevelopment/meteorclient/mixin/GuiRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/GuiRendererMixin.java
@@ -9,6 +9,7 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.events.render.Render2DEvent;
 import meteordevelopment.meteorclient.gui.WidgetScreen;
+import meteordevelopment.meteorclient.systems.hud.screens.HudEditorScreen;
 import meteordevelopment.meteorclient.utils.Utils;
 import meteordevelopment.meteorclient.utils.render.MeteorMcGuiRenderer;
 import net.minecraft.client.Minecraft;
@@ -52,7 +53,7 @@ public abstract class GuiRendererMixin {
         );
     }
 
-    @Inject(method = "draw", at = @At("HEAD"))
+    @Inject(method = "render", at = @At("TAIL"))
     private void draw$executeDrawRange(CallbackInfo ci) {
         if ((GuiRenderer) (Object) this instanceof MeteorMcGuiRenderer) return;
         var mc = Minecraft.getInstance();
@@ -63,7 +64,9 @@ public abstract class GuiRendererMixin {
         var fogRenderer = ((GameRendererAccessor) mc.gameRenderer).meteor$fogRenderer();
         var delta = mc.getDeltaTracker().getGameTimeDeltaTicks();
 
-        if (Utils.canUpdate()) {
+        RenderSystem.getDevice().createCommandEncoder().clearDepthTexture(mc.getMainRenderTarget().getDepthTexture(), 1.0);
+
+        if (Utils.canUpdate() || HudEditorScreen.isOpen()) {
             Profiler.get().push(MeteorClient.MOD_ID + "_render_2d");
 
             Utils.unscaledProjection();
@@ -83,7 +86,6 @@ public abstract class GuiRendererMixin {
             guiRenderer.render(fogRenderer.getBuffer(FogRenderer.FogMode.NONE));
         }
 
-        RenderSystem.getDevice().createCommandEncoder().clearDepthTexture(mc.getMainRenderTarget().getDepthTexture(), 1.0);
         guiRenderer.endFrame();
     }
 }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Fixes the hide HUD setting re-displaying the HUD only on the hud editor screen, not the add hud element and hud element setting screens as well

Also fixes Meteor's HUD rendering behind Minecraft hud elements, we were injecting into `GuiRenderer#draw` which is only a sub step of `GuiRenderer#render`, instead we need to inject after render has finished 

## Related issues

N/A (I actually checked so hard this time)

# How Has This Been Tested?

https://github.com/user-attachments/assets/62e2b697-024e-4a1d-987b-3778fce0b720

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.