### PR TITLE
Command cycle

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
@@ -567,6 +567,7 @@ public class Modules extends System<Modules> {
         add(new BetterBeacons());
         add(new BetterChat());
         add(new BookBot());
+        add(new CommandCycle());
         add(new DiscordPresence());
         add(new InventoryTweaks());
         add(new MessageAura());

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/CommandCycle.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/CommandCycle.java
@@ -23,14 +23,14 @@ public class CommandCycle extends Module {
 
     private final Setting<List<String>> commands = sgGeneral.add(new StringListSetting.Builder()
         .name("commands")
-        .description("Commands with optional delay. Example: /spawn [5], /home [10], /kill")
-        .defaultValue(List.of("/spawn [5]", "/home [10]", "/kill"))
+        .description("Commands with optional delays. Example: /spawn [5] [10] [15], /home [8], /kill")
+        .defaultValue(List.of("/spawn [5] [10]", "/home [8]", "/kill"))
         .build()
     );
 
     private final Setting<Integer> defaultDelay = sgGeneral.add(new IntSetting.Builder()
         .name("default-delay")
-        .description("Default delay in seconds when no [delay] is given")
+        .description("Default delay in seconds if no [delay] is specified")
         .defaultValue(5)
         .min(0)
         .sliderMax(120)
@@ -39,7 +39,7 @@ public class CommandCycle extends Module {
 
     private final Setting<Boolean> loop = sgGeneral.add(new BoolSetting.Builder()
         .name("loop")
-        .description("Repeat the list when finished")
+        .description("Repeat the sequence when finished")
         .defaultValue(true)
         .build()
     );
@@ -76,18 +76,21 @@ public class CommandCycle extends Module {
             line = line.trim();
             if (line.isEmpty()) continue;
 
-            int delayTicks = defaultDelay.get() * 20; // seconds → ticks
+            int delay = defaultDelay.get() * 20;
 
+            // Find the LAST delay in the line
             Matcher matcher = DELAY_PATTERN.matcher(line);
-            if (matcher.find()) {
+            while (matcher.find()) {
                 try {
-                    delayTicks = Integer.parseInt(matcher.group(1)) * 20;
-                    line = line.replaceFirst("\\[\\d+]", "").trim(); // remove [number]
+                    delay = Integer.parseInt(matcher.group(1)) * 20;
                 } catch (Exception ignored) {}
             }
 
-            if (!line.startsWith("/")) line = "/" + line;
-            parsedCommands.add(new CommandEntry(line, delayTicks));
+            // Remove all [numbers] from the command
+            String command = line.replaceAll("\\[\\d+]", "").trim();
+            if (!command.startsWith("/")) command = "/" + command;
+
+            parsedCommands.add(new CommandEntry(command, delay));
         }
     }
 
@@ -105,15 +108,12 @@ public class CommandCycle extends Module {
 
         CommandEntry entry = parsedCommands.get(currentIndex);
 
-        // Send the command safely
         ChatUtils.sendPlayerMsg(entry.command());
 
         timer = entry.delay();
 
-        // Go to next command
         currentIndex = (currentIndex + 1) % parsedCommands.size();
 
-        // If loop is disabled & we reached the end → stop module
         if (currentIndex == 0 && !loop.get()) {
             toggle();
         }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/CommandCycle.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/CommandCycle.java
@@ -1,0 +1,121 @@
+/*
+ * This file is part of the Meteor Client distribution[](https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.systems.modules.misc;
+
+import meteordevelopment.meteorclient.events.game.GameLeftEvent;
+import meteordevelopment.meteorclient.events.world.TickEvent;
+import meteordevelopment.meteorclient.settings.*;
+import meteordevelopment.meteorclient.systems.modules.Categories;
+import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.meteorclient.utils.player.ChatUtils;
+import meteordevelopment.orbit.EventHandler;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class CommandCycle extends Module {
+    private final SettingGroup sgGeneral = settings.getDefaultGroup();
+
+    private final Setting<List<String>> commands = sgGeneral.add(new StringListSetting.Builder()
+        .name("commands")
+        .description("Commands with optional delay. Example: /spawn [5], /home [10], /kill")
+        .defaultValue(List.of("/spawn [5]", "/home [10]", "/kill"))
+        .build()
+    );
+
+    private final Setting<Integer> defaultDelay = sgGeneral.add(new IntSetting.Builder()
+        .name("default-delay")
+        .description("Default delay in seconds when no [delay] is given")
+        .defaultValue(5)
+        .min(0)
+        .sliderMax(120)
+        .build()
+    );
+
+    private final Setting<Boolean> loop = sgGeneral.add(new BoolSetting.Builder()
+        .name("loop")
+        .description("Repeat the list when finished")
+        .defaultValue(true)
+        .build()
+    );
+
+    private final Setting<Boolean> disableOnLeave = sgGeneral.add(new BoolSetting.Builder()
+        .name("disable-on-leave")
+        .description("Automatically disable when leaving the server")
+        .defaultValue(true)
+        .build()
+    );
+
+    private int timer = 0;
+    private int currentIndex = 0;
+    private final List<CommandEntry> parsedCommands = new ArrayList<>();
+
+    private static final Pattern DELAY_PATTERN = Pattern.compile("\\[(\\d+)]");
+
+    private record CommandEntry(String command, int delay) {}
+
+    public CommandCycle() {
+        super(Categories.Misc, "command-cycle", "Executes a list of commands in sequence with custom delays.");
+    }
+
+    @Override
+    public void onActivate() {
+        parseCommands();
+        currentIndex = 0;
+        timer = 0;
+    }
+
+    private void parseCommands() {
+        parsedCommands.clear();
+        for (String line : commands.get()) {
+            line = line.trim();
+            if (line.isEmpty()) continue;
+
+            int delayTicks = defaultDelay.get() * 20; // seconds → ticks
+
+            Matcher matcher = DELAY_PATTERN.matcher(line);
+            if (matcher.find()) {
+                try {
+                    delayTicks = Integer.parseInt(matcher.group(1)) * 20;
+                    line = line.replaceFirst("\\[\\d+]", "").trim(); // remove [number]
+                } catch (Exception ignored) {}
+            }
+
+            if (!line.startsWith("/")) line = "/" + line;
+            parsedCommands.add(new CommandEntry(line, delayTicks));
+        }
+    }
+
+    @EventHandler
+    private void onGameLeft(GameLeftEvent event) {
+        if (disableOnLeave.get()) toggle();
+    }
+
+    @EventHandler
+    private void onTick(TickEvent.Post event) {
+        if (parsedCommands.isEmpty() || timer > 0) {
+            if (timer > 0) timer--;
+            return;
+        }
+
+        CommandEntry entry = parsedCommands.get(currentIndex);
+
+        // Send the command safely
+        ChatUtils.sendPlayerMsg(entry.command());
+
+        timer = entry.delay();
+
+        // Go to next command
+        currentIndex = (currentIndex + 1) % parsedCommands.size();
+
+        // If loop is disabled & we reached the end → stop module
+        if (currentIndex == 0 && !loop.get()) {
+            toggle();
+        }
+    }
+}


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature

## Description

Added a new module called `CommandCycle` to the Misc category. This module allows players to execute a list of custom commands sequentially with specified delays (e.g., `/spawn [5]`, `/home [10]`). It includes configurable settings for a default delay, looping the sequence, and automatically disabling the module upon leaving the server.
<img width="597" height="534" alt="meteor_client_commandcycle" src="https://github.com/user-attachments/assets/6d3665b4-7743-4c28-8d85-44d0d48fac84" />


Reasoning: This feature provides a highly requested utility for automating repetitive server tasks and navigation sequences in a clean, user-friendly way.

## Related issues

None.

# How Has This Been Tested?

Tested locally in a Minecraft development environment. The module successfully parses custom delays from the string list, executes commands safely via ChatUtils, counts down ticks accurately, and toggles off correctly when looping is disabled or upon disconnecting from the server.

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.