### PR TITLE
add confirmation step to 'set here' in BlockPosSetting

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/widgets/input/WBlockPosEdit.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/widgets/input/WBlockPosEdit.java
@@ -53,7 +53,7 @@ public class WBlockPosEdit extends WHorizontalList {
                 mc.setScreen(null);
             };
 
-            WButton here = add(theme.button("Set Here")).expandX().widget();
+            WButton here = add(theme.confirmedButton("Set Here", "Confirm")).expandX().widget();
             here.action = () -> {
                 lastValue = value;
                 set(new BlockPos(mc.player.blockPosition()));


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

add confirmation step to 'set here' in BlockPosSetting

I accidentally pressed it while it was set to a enemy's stash. Which is it kinda annoying because it got leaked via screenshot and I didn't have it saved anywhere else

# How Has This Been Tested?

https://github.com/user-attachments/assets/fd28493b-c166-4a16-8932-6961c7a9b6ae

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
