### PR TITLE
Fix 2D rendering being choppy

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/GuiRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/GuiRendererMixin.java
@@ -80,23 +80,27 @@ public abstract class GuiRendererMixin {
     private void meteor$render2D(Minecraft mc) {
         var mouseX = (int) mc.mouseHandler.getScaledXPos(mc.getWindow());
         var mouseY = (int) mc.mouseHandler.getScaledYPos(mc.getWindow());
-
         var fogRenderer = ((GameRendererAccessor) mc.gameRenderer).meteor$fogRenderer();
-        var delta = mc.getDeltaTracker().getGameTimeDeltaTicks();
-        var graphics = new GuiGraphicsExtractor(mc, renderState, mouseX, mouseY);
 
         if (Utils.canUpdate() || HudEditorScreen.isOpen()) {
             Profiler.get().push(MeteorClient.MOD_ID + "_render_2d");
-
             Utils.unscaledProjection();
-            MeteorClient.EVENT_BUS.post(Render2DEvent.get(graphics, graphics.guiWidth(), graphics.guiHeight(), delta));
+
+            var graphics = new GuiGraphicsExtractor(mc, renderState, mouseX, mouseY);
+            var tickDelta = mc.getDeltaTracker().getGameTimeDeltaPartialTick(true);
+
+            MeteorClient.EVENT_BUS.post(Render2DEvent.get(graphics, graphics.guiWidth(), graphics.guiHeight(), tickDelta));
             guiRenderer.render(fogRenderer.getBuffer(FogRenderer.FogMode.NONE));
+
             Utils.scaledProjection();
             Profiler.get().pop();
         }
 
         if (mc.screen instanceof WidgetScreen widgetScreen) {
-            widgetScreen.renderCustom(graphics, mouseX, mouseY, delta);
+            var graphics = new GuiGraphicsExtractor(mc, renderState, mouseX, mouseY);
+            var guiDelta = mc.getDeltaTracker().getGameTimeDeltaTicks();
+
+            widgetScreen.renderCustom(graphics, mouseX, mouseY, guiDelta);
             guiRenderer.render(fogRenderer.getBuffer(FogRenderer.FogMode.NONE));
         }
     }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

From what I can tell, deltaTracker.getGameTimeDeltaTicks() returns an approximation of how long a frame lasted in terms of 1 tick, while getGameTimeDeltaPartialTick() returns how far into the current tick we are, which is what we used until 26.1. So for example, if the game were running at 60 fps and 20 tps, the outputs for each during 1 tick would be:

_deltaTicks_
Frame 1: 0.33
Frame 2: 0.33
Frame 3: 0.33

_deltaPartialTick_
Frame 1: 0.33
Frame 2: 0.66
Frame 3: 0.99

For ingame 2D rendering we need partialTick to interpolate positions based on progress in the current tick, while deltaTicks serves as a reference for how fast animations and rendering should advance frame to frame, previously we've only been passing one or the other to both (currently passing partialTick, which causes the delta to always be identical, this interpolating nametags to the same position every frame)

Fix is to provide the different deltas to the systems that need them

## Related issues

N/A

# How Has This Been Tested?

Before: 

https://github.com/user-attachments/assets/b69950db-dc70-4abb-beeb-331f3a625b71

After:

https://github.com/user-attachments/assets/54fdba27-7473-4120-8b4a-51c897364fd9

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
