### PR TITLE
Fix NullPointerException in PlayerRadarHud when switching servers by filtering null entities in getPlayers().

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PlayerRadarHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/PlayerRadarHud.java
@@ -203,6 +203,7 @@ public class PlayerRadarHud extends HudElement {
     private List<AbstractClientPlayer> getPlayers() {
         players.clear();
         players.addAll(mc.level.players());
+        players.removeIf(entity -> entity == null);
         if (players.size() > limit.get()) players.subList(limit.get() - 1, players.size() - 1).clear();
         players.sort(Comparator.comparingDouble(e -> e.distanceToSqr(mc.getCameraEntity())));
 


### PR DESCRIPTION
Fixes #6433.

Fix NullPointerException in PlayerRadarHud when switching servers by filtering null entities in getPlayers(). The crash occurs because mc.level.players() can return null entities during world transitions (e.g., when a StartConfigurationPacket is processed). Adding players.removeIf(entity -> entity == null) right after the addAll prevents the subsequent sort from calling position() on a null entity.

I checked the changed Java file with the available static check.