### PR TITLE
Better Farming module (crop farming improvements)

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
@@ -435,6 +435,7 @@ public class Modules extends System<Modules> {
         add(new AutoRespawn());
         add(new AutoTool());
         add(new BreakDelay());
+        add(new BetterFarming());
         add(new ChestSwap());
         add(new EXPThrower());
         add(new FakePlayer());

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/BetterFarming.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/BetterFarming.java
@@ -1,0 +1,155 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.systems.modules.player;
+
+import meteordevelopment.meteorclient.MeteorClient;
+import meteordevelopment.meteorclient.events.entity.player.StartBreakingBlockEvent;
+import meteordevelopment.meteorclient.events.packets.PacketEvent;
+import meteordevelopment.meteorclient.events.world.TickEvent;
+import meteordevelopment.meteorclient.mixin.ServerboundMovePlayerPacketAccessor;
+import meteordevelopment.meteorclient.mixininterface.IServerboundMovePlayerPacket;
+import meteordevelopment.meteorclient.settings.BoolSetting;
+import meteordevelopment.meteorclient.settings.Setting;
+import meteordevelopment.meteorclient.settings.SettingGroup;
+import meteordevelopment.meteorclient.systems.modules.Categories;
+import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.meteorclient.utils.player.FindItemResult;
+import meteordevelopment.meteorclient.utils.player.InvUtils;
+import meteordevelopment.meteorclient.utils.world.BlockUtils;
+import meteordevelopment.orbit.EventHandler;
+import meteordevelopment.orbit.EventPriority;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+
+import java.util.ArrayList;
+
+public class BetterFarming extends Module {
+    private final SettingGroup sgGeneral = settings.getDefaultGroup();
+
+    // General
+
+    private final Setting<Boolean> cropReplace = sgGeneral.add(new BoolSetting.Builder()
+        .name("crop-replace")
+        .description("Automatically plant new crop on harvest.")
+        .defaultValue(true)
+        .build()
+    );
+
+    private final Setting<Boolean> suppressTrample = sgGeneral.add(new BoolSetting.Builder()
+        .name("suppress-trample")
+        .description("Attempts to prevent player from trampling crops.")
+        .defaultValue(true)
+        .build()
+    );
+
+    public BetterFarming() {
+        super(Categories.Player, "better-farming", "Improvements for crop farming.");
+    }
+
+    private Item placeItem = null;
+    private ArrayList<BlockPos> placements = new ArrayList<>();
+    private int mineCooldown = 0;
+
+    @EventHandler(priority = EventPriority.HIGH)
+    private void onTick(TickEvent.Pre event) {
+        if (cropReplace.get()) autoPlaceTick();
+    }
+
+    @EventHandler(priority = EventPriority.HIGH)
+    private void onStartBreakingBlockEvent(StartBreakingBlockEvent event) {
+        if (cropReplace.get()) autoPlaceBreakEvent(event);
+    }
+
+    @EventHandler
+    private void onSendPacket(PacketEvent.Send event) {
+        if (suppressTrample.get()) trampleSuppressionSendEvent(event);
+    }
+
+    private void autoPlaceTick() {
+        if (mineCooldown > 0) {
+            mineCooldown--;
+        }
+
+        if (placeItem == null) return;
+        if (placements.isEmpty()) {
+            placeItem = null;
+            return;
+        }
+
+        BlockPos blockPos = placements.getFirst();
+        placements.removeFirst();
+
+        FindItemResult foundItem = InvUtils.find(placeItem);
+
+        // If the found item is not in mainhand yet, its not ready
+        if (!foundItem.isMainHand()) return;
+
+        BlockState blockState = mc.level.getBlockState(blockPos);
+
+        if (blockState.is(BlockTags.AIR)) {
+            BlockUtils.place(blockPos, foundItem, 0);
+        } else {
+            BlockUtils.breakBlock(blockPos, true);
+        }
+    }
+
+    private void autoPlaceBreakEvent(StartBreakingBlockEvent event) {
+        MeteorClient.LOG.info("BREAK");
+        BlockState blockState = mc.level.getBlockState(event.blockPos);
+
+        if (!blockState.is(BlockTags.CROPS)) return;
+
+        if (mineCooldown > 0) {
+            event.cancel();
+            return;
+        }
+
+        Item blockItem = blockState.getBlock().asItem();
+        FindItemResult foundItem = InvUtils.find(blockItem);
+
+        if (!foundItem.found()) return;
+
+        placeItem = blockItem;
+        placements.add(event.blockPos);
+        mineCooldown = 3;
+
+        if (foundItem.isMainHand()) return;
+
+        mc.gameMode.handlePickItemFromBlock(event.blockPos, false);
+
+        // Cancel the event to allow pickblock to do its thing
+        event.cancel();
+    }
+
+    private void trampleSuppressionSendEvent(PacketEvent.Send event) {
+        if (mc.player == null) return;
+        if (!(event.packet instanceof ServerboundMovePlayerPacket)
+            || ((IServerboundMovePlayerPacket) event.packet).meteor$getTag() == 1337) return;
+
+        ServerboundMovePlayerPacket packet = (ServerboundMovePlayerPacket) event.packet;
+
+        // Only suppress fall if current block or block beneath is farmland
+        BlockPos blockPos = new BlockPos(
+            (int) packet.getX(0d),
+            (int) packet.getY(0d),
+            (int) packet.getZ(0d)
+        );
+
+        BlockState blockState1 = mc.level.getBlockState(blockPos.offset(0, -1, 0));
+        // Check block one over as well to fix edge jumping
+        BlockState blockState2 = mc.level.getBlockState(blockPos.offset(-1, -1, 1));
+
+        MeteorClient.LOG.info(blockPos.toShortString());
+
+        if (blockState1.is(Blocks.FARMLAND) || blockState2.is(Blocks.FARMLAND)) {
+            ((ServerboundMovePlayerPacketAccessor) event.packet).meteor$setOnGround(true);
+        }
+    }
+}

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/BetterFarming.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/BetterFarming.java
@@ -5,7 +5,6 @@
 
 package meteordevelopment.meteorclient.systems.modules.player;
 
-import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.events.entity.player.StartBreakingBlockEvent;
 import meteordevelopment.meteorclient.events.packets.PacketEvent;
 import meteordevelopment.meteorclient.events.world.TickEvent;
@@ -26,6 +25,7 @@ import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.CropBlock;
 import net.minecraft.world.level.block.state.BlockState;
 
 import java.util.ArrayList;
@@ -49,13 +49,20 @@ public class BetterFarming extends Module {
         .build()
     );
 
+    private final Setting<Boolean> noBreakUnripe = sgGeneral.add(new BoolSetting.Builder()
+        .name("no-break-unripe")
+        .description("Prevents player from breaking unripe crops.")
+        .defaultValue(true)
+        .build()
+    );
+
     public BetterFarming() {
         super(Categories.Player, "better-farming", "Improvements for crop farming.");
     }
 
     private Item placeItem = null;
-    private ArrayList<BlockPos> placements = new ArrayList<>();
-    private int mineCooldown = 0;
+    private ArrayList<BlockPos> cropPlacements = new ArrayList<>();
+    private int blockBreakCooldown = 0;
 
     @EventHandler(priority = EventPriority.HIGH)
     private void onTick(TickEvent.Pre event) {
@@ -64,6 +71,7 @@ public class BetterFarming extends Module {
 
     @EventHandler(priority = EventPriority.HIGH)
     private void onStartBreakingBlockEvent(StartBreakingBlockEvent event) {
+        if (noBreakUnripe.get()) noBreakUnripeBreakEvent(event);
         if (cropReplace.get()) autoPlaceBreakEvent(event);
     }
 
@@ -72,19 +80,29 @@ public class BetterFarming extends Module {
         if (suppressTrample.get()) trampleSuppressionSendEvent(event);
     }
 
+    private void noBreakUnripeBreakEvent(StartBreakingBlockEvent event) {
+        BlockState blockState = mc.level.getBlockState(event.blockPos);
+
+        if (blockState.getBlock() instanceof CropBlock cropBlock) {
+            if (cropBlock.isMaxAge(blockState)) return;
+
+            event.cancel();
+        }
+    }
+
     private void autoPlaceTick() {
-        if (mineCooldown > 0) {
-            mineCooldown--;
+        if (blockBreakCooldown > 0) {
+            blockBreakCooldown--;
         }
 
         if (placeItem == null) return;
-        if (placements.isEmpty()) {
+        if (cropPlacements.isEmpty()) {
             placeItem = null;
             return;
         }
 
-        BlockPos blockPos = placements.getFirst();
-        placements.removeFirst();
+        BlockPos blockPos = cropPlacements.getFirst();
+        cropPlacements.removeFirst();
 
         FindItemResult foundItem = InvUtils.find(placeItem);
 
@@ -101,12 +119,13 @@ public class BetterFarming extends Module {
     }
 
     private void autoPlaceBreakEvent(StartBreakingBlockEvent event) {
-        MeteorClient.LOG.info("BREAK");
+        if (event.isCancelled()) return;
+
         BlockState blockState = mc.level.getBlockState(event.blockPos);
 
         if (!blockState.is(BlockTags.CROPS)) return;
 
-        if (mineCooldown > 0) {
+        if (blockBreakCooldown > 0) {
             event.cancel();
             return;
         }
@@ -117,10 +136,12 @@ public class BetterFarming extends Module {
         if (!foundItem.found()) return;
 
         placeItem = blockItem;
-        placements.add(event.blockPos);
-        mineCooldown = 3;
+        cropPlacements.add(event.blockPos);
 
-        if (foundItem.isMainHand()) return;
+        if (foundItem.isMainHand()) {
+            blockBreakCooldown = 3;
+            return;
+        };
 
         mc.gameMode.handlePickItemFromBlock(event.blockPos, false);
 
@@ -135,21 +156,33 @@ public class BetterFarming extends Module {
 
         ServerboundMovePlayerPacket packet = (ServerboundMovePlayerPacket) event.packet;
 
-        // Only suppress fall if current block or block beneath is farmland
         BlockPos blockPos = new BlockPos(
             (int) packet.getX(0d),
             (int) packet.getY(0d),
             (int) packet.getZ(0d)
         );
 
-        BlockState blockState1 = mc.level.getBlockState(blockPos.offset(0, -1, 0));
-        // Check block one over as well to fix edge jumping
-        BlockState blockState2 = mc.level.getBlockState(blockPos.offset(-1, -1, 1));
+        // Only suppress fall if blocks beneath are farmland
+        // Check 3x3 area beneath player, for if the player jumps on the edge
+        BlockPos[] posChecks = {
+            blockPos.offset(-1, -1, -1),
+            blockPos.offset(-1, -1, 0),
+            blockPos.offset(-1, -1, 1),
+            blockPos.offset(0, -1, -1),
+            blockPos.offset(0, -1, 0),
+            blockPos.offset(0, -1, 1),
+            blockPos.offset(1, -1, -1),
+            blockPos.offset(1, -1, 0),
+            blockPos.offset(1, -1, 1),
+        };
 
-        MeteorClient.LOG.info(blockPos.toShortString());
+        for (BlockPos pos : posChecks) {
+            BlockState blockState = mc.level.getBlockState(pos);
 
-        if (blockState1.is(Blocks.FARMLAND) || blockState2.is(Blocks.FARMLAND)) {
-            ((ServerboundMovePlayerPacketAccessor) event.packet).meteor$setOnGround(true);
+            if (blockState.is(Blocks.FARMLAND)) {
+                ((ServerboundMovePlayerPacketAccessor) event.packet).meteor$setOnGround(true);
+                break;
+            }
         }
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/BetterFarming.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/BetterFarming.java
@@ -26,12 +26,14 @@ import net.minecraft.tags.BlockTags;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.CropBlock;
+import net.minecraft.world.level.block.NetherWartBlock;
 import net.minecraft.world.level.block.state.BlockState;
 
 import java.util.ArrayList;
 
 public class BetterFarming extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
+    private final SettingGroup sgNoBreak = settings.createGroup("No Break");
 
     // General
 
@@ -49,9 +51,16 @@ public class BetterFarming extends Module {
         .build()
     );
 
-    private final Setting<Boolean> noBreakUnripe = sgGeneral.add(new BoolSetting.Builder()
+    private final Setting<Boolean> noBreakUnripe = sgNoBreak.add(new BoolSetting.Builder()
         .name("no-break-unripe")
         .description("Prevents player from breaking unripe crops.")
+        .defaultValue(true)
+        .build()
+    );
+
+    private final Setting<Boolean> noBreakCaneBase = sgNoBreak.add(new BoolSetting.Builder()
+        .name("no-break-cane-base")
+        .description("Prevents player from breaking the base of sugarcane and bamboo blocks.")
         .defaultValue(true)
         .build()
     );
@@ -61,7 +70,7 @@ public class BetterFarming extends Module {
     }
 
     private Item placeItem = null;
-    private ArrayList<BlockPos> cropPlacements = new ArrayList<>();
+    private final ArrayList<BlockPos> cropPlacements = new ArrayList<>();
     private int blockBreakCooldown = 0;
 
     @EventHandler(priority = EventPriority.HIGH)
@@ -72,6 +81,7 @@ public class BetterFarming extends Module {
     @EventHandler(priority = EventPriority.HIGH)
     private void onStartBreakingBlockEvent(StartBreakingBlockEvent event) {
         if (noBreakUnripe.get()) noBreakUnripeBreakEvent(event);
+        if (noBreakCaneBase.get()) noBreakCaneBaseEvent(event);
         if (cropReplace.get()) autoPlaceBreakEvent(event);
     }
 
@@ -88,6 +98,24 @@ public class BetterFarming extends Module {
 
             event.cancel();
         }
+
+        if (blockState.getBlock() instanceof NetherWartBlock) {
+            if (blockState.getValue(NetherWartBlock.AGE) >= NetherWartBlock.MAX_AGE) return;
+
+            event.cancel();
+        }
+    }
+
+    private void noBreakCaneBaseEvent(StartBreakingBlockEvent event) {
+        BlockState blockState = mc.level.getBlockState(event.blockPos);
+        BlockState bsBelow = mc.level.getBlockState(event.blockPos.offset(0, -1, 0));
+
+        boolean bsIsCane = (blockState.is(Blocks.SUGAR_CANE) || blockState.is(Blocks.BAMBOO));
+        boolean bsBelowIsCane = (bsBelow.is(Blocks.SUGAR_CANE) || bsBelow.is(Blocks.BAMBOO));
+
+        if (!bsIsCane || bsBelowIsCane) return;
+
+        event.cancel();
     }
 
     private void autoPlaceTick() {
@@ -123,7 +151,7 @@ public class BetterFarming extends Module {
 
         BlockState blockState = mc.level.getBlockState(event.blockPos);
 
-        if (!blockState.is(BlockTags.CROPS)) return;
+        if (!(blockState.is(BlockTags.CROPS) || blockState.is(Blocks.NETHER_WART))) return;
 
         if (blockBreakCooldown > 0) {
             event.cancel();

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/BetterFarming.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/BetterFarming.java
@@ -21,6 +21,7 @@ import meteordevelopment.meteorclient.utils.world.BlockUtils;
 import meteordevelopment.orbit.EventHandler;
 import meteordevelopment.orbit.EventPriority;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.world.item.Item;
@@ -28,6 +29,7 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.CropBlock;
 import net.minecraft.world.level.block.NetherWartBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 
 import java.util.ArrayList;
 
@@ -60,7 +62,14 @@ public class BetterFarming extends Module {
 
     private final Setting<Boolean> noBreakCaneBase = sgNoBreak.add(new BoolSetting.Builder()
         .name("no-break-cane-base")
-        .description("Prevents player from breaking the base of sugarcane and bamboo blocks.")
+        .description("Prevents player from breaking the base of sugarcane, bamboo and cactus blocks.")
+        .defaultValue(true)
+        .build()
+    );
+
+    private final Setting<Boolean> noBreakSupportingBlocks = sgNoBreak.add(new BoolSetting.Builder()
+        .name("no-break-supporting-blocks")
+        .description("Prevents player from breaking the block supporting a crop, eg. Jungle log with cocoa, budding amethyst, sand under cactus.")
         .defaultValue(true)
         .build()
     );
@@ -81,7 +90,8 @@ public class BetterFarming extends Module {
     @EventHandler(priority = EventPriority.HIGH)
     private void onStartBreakingBlockEvent(StartBreakingBlockEvent event) {
         if (noBreakUnripe.get()) noBreakUnripeBreakEvent(event);
-        if (noBreakCaneBase.get()) noBreakCaneBaseEvent(event);
+        if (noBreakCaneBase.get()) noBreakCaneBaseBreakEvent(event);
+        if (noBreakSupportingBlocks.get()) noBreakSupportingBlocksBreakEvent(event);
         if (cropReplace.get()) autoPlaceBreakEvent(event);
     }
 
@@ -106,16 +116,79 @@ public class BetterFarming extends Module {
         }
     }
 
-    private void noBreakCaneBaseEvent(StartBreakingBlockEvent event) {
+    private boolean isCaneBlock(BlockState blockState) {
+        return blockState.is(Blocks.SUGAR_CANE)
+            || blockState.is(Blocks.BAMBOO)
+            || blockState.is(Blocks.CACTUS);
+    }
+
+    private boolean isSupportedBelowCrop(BlockState blockState) {
+        return blockState.is(BlockTags.CROPS)
+            || blockState.is(Blocks.NETHER_WART)
+            || isCaneBlock(blockState);
+    }
+
+    private boolean isReplaceableCrop(BlockState blockState) {
+        return blockState.is(BlockTags.CROPS)
+            || blockState.is(Blocks.NETHER_WART);
+    }
+
+    private boolean checkForCocoa(BlockPos blockPos) {
+        Direction[] checkDirections = {
+            Direction.NORTH,
+            Direction.SOUTH,
+            Direction.EAST,
+            Direction.WEST,
+        };
+
+        for (Direction direction : checkDirections) {
+            // Check block at blockPos offset by the direction normal vector.
+            BlockState bsCheck = mc.level.getBlockState(blockPos.offset(direction.getUnitVec3i()));
+
+            if (bsCheck.is(Blocks.COCOA)) {
+
+                Direction facingDirection = bsCheck.getValue(BlockStateProperties.HORIZONTAL_FACING);
+
+                if (facingDirection == direction.getOpposite()) {
+                    return true;
+                }
+            }
+
+        }
+
+        return false;
+    }
+
+    private void noBreakCaneBaseBreakEvent(StartBreakingBlockEvent event) {
         BlockState blockState = mc.level.getBlockState(event.blockPos);
         BlockState bsBelow = mc.level.getBlockState(event.blockPos.offset(0, -1, 0));
 
-        boolean bsIsCane = (blockState.is(Blocks.SUGAR_CANE) || blockState.is(Blocks.BAMBOO));
-        boolean bsBelowIsCane = (bsBelow.is(Blocks.SUGAR_CANE) || bsBelow.is(Blocks.BAMBOO));
+        boolean bsIsCane = isCaneBlock(blockState);
+        boolean bsBelowIsCane = isCaneBlock(bsBelow);
 
         if (!bsIsCane || bsBelowIsCane) return;
 
         event.cancel();
+    }
+
+    private void noBreakSupportingBlocksBreakEvent(StartBreakingBlockEvent event) {
+        BlockPos blockPos = event.blockPos;
+        BlockState blockState = mc.level.getBlockState(blockPos);
+        BlockState bsAbove = mc.level.getBlockState(blockPos.offset(0, 1, 0));
+
+        if (!isSupportedBelowCrop(blockState) && isSupportedBelowCrop(bsAbove)) {
+            event.cancel();
+            return;
+        }
+
+        if (blockState.is(BlockTags.SUPPORTS_COCOA) && checkForCocoa(blockPos)) {
+            event.cancel();
+            return;
+        }
+
+        if (blockState.is(Blocks.BUDDING_AMETHYST)) {
+            event.cancel();
+        }
     }
 
     private void autoPlaceTick() {
@@ -151,7 +224,7 @@ public class BetterFarming extends Module {
 
         BlockState blockState = mc.level.getBlockState(event.blockPos);
 
-        if (!(blockState.is(BlockTags.CROPS) || blockState.is(Blocks.NETHER_WART))) return;
+        if (!isReplaceableCrop(blockState)) return;
 
         if (blockBreakCooldown > 0) {
             event.cancel();

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/BetterFarming.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/BetterFarming.java
@@ -144,7 +144,7 @@ public class BetterFarming extends Module {
 
         for (Direction direction : checkDirections) {
             // Check block at blockPos offset by the direction normal vector.
-            BlockState bsCheck = mc.level.getBlockState(blockPos.offset(direction.getUnitVec3i()));
+            BlockState bsCheck = mc.level.getBlockState(blockPos.relative(direction));
 
             if (bsCheck.is(Blocks.COCOA)) {
 

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/BetterFarming.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/BetterFarming.java
@@ -24,6 +24,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket;
 import net.minecraft.tags.BlockTags;
+import net.minecraft.util.ArrayListDeque;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.CropBlock;
@@ -79,7 +80,7 @@ public class BetterFarming extends Module {
     }
 
     private Item placeItem = null;
-    private final ArrayList<BlockPos> cropPlacements = new ArrayList<>();
+    private final ArrayListDeque<BlockPos> cropPlacements = new ArrayListDeque<>();
     private int blockBreakCooldown = 0;
 
     @EventHandler(priority = EventPriority.HIGH)
@@ -174,7 +175,7 @@ public class BetterFarming extends Module {
     private void noBreakSupportingBlocksBreakEvent(StartBreakingBlockEvent event) {
         BlockPos blockPos = event.blockPos;
         BlockState blockState = mc.level.getBlockState(blockPos);
-        BlockState bsAbove = mc.level.getBlockState(blockPos.offset(0, 1, 0));
+        BlockState bsAbove = mc.level.getBlockState(blockPos.above());
 
         if (!isSupportedBelowCrop(blockState) && isSupportedBelowCrop(bsAbove)) {
             event.cancel();
@@ -242,7 +243,7 @@ public class BetterFarming extends Module {
         if (foundItem.isMainHand()) {
             blockBreakCooldown = 3;
             return;
-        };
+        }
 
         mc.gameMode.handlePickItemFromBlock(event.blockPos, false);
 
@@ -257,10 +258,10 @@ public class BetterFarming extends Module {
 
         ServerboundMovePlayerPacket packet = (ServerboundMovePlayerPacket) event.packet;
 
-        BlockPos blockPos = new BlockPos(
-            (int) packet.getX(0d),
-            (int) packet.getY(0d),
-            (int) packet.getZ(0d)
+        BlockPos blockPos = BlockPos.containing(
+            packet.getX(0d),
+            packet.getY(0d),
+            packet.getZ(0d)
         );
 
         // Only suppress fall if blocks beneath are farmland


### PR DESCRIPTION
## Type of change

- [x] New feature

## Description

This adds a new module, named Better Farming, which adds couple of utilities related to crop farming.

Firstly, the module will attempt to replace a harvested crop automatically, granted the player has its seed in their inventory.

Secondly, using the same method as NoFall, but changing it to work only when above farmland, it suppresses crop trampling, allowing the player to jump on the crops without them trampling.

Then, it will also prevent the player from harvesting crops that are not yet ripe.

Lastly, for sugar cane and bamboo, it will prevent the player from breaking the bottom block.

All of these should help players maintain sizable manual crop farms. All listed behaviours can be toggled in the settings.

<img width="357" height="465" alt="image" src="https://github.com/user-attachments/assets/5962e5e5-bfbf-4cd2-961e-63c57237ffff" />


# How Has This Been Tested?
https://youtu.be/VH0yt58lyZs

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
