### PR TITLE
Add teleport button to waypoints when player has OP

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/WaypointsModule.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/WaypointsModule.java
@@ -24,6 +24,7 @@ import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.systems.waypoints.Waypoint;
 import meteordevelopment.meteorclient.systems.waypoints.Waypoints;
 import meteordevelopment.meteorclient.utils.Utils;
+import meteordevelopment.meteorclient.utils.player.ChatUtils;
 import meteordevelopment.meteorclient.utils.player.PlayerUtils;
 import meteordevelopment.meteorclient.utils.render.NametagUtils;
 import meteordevelopment.meteorclient.utils.render.color.Color;
@@ -33,6 +34,7 @@ import net.minecraft.client.gui.screens.DeathScreen;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.server.permissions.Permissions;
 import net.minecraft.world.phys.Vec3;
 import org.joml.Vector3d;
 
@@ -41,6 +43,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import static meteordevelopment.meteorclient.MeteorClient.mc;
 import static meteordevelopment.meteorclient.utils.player.ChatUtils.formatCoords;
 
 public class WaypointsModule extends Module {
@@ -252,6 +255,24 @@ public class WaypointsModule extends Module {
                         PathManagers.get().stop();
 
                     PathManagers.get().moveTo(waypoint.getPos());
+                };
+            }
+
+            boolean isOperator = mc.player.permissions().hasPermission(Permissions.COMMANDS_GAMEMASTER);
+            if (isOperator) {
+                WButton teleportB = table.add(theme.button("TP")).widget();
+                teleportB.action = () -> {
+                    BlockPos pos = waypoint.pos.get();
+
+                    String command = String.format(
+                        "/execute in %s run tp %d %d %d",
+                        waypoint.dimension.toString(),
+                        pos.getX(),
+                        pos.getY(),
+                        pos.getZ()
+                    );
+
+                    ChatUtils.sendPlayerMsg(command, false);
                 };
             }
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/world/Dimension.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/world/Dimension.java
@@ -17,4 +17,12 @@ public enum Dimension {
             default -> this;
         };
     }
+
+    public String toString() {
+        return switch (this) {
+            case Nether -> "minecraft:the_nether";
+            case End -> "minecraft:the_end";
+            default -> "minecraft:overworld";
+        };
+    }
 }


### PR DESCRIPTION
## Type of change

- [x] New feature

## Description

Adds a button to the waypoints UI to teleport to said waypoint. Only shows if the player has OP.

Useful for creative mode worlds.

<img width="617" height="535" alt="image" src="https://github.com/user-attachments/assets/2ce892a1-823a-4554-9f7d-2d916163dbb4" />
