### PR TITLE
Fix multiple carets blinking in text boxes

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/WidgetScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/WidgetScreen.java
@@ -202,6 +202,7 @@ public abstract class WidgetScreen extends Screen {
         boolean shouldReturn = root.keyPressed(input) || super.keyPressed(input);
         if (shouldReturn) return true;
 
+        // Select next text box if TAB was pressed
         if (input.key() == GLFW_KEY_TAB) {
             AtomicReference<WTextBox> firstTextBox = new AtomicReference<>(null);
             AtomicBoolean done = new AtomicBoolean(false);
@@ -273,6 +274,7 @@ public abstract class WidgetScreen extends Screen {
 
         GuiKeyEvents.canUseKeys = true;
 
+        // Apply projection without scaling
         Utils.unscaledProjection();
 
         onRenderBefore(graphics, mouseX, mouseY, delta);

--- a/src/main/java/meteordevelopment/meteorclient/gui/WidgetScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/WidgetScreen.java
@@ -129,6 +129,12 @@ public abstract class WidgetScreen extends Screen {
         mouseX *= s;
         mouseY *= s;
 
+        loopWidgets(root, widget -> {
+            if (widget instanceof WTextBox textBox && textBox.isFocused() && !textBox.mouseOver) {
+                textBox.setFocused(false);
+            }
+        });
+
         return root.mouseClicked(new MouseButtonEvent(mouseX, mouseY, click.buttonInfo()), doubled);
     }
 
@@ -196,7 +202,6 @@ public abstract class WidgetScreen extends Screen {
         boolean shouldReturn = root.keyPressed(input) || super.keyPressed(input);
         if (shouldReturn) return true;
 
-        // Select next text box if TAB was pressed
         if (input.key() == GLFW_KEY_TAB) {
             AtomicReference<WTextBox> firstTextBox = new AtomicReference<>(null);
             AtomicBoolean done = new AtomicBoolean(false);
@@ -268,7 +273,6 @@ public abstract class WidgetScreen extends Screen {
 
         GuiKeyEvents.canUseKeys = true;
 
-        // Apply projection without scaling
         Utils.unscaledProjection();
 
         onRenderBefore(graphics, mouseX, mouseY, delta);

--- a/src/main/java/meteordevelopment/meteorclient/gui/WidgetScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/WidgetScreen.java
@@ -353,7 +353,7 @@ public abstract class WidgetScreen extends Screen {
 
                     // Restore mouse position to where it was when the screen was closed
                     if (parent == null) {
-                        glfwSetCursorPos(mc.getWindow().getWindow(), restoreX, restoreY);
+                        glfwSetCursorPos(mc.getWindow().handle(), restoreX, restoreY);
                     }
                 };
             }

--- a/src/main/java/meteordevelopment/meteorclient/gui/WidgetScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/WidgetScreen.java
@@ -129,6 +129,7 @@ public abstract class WidgetScreen extends Screen {
         mouseX *= s;
         mouseY *= s;
 
+        // Unfocus all text boxes that are not under the mouse cursor
         loopWidgets(root, widget -> {
             if (widget instanceof WTextBox textBox && textBox.isFocused() && !textBox.mouseOver) {
                 textBox.setFocused(false);
@@ -343,9 +344,17 @@ public abstract class WidgetScreen extends Screen {
             }
 
             if (onClose) {
+                double restoreX = lastMouseX / mc.getWindow().getGuiScale();
+                double restoreY = lastMouseY / mc.getWindow().getGuiScale();
+
                 taskAfterRender = () -> {
                     locked = true;
                     mc.setScreen(parent);
+
+                    // Restore mouse position to where it was when the screen was closed
+                    if (parent == null) {
+                        glfwSetCursorPos(mc.getWindow().getWindow(), restoreX, restoreY);
+                    }
                 };
             }
         }

--- a/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/input/WMeteorTextBox.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/input/WMeteorTextBox.java
@@ -93,6 +93,7 @@ public class WMeteorTextBox extends WTextBox implements MeteorWidget {
     protected void onCursorChanged() {
         cursorVisible = true;
         cursorTimer = 0;
+        animProgress = focused ? 1.0 : 0.0;
     }
 
     @Override


### PR DESCRIPTION
## Type of change
- [x] Bug fix

## Description
When clicking on an input field other text boxes that were already focused did not lose their focus this caused multiple carets to blink simultaneously across different input fields fixed by unfocusing all other text boxes when a click event occurs in WidgetScreen

## Related issues
Fixes #6451

## How Has This Been Tested?
Opened multiple input fields in the Spam module and verified that only the clicked input field shows a blinking caret.

## Checklist:
- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.