### PR TITLE
Allow BoatFly to descend

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayerEntityMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayerEntityMixin.java
@@ -21,10 +21,13 @@ import net.minecraft.client.input.Input;
 import net.minecraft.client.network.AbstractClientPlayerEntity;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.world.ClientWorld;
+import net.minecraft.entity.vehicle.AbstractBoatEntity;
+import net.minecraft.util.PlayerInput;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
@@ -128,6 +131,25 @@ public abstract class ClientPlayerEntityMixin extends AbstractClientPlayerEntity
     @Inject(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayNetworkHandler;sendPacket(Lnet/minecraft/network/packet/Packet;)V", ordinal = 1))
     private void onTickHasVehicleBeforeSendPackets(CallbackInfo info) {
         MeteorClient.EVENT_BUS.post(SendMovementPacketsEvent.Pre.get());
+    }
+
+    @ModifyArg(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/packet/c2s/play/PlayerInputC2SPacket;<init>(Lnet/minecraft/util/PlayerInput;)V"), index = 0)
+    private PlayerInput onCreateVehicleInputPacket(PlayerInput input) {
+        BoatFly boatFly = Modules.get().get(BoatFly.class);
+        if (!boatFly.sneakDescendsDownward()) return input;
+        if (!input.sneak()) return input;
+        if (!(getVehicle() instanceof AbstractBoatEntity boat)) return input;
+        if (boat.getControllingPassenger() != (Object) this) return input;
+
+        return new PlayerInput(
+            input.forward(),
+            input.backward(),
+            input.left(),
+            input.right(),
+            input.jump(),
+            false,
+            input.sprint()
+        );
     }
 
     @Inject(method = "sendMovementPackets", at = @At("TAIL"))

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/BoatFly.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/movement/BoatFly.java
@@ -55,6 +55,13 @@ public class BoatFly extends Module {
         .build()
     );
 
+    private final Setting<Boolean> sneakDescendsDownward = sgGeneral.add(new BoolSetting.Builder()
+        .name("sneak-descends-downward")
+        .description("Uses the sneak key to descend instead of sprint.")
+        .defaultValue(false)
+        .build()
+    );
+
     public BoatFly() {
         super(Categories.Movement, "boat-fly", "Transforms your boat into a plane.");
     }
@@ -73,7 +80,12 @@ public class BoatFly extends Module {
 
         // Vertical movement
         if (mc.options.jumpKey.isPressed()) velY += verticalSpeed.get() / 20;
-        if (mc.options.sprintKey.isPressed()) velY -= verticalSpeed.get() / 20;
+
+        boolean descending = sneakDescendsDownward.get()
+            ? mc.options.sneakKey.isPressed()
+            : mc.options.sprintKey.isPressed();
+
+        if (descending) velY -= verticalSpeed.get() / 20;
         else velY -= fallSpeed.get() / 20;
 
         // Apply velocity
@@ -85,5 +97,9 @@ public class BoatFly extends Module {
         if (event.packet instanceof VehicleMoveS2CPacket && cancelServerPackets.get()) {
             event.cancel();
         }
+    }
+
+    public boolean sneakDescendsDownward() {
+        return isActive() && sneakDescendsDownward.get();
     }
 }


### PR DESCRIPTION
BoatFly now has a new option: "Sneak Descends Downward". If you enable it, then, when you are flying in a boat, press sneak, and youll descend (instead of the default "jump out of boat and probably die" behavior)

## Type of change

- [X] Bug fix
- [ ] New feature

## Description

BoatFly now has a new option: "Sneak Descends Downward". If you enable it, then, when you are flying in a boat, press sneak, and youll descend (instead of the default "jump out of boat and probably die" behavior)

# How Has This Been Tested?

Videos or screenshots of the changes if applicable.

# Checklist:

- [?] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
