### PR TITLE
Allow all particles in ParticleListSettings

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/ParticleTypeListSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/ParticleTypeListSettingScreen.java
@@ -11,7 +11,6 @@ import meteordevelopment.meteorclient.gui.widgets.WWidget;
 import meteordevelopment.meteorclient.settings.Setting;
 import meteordevelopment.meteorclient.utils.misc.Names;
 import net.minecraft.core.particles.ParticleType;
-import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.core.registries.BuiltInRegistries;
 
 import java.util.List;
@@ -19,11 +18,6 @@ import java.util.List;
 public class ParticleTypeListSettingScreen extends CollectionListSettingScreen<ParticleType<?>> {
     public ParticleTypeListSettingScreen(GuiTheme theme, Setting<List<ParticleType<?>>> setting) {
         super(theme, "Select Particles", setting, setting.get(), BuiltInRegistries.PARTICLE_TYPE);
-    }
-
-    @Override
-    protected boolean includeValue(ParticleType<?> value) {
-        return value != ParticleTypes.FLASH;
     }
 
     @Override

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/ParticleTypeListSettingScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/settings/ParticleTypeListSettingScreen.java
@@ -10,8 +10,8 @@ import meteordevelopment.meteorclient.gui.screens.settings.base.CollectionListSe
 import meteordevelopment.meteorclient.gui.widgets.WWidget;
 import meteordevelopment.meteorclient.settings.Setting;
 import meteordevelopment.meteorclient.utils.misc.Names;
-import net.minecraft.core.particles.ParticleOptions;
 import net.minecraft.core.particles.ParticleType;
+import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.core.registries.BuiltInRegistries;
 
 import java.util.List;
@@ -23,7 +23,7 @@ public class ParticleTypeListSettingScreen extends CollectionListSettingScreen<P
 
     @Override
     protected boolean includeValue(ParticleType<?> value) {
-        return value instanceof ParticleOptions;
+        return value != ParticleTypes.FLASH;
     }
 
     @Override

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientLevelMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientLevelMixin.java
@@ -13,6 +13,7 @@ import meteordevelopment.meteorclient.systems.modules.render.NoRender;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
@@ -42,6 +43,16 @@ public abstract class ClientLevelMixin {
             MeteorClient.EVENT_BUS.post(EntityRemovedEvent.get(getEntity(id)));
     }
 
+    @Inject(method = "addDestroyBlockEffect", at = @At("HEAD"), cancellable = true)
+    private void onAddDestroyBlockEffect(BlockPos pos, BlockState blockState, CallbackInfo ci) {
+        if (Modules.get().get(NoRender.class).noParticle(ParticleTypes.BLOCK)) ci.cancel();
+    }
+
+    @Inject(method = "addBreakingBlockEffect", at = @At("HEAD"), cancellable = true)
+    private void onAddBlockBreakingParticles(BlockPos pos, Direction direction, CallbackInfo ci) {
+        if (Modules.get().get(NoRender.class).noParticle(ParticleTypes.BLOCK)) ci.cancel();
+    }
+
     @ModifyArgs(method = "animateTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/multiplayer/ClientLevel;doAnimateTick(IIIILnet/minecraft/util/RandomSource;Lnet/minecraft/world/level/block/Block;Lnet/minecraft/core/BlockPos$MutableBlockPos;)V"))
     private void doRandomBlockDisplayTicks(Args args) {
         if (Modules.get().get(NoRender.class).noBarrierInvis()) {
@@ -49,13 +60,5 @@ public abstract class ClientLevelMixin {
         }
     }
 
-    @Inject(method = "addDestroyBlockEffect", at = @At("HEAD"), cancellable = true)
-    private void onAddDestroyBlockEffect(BlockPos pos, BlockState blockState, CallbackInfo ci) {
-        if (Modules.get().get(NoRender.class).noBlockBreakParticles()) ci.cancel();
-    }
 
-    @Inject(method = "addBreakingBlockEffect", at = @At("HEAD"), cancellable = true)
-    private void onAddBlockBreakingParticles(BlockPos pos, Direction direction, CallbackInfo ci) {
-        if (Modules.get().get(NoRender.class).noBlockBreakParticles()) ci.cancel();
-    }
 }

--- a/src/main/java/meteordevelopment/meteorclient/mixin/ParticleEngineMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ParticleEngineMixin.java
@@ -10,28 +10,17 @@ import meteordevelopment.meteorclient.events.world.ParticleEvent;
 import net.minecraft.client.particle.Particle;
 import net.minecraft.client.particle.ParticleEngine;
 import net.minecraft.core.particles.ParticleOptions;
-import net.minecraft.core.particles.ParticleTypes;
-import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(ParticleEngine.class)
 public abstract class ParticleEngineMixin {
-    @Shadow
-    @Nullable
-    protected abstract <T extends ParticleOptions> Particle makeParticle(T options, double x, double y, double z, double xa, double ya, double za);
-
     @Inject(method = "createParticle(Lnet/minecraft/core/particles/ParticleOptions;DDDDDD)Lnet/minecraft/client/particle/Particle;", at = @At("HEAD"), cancellable = true)
     private void onCreateParticle(ParticleOptions options, double x, double y, double z, double xa, double ya, double za, CallbackInfoReturnable<Particle> cir) {
         ParticleEvent event = MeteorClient.EVENT_BUS.post(ParticleEvent.get(options));
 
-        if (event.isCancelled()) {
-            if (options.getType() == ParticleTypes.FLASH)
-                cir.setReturnValue(makeParticle(options, x, y, z, xa, ya, za));
-            else cir.cancel();
-        }
+        if (event.isCancelled()) cir.cancel();
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/settings/ParticleTypeListSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/ParticleTypeListSetting.java
@@ -37,7 +37,7 @@ public class ParticleTypeListSetting extends Setting<List<ParticleType<?>>> {
         try {
             for (String value : values) {
                 ParticleType<?> particleType = parseId(BuiltInRegistries.PARTICLE_TYPE, value);
-                if (particleType instanceof ParticleOptions) particleTypes.add(particleType);
+                if (particleType != null) particleTypes.add(particleType);
             }
         } catch (Exception _) {
         }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/NoRender.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/NoRender.java
@@ -231,13 +231,6 @@ public class NoRender extends Module {
         .build()
     );
 
-    private final Setting<Boolean> noBlockBreakParticles = sgWorld.add(new BoolSetting.Builder()
-        .name("block-break-particles")
-        .description("Disables rendering of block-break particles.")
-        .defaultValue(false)
-        .build()
-    );
-
     private final Setting<Boolean> noBlockBreakOverlay = sgWorld.add(new BoolSetting.Builder()
         .name("block-break-overlay")
         .description("Disables rendering of block-break overlay.")
@@ -512,8 +505,8 @@ public class NoRender extends Module {
         return isActive() && noSignText.get();
     }
 
-    public boolean noBlockBreakParticles() {
-        return isActive() && noBlockBreakParticles.get();
+    public boolean noParticle(ParticleType<?> type) {
+        return isActive() && particles.get().contains(type);
     }
 
     public boolean noBlockBreakOverlay() {

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/Names.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/Names.java
@@ -15,7 +15,6 @@ import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.client.sounds.WeighedSoundEvents;
 import net.minecraft.core.Holder;
-import net.minecraft.core.particles.ParticleOptions;
 import net.minecraft.core.particles.ParticleType;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
@@ -107,7 +106,6 @@ public class Names {
     }
 
     public static String get(ParticleType<?> type) {
-        if (!(type instanceof ParticleOptions)) return "";
         return particleTypesNames.computeIfAbsent(type, _ -> StringUtils.capitalize(BuiltInRegistries.PARTICLE_TYPE.getKey(type).getPath().replace("_", " ")));
     }
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Removed the `instanceof ParticleOptions` check when creating particle list settings. Originally only particles of type `SimpleParticleType` would be shown, because they implement both `ParticleType` and `ParticleOptions`, however several other particles like potion swirls use a separate `ParticleOptions` which would cause them to be dropped

Related, because block destroy particles were previously excluded by the filter, the dedicated setting has been removed to prefer using the particles setting. It also seems like the Flash particle type was hardcoded to always render during the 26.1.2 port but I was unable to find anywhere that depended on the particle being created, so I removed the block and it can be canceled properly

## Related issues

N/A

# How Has This Been Tested?

Compiled a list of every particle that was previously blocked, which includes:
- Entity Effect / Effect / Instant Effect
- Dust
- Dust Color Transition
- Dragon Breath
- Tinted Leaves
- Block / Block Marker / Block Crumble
- Falling Dust
- Dust Pillar
- Sculk Charge
- Vibration
- Shriek
- Trail
- Flash

And created commands blocks to spawn each, NoRender now keeps them from spawning:

https://github.com/user-attachments/assets/ad07b54f-b36f-4fa1-b648-90df399bef37

Also played in normal anarchy server for ~1 hour and experienced no new bugs or weirdness

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
