### PR TITLE
fix(KillAura): use isAggressive() instead of isAngry() for Enderman

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/KillAura.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/KillAura.java
@@ -418,7 +418,7 @@ public class KillAura extends Module {
             ) return false;
         }
         if (ignorePassive.get()) {
-            if (entity instanceof EnderMan enderman && !enderman.isAngry()) return false;
+            if (entity instanceof EnderMan enderman && !enderman.isAggressive()) return false;
             if ((entity instanceof Piglin || entity instanceof ZombifiedPiglin || entity instanceof Wolf) && !((Mob) entity).isAggressive())
                 return false;
         }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/KillAura.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/KillAura.java
@@ -418,7 +418,7 @@ public class KillAura extends Module {
             ) return false;
         }
         if (ignorePassive.get()) {
-            if (entity instanceof EnderMan enderman && !enderman.isAggressive()) return false;
+            if (entity instanceof EnderMan enderman && !enderman.isCreepy()) return false;
             if ((entity instanceof Piglin || entity instanceof ZombifiedPiglin || entity instanceof Wolf) && !((Mob) entity).isAggressive())
                 return false;
         }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/EndermanLook.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/EndermanLook.java
@@ -15,11 +15,11 @@ import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.utils.entity.Target;
 import meteordevelopment.meteorclient.utils.player.Rotations;
 import meteordevelopment.orbit.EventHandler;
+import net.minecraft.tags.ItemTags;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.monster.EnderMan;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.phys.Vec3;
 
 public class EndermanLook extends Module {
@@ -47,7 +47,7 @@ public class EndermanLook extends Module {
     @EventHandler
     private void onTick(TickEvent.Pre event) {
         // if either are true nothing happens when you look at an enderman
-        if (mc.player.getItemBySlot(EquipmentSlot.HEAD).is(Blocks.CARVED_PUMPKIN.asItem()) || mc.player.getAbilities().instabuild)
+        if (mc.player.getItemBySlot(EquipmentSlot.HEAD).is(ItemTags.GAZE_DISGUISE_EQUIPMENT) || mc.player.getAbilities().instabuild)
             return;
 
         for (Entity entity : mc.level.entitiesForRendering()) {
@@ -56,12 +56,12 @@ public class EndermanLook extends Module {
 
             switch (lookMode.get()) {
                 case Away -> {
-                    if (enderman.isAngry() && stun.get())
+                    if (enderman.isCreepy() && stun.get())
                         Rotations.rotate(Rotations.getYaw(enderman), Rotations.getPitch(enderman, Target.Head), -75, null);
                     else if (angleCheck(enderman)) Rotations.rotate(mc.player.getYRot(), 90, -75, null);
                 }
                 case At -> {
-                    if (!enderman.isAngry())
+                    if (!enderman.isCreepy())
                         Rotations.rotate(Rotations.getYaw(enderman), Rotations.getPitch(enderman, Target.Head), -75, null);
                 }
             }


### PR DESCRIPTION
## Type of change

- [x] Bug fix

## Description

`isAngry()` is server-side only and always returns false on the client, causing angry Endermen to be incorrectly ignored by the ignore-passive option. Changed to `isAggressive()` which is properly synced to the client.

## Related issues

Fixes #6463

# How Has This Been Tested?

Tested in-game by angering an Enderman with ignore-passive enabled. KillAura now correctly targets the angry Enderman.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.