### PR TITLE
fix render bugs in xray and wallhack modules when using Indigo renderer (FAPI)

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/indigo/AltModelBlockRendererImplMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/indigo/AltModelBlockRendererImplMixin.java
@@ -11,6 +11,7 @@ import meteordevelopment.meteorclient.systems.modules.render.Xray;
 import net.fabricmc.fabric.api.client.renderer.v1.mesh.MutableQuadView;
 import net.fabricmc.fabric.impl.client.indigo.renderer.render.AltModelBlockRendererImpl;
 import net.minecraft.client.renderer.block.BlockAndTintGetter;
+import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.block.state.BlockState;
@@ -40,7 +41,7 @@ public abstract class AltModelBlockRendererImplMixin {
         Xray xray = Modules.get().get(Xray.class);
 
         if (xray.isActive()) {
-            return xray.modifyDrawSide(blockState, level, pos, direction, original);
+            return !xray.modifyDrawSide(blockState, level, pos, direction, !original);
         }
 
         return original;
@@ -54,6 +55,10 @@ public abstract class AltModelBlockRendererImplMixin {
             cir.setReturnValue(false);
         }
         else if (alpha != -1) {
+            if (alpha > 0 && alpha < 255) {
+                quad.chunkLayer(ChunkSectionLayer.TRANSLUCENT);
+            }
+        	            
             for (int i = 0; i < 4; i++) {
                 quad.color(i, rewriteQuadAlpha(quad.color(i), alpha));
             }

--- a/src/main/java/meteordevelopment/meteorclient/mixin/indigo/AltModelBlockRendererImplMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/indigo/AltModelBlockRendererImplMixin.java
@@ -53,12 +53,11 @@ public abstract class AltModelBlockRendererImplMixin {
 
         if (alpha == 0) {
             cir.setReturnValue(false);
-        }
-        else if (alpha != -1) {
+        } else if (alpha != -1) {
             if (alpha > 0 && alpha < 255) {
                 quad.chunkLayer(ChunkSectionLayer.TRANSLUCENT);
             }
-        	            
+
             for (int i = 0; i < 4; i++) {
                 quad.color(i, rewriteQuadAlpha(quad.color(i), alpha));
             }


### PR DESCRIPTION
## Type of change

- [x] Bug fix

- [ ] New feature

## Description

when using Indigo renderer from fabric api (fapi) transparency was not working on both modules because `AltModelBlockRendererImplMixin.transform$xray()` never changes the chunk layer to `TRANSLUCENT` when alpha is not 0 and 255

fix its just add call inside the `else if`  to
```java
quad.chunkLayer(ChunkSectionLayer.TRANSLUCENT); 
```
checking when `alpha > 0 && alpha < 255`

and import of course
```java
import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
```

also there was a bug in xray where only ores hidden faces were rendering (opposite behavior)

this is because

- `ModelBlockRenderer.shouldRenderFace` returns `true` to **show** exposed faces

- `AltModelBlockRendererImpl.shouldCullFace` returns `true` to **hide** exposed faces

as you can see logic is reversed

the fix is just invert `original` so `modifyDrawSide` returns `true` and then invert again that return so it converts to `false` preventing `shouldCullFace` working while xray is active

## Related issues

https://github.com/MeteorDevelopment/meteor-client/issues/6389

# How Has This Been Tested?

singleplayer and multiplayer

turning on xray and later wallhack

opacity set to different values, works fine

<img width="1366" height="696" alt="2026-05-10_07 17 05" src="https://github.com/user-attachments/assets/4b7f877e-ceba-4262-b454-57d83af33033" />

# Checklist:

- [x] My code follows the style guidelines of this project.

- [ ] I have added comments to my code in more complex areas. (no needed)

- [x] I have tested the code in both development and production environments.

