### PR TITLE
Fixed Better Tooltips shulker box tooltip translation string

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BetterTooltips.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BetterTooltips.java
@@ -416,7 +416,7 @@ public class BetterTooltips extends Module {
         });
 
         if (counts.size() > 5) {
-            textConsumer.accept((Component.translatable("container.shulkerBox.more", counts.size() - 5)).withStyle(ChatFormatting.ITALIC));
+            textConsumer.accept((Component.translatable("item.container.more_items", counts.size() - 5)).withStyle(ChatFormatting.ITALIC));
         }
     }
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix

## Description

Shulker box tooltip used a deprecated translation string when Better Tooltips was enabled.

<img width="587" height="398" alt="2026-05-21_00-26-06" src="https://github.com/user-attachments/assets/0d7fa90f-f87d-4783-9061-0db2267f7de4" />

I have replaced the translation string with the correct one.