### PR TITLE
Render fixes

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/input/WDropdown.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/input/WDropdown.java
@@ -16,6 +16,8 @@ import net.minecraft.client.input.CharacterEvent;
 import net.minecraft.client.input.KeyEvent;
 import net.minecraft.util.Mth;
 
+import static meteordevelopment.meteorclient.utils.Utils.getWindowHeight;
+
 public abstract class WDropdown<T> extends WPressable {
     public Runnable action;
 
@@ -112,11 +114,14 @@ public abstract class WDropdown<T> extends WPressable {
         animProgress = Mth.clamp(animProgress, 0, 1);
 
         WView view = getView();
-        boolean rootInView = view == null || view.isWidgetInView(root);
+        boolean rootInView = view == null || view.isWidgetInView(this);
 
         if (!render && animProgress > 0 && rootInView) {
+            double dropdownY = y + height;
+            double scissorHeight = Math.min(root.height * animProgress, getWindowHeight() - dropdownY);
+
             renderer.absolutePost(() -> {
-                renderer.scissorStart(x, y + height, width, root.height * animProgress);
+                renderer.scissorStart(x, dropdownY, width, scissorHeight);
                 root.render(renderer, mouseX, mouseY, delta);
                 renderer.scissorEnd();
             });

--- a/src/main/java/meteordevelopment/meteorclient/mixin/GuiRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/GuiRendererMixin.java
@@ -53,39 +53,51 @@ public abstract class GuiRendererMixin {
         );
     }
 
-    @Inject(method = "render", at = @At("TAIL"))
-    private void draw$executeDrawRange(CallbackInfo ci) {
+    @Inject(method = "render", at = @At("HEAD"))
+    private void render$preGui(CallbackInfo ci) {
         if ((GuiRenderer) (Object) this instanceof MeteorMcGuiRenderer) return;
         var mc = Minecraft.getInstance();
 
+        if (mc.screen == null || mc.screen instanceof WidgetScreen) return;
+        meteor$render2D(mc);
+    }
+
+    @Inject(method = "render", at = @At("TAIL"))
+    private void render$postGui(CallbackInfo ci) {
+        if ((GuiRenderer) (Object) this instanceof MeteorMcGuiRenderer) return;
+        var mc = Minecraft.getInstance();
+
+        RenderSystem.getDevice().createCommandEncoder().clearDepthTexture(mc.getMainRenderTarget().getDepthTexture(), 1.0);
+
+        if (mc.screen == null || mc.screen instanceof WidgetScreen) {
+            meteor$render2D(mc);
+        }
+
+        guiRenderer.endFrame();
+    }
+
+    @Unique
+    private void meteor$render2D(Minecraft mc) {
         var mouseX = (int) mc.mouseHandler.getScaledXPos(mc.getWindow());
         var mouseY = (int) mc.mouseHandler.getScaledYPos(mc.getWindow());
 
         var fogRenderer = ((GameRendererAccessor) mc.gameRenderer).meteor$fogRenderer();
         var delta = mc.getDeltaTracker().getGameTimeDeltaTicks();
-
-        RenderSystem.getDevice().createCommandEncoder().clearDepthTexture(mc.getMainRenderTarget().getDepthTexture(), 1.0);
+        var graphics = new GuiGraphicsExtractor(mc, renderState, mouseX, mouseY);
 
         if (Utils.canUpdate() || HudEditorScreen.isOpen()) {
             Profiler.get().push(MeteorClient.MOD_ID + "_render_2d");
 
             Utils.unscaledProjection();
-
-            var graphics = new GuiGraphicsExtractor(mc, renderState, mouseX, mouseY);
-            MeteorClient.EVENT_BUS.post(Render2DEvent.get(graphics, graphics.guiWidth(), graphics.guiWidth(), delta));
+            MeteorClient.EVENT_BUS.post(Render2DEvent.get(graphics, graphics.guiWidth(), graphics.guiHeight(), delta));
             guiRenderer.render(fogRenderer.getBuffer(FogRenderer.FogMode.NONE));
-
             Utils.scaledProjection();
-
             Profiler.get().pop();
         }
 
         if (mc.screen instanceof WidgetScreen widgetScreen) {
-            var graphics = new GuiGraphicsExtractor(mc, renderState, mouseX, mouseY);
             widgetScreen.renderCustom(graphics, mouseX, mouseY, delta);
             guiRenderer.render(fogRenderer.getBuffer(FogRenderer.FogMode.NONE));
         }
-
-        guiRenderer.endFrame();
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Zoom.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/Zoom.java
@@ -140,6 +140,8 @@ public class Zoom extends Module {
 
     @EventHandler
     private void onMouseScroll(MouseScrollEvent event) {
+        if (mc.screen != null) return;
+
         if (scrollSensitivity.get() > 0 && isActive()) {
             value += event.value * 0.25 * (scrollSensitivity.get() * value);
             if (value < 1) value = 1;


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

- Actually fixes render layering this time, previous fix made all 2D meteor elements render over everything MC, instead it's now split into two branches, we render at tail if no screens are open, otherwise we render at head so the hud/etc get covered
- Fixed an issue where the mouse scroll event in Zoom was intercepting scrolling inside screens
- Dropdown widgets now open as the last element in a window and are clamped to the screen edge

## Related issues

#6390, #6341, #6209

# How Has This Been Tested?

Played for 2 hours after all fixes were applied and encountered no issues in gameplay

https://github.com/user-attachments/assets/9f4f5e62-a491-41f1-a0be-e99d03cd6e3d

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
