### PR TITLE
slightly improve file i/o

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/utils/files/ByteBufferUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/files/ByteBufferUtils.java
@@ -15,7 +15,6 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.function.IntFunction;
 
-import static java.nio.file.Files.size;
 
 @NullMarked
 public final class ByteBufferUtils {
@@ -24,21 +23,23 @@ public final class ByteBufferUtils {
 
     public static ByteBuffer readFully(Path path, IntFunction<ByteBuffer> allocator) throws IOException {
         try (FileChannel channel = FileChannel.open(path, StandardOpenOption.READ)) {
-            long size = size(path);
+            long size = channel.size();
             if (size > Integer.MAX_VALUE) {
                 throw new IOException("File too large to read into ByteBuffer: " + path);
             }
-            ByteBuffer buffer = allocator.apply((int) size);
-            while (buffer.hasRemaining()) {
-                int bytesRead = channel.read(buffer);
-                if (bytesRead == -1) break; // EOF
-            }
-            buffer.flip();
-            return buffer;
+            return readFully(channel, (int) size, allocator);
         }
     }
 
     public static ByteBuffer readFully(ReadableByteChannel channel, IntFunction<ByteBuffer> allocator) throws IOException {
+        if (channel instanceof FileChannel fileChannel) {
+            long size = fileChannel.size();
+            if (size > Integer.MAX_VALUE) {
+                throw new IOException("File too large to read into ByteBuffer");
+            }
+            return readFully(fileChannel, (int) size, allocator);
+        }
+
         ByteBuffer buffer = requireCapacity(allocator.apply(8192), 8192);
 
         while (true) {
@@ -63,6 +64,16 @@ public final class ByteBufferUtils {
             }
         }
 
+        buffer.flip();
+        return buffer;
+    }
+
+    private static ByteBuffer readFully(FileChannel fileChannel, int fileSize, IntFunction<ByteBuffer> allocator) throws IOException {
+        ByteBuffer buffer = requireCapacity(allocator.apply(fileSize), fileSize);
+        while (buffer.hasRemaining()) {
+            int bytesRead = fileChannel.read(buffer);
+            if (bytesRead == -1) break; // EOF
+        }
         buffer.flip();
         return buffer;
     }

--- a/src/main/java/meteordevelopment/meteorclient/utils/files/ByteBufferUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/files/ByteBufferUtils.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.SeekableByteChannel;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.function.IntFunction;
@@ -31,12 +32,13 @@ public final class ByteBufferUtils {
     }
 
     public static ByteBuffer readFully(ReadableByteChannel channel, IntFunction<ByteBuffer> allocator) throws IOException {
-        if (channel instanceof FileChannel fileChannel) {
-            long size = fileChannel.size();
+        // special-case if content size is known
+        if (channel instanceof SeekableByteChannel seekableChannel) {
+            long size = seekableChannel.size();
             if (size > Integer.MAX_VALUE) {
-                throw new IOException("File too large to read into ByteBuffer");
+                throw new IOException("Channel content too large to read into ByteBuffer");
             }
-            return readFully(fileChannel, (int) size, allocator);
+            return readFully(seekableChannel, (int) size, allocator);
         }
 
         ByteBuffer buffer = requireCapacity(allocator.apply(8192), 8192);
@@ -67,10 +69,10 @@ public final class ByteBufferUtils {
         return buffer;
     }
 
-    private static ByteBuffer readFully(FileChannel fileChannel, int fileSize, IntFunction<ByteBuffer> allocator) throws IOException {
-        ByteBuffer buffer = requireCapacity(allocator.apply(fileSize), fileSize);
+    private static ByteBuffer readFully(SeekableByteChannel channel, int size, IntFunction<ByteBuffer> allocator) throws IOException {
+        ByteBuffer buffer = requireCapacity(allocator.apply(size), size);
         while (buffer.hasRemaining()) {
-            int bytesRead = fileChannel.read(buffer);
+            int bytesRead = channel.read(buffer);
             if (bytesRead == -1) break; // EOF
         }
         buffer.flip();

--- a/src/main/java/meteordevelopment/meteorclient/utils/files/ByteBufferUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/files/ByteBufferUtils.java
@@ -15,7 +15,6 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.function.IntFunction;
 
-
 @NullMarked
 public final class ByteBufferUtils {
     private ByteBufferUtils() {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature

## Description

- use `FileChannel#size` instead of `Files#size` to reduce i/o calls
- special-case `SeekableByteChannel` in the `readFully` `ReadableByteChannel` overload to reduce the buffer allocation rate, useful since most calls to this overload pass in a `FileChannel`
- add `requireCapacity` sanity checking to the `readFully` `Path` overload

## Related issues

none

# How Has This Been Tested?

the J

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
