### PR TITLE
Fix PlayerRadarHud null crash when switching servers

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PlayerRadarHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PlayerRadarHud.java
@@ -203,6 +203,8 @@ public class PlayerRadarHud extends HudElement {
     private List<AbstractClientPlayer> getPlayers() {
         players.clear();
         players.addAll(mc.level.players());
+        // Filter out null entities and skip if camera entity is null to prevent crashes during server switches
+        players.removeIf(e -> e == null || mc.getCameraEntity() == null);
         if (players.size() > limit.get()) players.subList(limit.get() - 1, players.size() - 1).clear();
         players.sort(Comparator.comparingDouble(e -> e.distanceToSqr(mc.getCameraEntity())));
 


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature

## Description
PlayerRadarHud was crashing when switching servers on a hub network. During a server switch, Minecraft starts clearing the current world and entities become null. The HUD was still rendering and trying to call .position() on null entities, causing a NullPointerException. Fixed by adding a null check to filter out null entities and a null camera entity before sorting.

## Related issues
Fixes #6433

## How Has This Been Tested?
Tested by switching servers on a hub network with PlayerRadarHud enabled. The crash no longer occurs.

## Checklist:
- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.