### PR TITLE
Fix custom font fallback rendering

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/renderer/Fonts.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/Fonts.java
@@ -17,6 +17,8 @@ import meteordevelopment.meteorclient.utils.PreInit;
 import meteordevelopment.meteorclient.utils.render.FontUtils;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -25,6 +27,23 @@ import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class Fonts {
     public static final String[] BUILTIN_FONTS = {"JetBrains Mono", "Comfortaa", "Tw Cen MT", "Pixelation"};
+    private static final String[] FALLBACK_FONT_FAMILIES = {
+        "Noto Sans SC",
+        "Microsoft YaHei",
+        "Microsoft YaHei UI",
+        "DengXian",
+        "SimHei",
+        "SimSun",
+        "KaiTi",
+        "Microsoft JhengHei",
+        "Malgun Gothic",
+        "Yu Gothic",
+        "MS Gothic",
+        "Source Han Sans SC",
+        "WenQuanYi Zen Hei",
+        "PingFang SC",
+        "Hiragino Sans GB"
+    };
 
     public static String DEFAULT_FONT_FAMILY;
     public static FontFace DEFAULT_FONT;
@@ -86,6 +105,59 @@ public class Fonts {
             if (fontFamily.getName().equalsIgnoreCase(name)) {
                 return fontFamily;
             }
+        }
+
+        return null;
+    }
+
+    public static List<FontFace> getFallbackFonts(FontFace primary) {
+        List<FontFace> fonts = new ArrayList<>();
+
+        for (String familyName : FALLBACK_FONT_FAMILIES) {
+            FontFace font = getFallbackFont(familyName, primary);
+            if (font != null) {
+                fonts.add(font);
+                break;
+            }
+        }
+
+        return fonts;
+    }
+
+    public static List<ByteBuffer> readFontBuffers(FontFace primary) throws IOException {
+        List<ByteBuffer> buffers = new ArrayList<>();
+        buffers.add(primary.readToDirectByteBuffer());
+
+        for (FontFace fallbackFont : getFallbackFonts(primary)) {
+            try {
+                buffers.add(fallbackFont.readToDirectByteBuffer());
+            } catch (IOException e) {
+                MeteorClient.LOG.warn("Failed to load fallback font: {}", fallbackFont, e);
+            }
+        }
+
+        return buffers;
+    }
+
+    private static FontFace getFallbackFont(String familyName, FontFace primary) {
+        FontFamily family = getFamily(familyName);
+
+        if (family == null) {
+            String needle = familyName.toLowerCase();
+
+            for (FontFamily fontFamily : FONT_FAMILIES) {
+                if (fontFamily.getName().toLowerCase().contains(needle)) {
+                    family = fontFamily;
+                    break;
+                }
+            }
+        }
+
+        if (family == null) return null;
+
+        for (FontInfo.Type type : FontInfo.Type.values()) {
+            FontFace font = family.get(type);
+            if (font != null && !font.info.equals(primary.info)) return font;
         }
 
         return null;

--- a/src/main/java/meteordevelopment/meteorclient/renderer/Fonts.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/Fonts.java
@@ -22,12 +22,15 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
 
 import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class Fonts {
     public static final String[] BUILTIN_FONTS = {"JetBrains Mono", "Comfortaa", "Tw Cen MT", "Pixelation"};
-    private static final String[] FALLBACK_FONT_FAMILIES = {
+    private static final List<String> FALLBACK_FONT_FAMILIES = List.of(
+        "Noto Sans CJK SC",
         "Noto Sans SC",
         "Microsoft YaHei",
         "Microsoft YaHei UI",
@@ -43,7 +46,7 @@ public class Fonts {
         "WenQuanYi Zen Hei",
         "PingFang SC",
         "Hiragino Sans GB"
-    };
+    );
 
     public static String DEFAULT_FONT_FAMILY;
     public static FontFace DEFAULT_FONT;
@@ -78,14 +81,12 @@ public class Fonts {
     }
 
     public static void load(FontFace fontFace) {
-        if (RENDERER != null) {
-            if (RENDERER.fontFace.equals(fontFace)) return;
-            else RENDERER.destroy();
-        }
+        CustomTextRenderer previous = RENDERER;
+        if (previous != null && previous.fontFace.equals(fontFace)) return;
 
+        CustomTextRenderer replacement;
         try {
-            RENDERER = new CustomTextRenderer(fontFace);
-            MeteorClient.EVENT_BUS.post(CustomFontChangedEvent.get());
+            replacement = new CustomTextRenderer(fontFace);
         } catch (Exception e) {
             if (fontFace.equals(DEFAULT_FONT)) {
                 throw new RuntimeException("Failed to load default font: " + fontFace, e);
@@ -93,7 +94,12 @@ public class Fonts {
 
             MeteorClient.LOG.error("Failed to load font: {}", fontFace, e);
             load(Fonts.DEFAULT_FONT);
+            return;
         }
+
+        RENDERER = replacement;
+        if (previous != null) previous.destroy();
+        MeteorClient.EVENT_BUS.post(CustomFontChangedEvent.get());
 
         if (mc.screen instanceof WidgetScreen widgetScreen && Config.get().customFont.get()) {
             widgetScreen.invalidate();
@@ -110,43 +116,43 @@ public class Fonts {
         return null;
     }
 
-    public static List<FontFace> getFallbackFonts(FontFace primary) {
-        List<FontFace> fonts = new ArrayList<>();
-
+    public static Optional<FontFace> getFallbackFont(FontFace primary) {
         for (String familyName : FALLBACK_FONT_FAMILIES) {
-            FontFace font = getFallbackFont(familyName, primary);
-            if (font != null) {
-                fonts.add(font);
-                break;
-            }
+            FontFace font = findFallbackFont(familyName, primary);
+            if (font != null) return Optional.of(font);
         }
 
-        return fonts;
+        return Optional.empty();
     }
 
     public static List<ByteBuffer> readFontBuffers(FontFace primary) throws IOException {
         List<ByteBuffer> buffers = new ArrayList<>();
         buffers.add(primary.readToDirectByteBuffer());
 
-        for (FontFace fallbackFont : getFallbackFonts(primary)) {
-            try {
-                buffers.add(fallbackFont.readToDirectByteBuffer());
-            } catch (IOException e) {
-                MeteorClient.LOG.warn("Failed to load fallback font: {}", fallbackFont, e);
-            }
-        }
+        getFallbackFont(primary)
+            .flatMap(Fonts::readFallbackFont)
+            .ifPresent(buffers::add);
 
-        return buffers;
+        return List.copyOf(buffers);
     }
 
-    private static FontFace getFallbackFont(String familyName, FontFace primary) {
+    private static Optional<ByteBuffer> readFallbackFont(FontFace font) {
+        try {
+            return Optional.of(font.readToDirectByteBuffer());
+        } catch (IOException e) {
+            MeteorClient.LOG.warn("Failed to load fallback font: {}", font, e);
+            return Optional.empty();
+        }
+    }
+
+    private static FontFace findFallbackFont(String familyName, FontFace primary) {
         FontFamily family = getFamily(familyName);
 
         if (family == null) {
-            String needle = familyName.toLowerCase();
+            String needle = familyName.toLowerCase(Locale.ROOT);
 
             for (FontFamily fontFamily : FONT_FAMILIES) {
-                if (fontFamily.getName().toLowerCase().contains(needle)) {
+                if (fontFamily.getName().toLowerCase(Locale.ROOT).contains(needle)) {
                     family = fontFamily;
                     break;
                 }
@@ -154,10 +160,19 @@ public class Fonts {
         }
 
         if (family == null) return null;
+        if (family.getName().equalsIgnoreCase(primary.info.family())) return null;
+
+        FontFace styleMatch = family.get(primary.info.type());
+        if (styleMatch != null) return styleMatch;
+
+        FontFace regular = family.get(FontInfo.Type.Regular);
+        if (regular != null) return regular;
 
         for (FontInfo.Type type : FontInfo.Type.values()) {
+            if (type == primary.info.type() || type == FontInfo.Type.Regular) continue;
+
             FontFace font = family.get(type);
-            if (font != null && !font.info.equals(primary.info)) return font;
+            if (font != null) return font;
         }
 
         return null;

--- a/src/main/java/meteordevelopment/meteorclient/renderer/text/CustomTextRenderer.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/text/CustomTextRenderer.java
@@ -5,6 +5,7 @@
 
 package meteordevelopment.meteorclient.renderer.text;
 
+import meteordevelopment.meteorclient.renderer.Fonts;
 import meteordevelopment.meteorclient.renderer.MeshBuilder;
 import meteordevelopment.meteorclient.renderer.MeshRenderer;
 import meteordevelopment.meteorclient.renderer.MeteorRenderPipelines;
@@ -13,6 +14,7 @@ import net.minecraft.client.Minecraft;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.List;
 
 public class CustomTextRenderer implements TextRenderer {
     public static final Color SHADOW_COLOR = new Color(60, 60, 60, 180);
@@ -32,11 +34,11 @@ public class CustomTextRenderer implements TextRenderer {
     public CustomTextRenderer(FontFace fontFace) throws IOException {
         this.fontFace = fontFace;
 
-        ByteBuffer buffer = fontFace.readToDirectByteBuffer();
+        List<ByteBuffer> buffers = Fonts.readFontBuffers(fontFace);
 
         fonts = new Font[5];
         for (int i = 0; i < fonts.length; i++) {
-            fonts[i] = new Font(buffer, (int) Math.round(27 * ((i * 0.5) + 1)));
+            fonts[i] = new Font(buffers, (int) Math.round(27 * ((i * 0.5) + 1)));
         }
     }
 
@@ -120,6 +122,7 @@ public class CustomTextRenderer implements TextRenderer {
 
         if (!scaleOnly) {
             mesh.end();
+            font.uploadPendingGlyphs();
 
             MeshRenderer.begin()
                 .attachments(Minecraft.getInstance().getMainRenderTarget())

--- a/src/main/java/meteordevelopment/meteorclient/renderer/text/CustomTextRenderer.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/text/CustomTextRenderer.java
@@ -20,25 +20,32 @@ public class CustomTextRenderer implements TextRenderer {
     public static final Color SHADOW_COLOR = new Color(60, 60, 60, 180);
 
     private final MeshBuilder mesh = new MeshBuilder(MeteorRenderPipelines.UI_TEXT);
+    private final Color shadowColor = new Color(SHADOW_COLOR);
 
     public final FontFace fontFace;
 
+    private final List<ByteBuffer> fontBuffers;
     private final Font[] fonts;
     private Font font;
 
     private boolean building;
     private boolean scaleOnly;
+    private boolean destroyed;
     private double fontScale = 1;
     private double scale = 1;
 
     public CustomTextRenderer(FontFace fontFace) throws IOException {
         this.fontFace = fontFace;
+        this.fontBuffers = Fonts.readFontBuffers(fontFace);
 
-        List<ByteBuffer> buffers = Fonts.readFontBuffers(fontFace);
-
-        fonts = new Font[5];
-        for (int i = 0; i < fonts.length; i++) {
-            fonts[i] = new Font(buffers, (int) Math.round(27 * ((i * 0.5) + 1)));
+        this.fonts = new Font[5];
+        try {
+            for (int i = 0; i < fonts.length; i++) {
+                fonts[i] = createFont((int) Math.round(27 * ((i * 0.5) + 1)));
+            }
+        } catch (RuntimeException | Error e) {
+            closeFonts();
+            throw e;
         }
     }
 
@@ -49,6 +56,7 @@ public class CustomTextRenderer implements TextRenderer {
 
     @Override
     public void begin(double scale, boolean scaleOnly, boolean big) {
+        if (destroyed) throw new IllegalStateException("CustomTextRenderer has already been destroyed.");
         if (building) throw new RuntimeException("CustomTextRenderer.begin() called twice");
 
         if (!scaleOnly) mesh.begin();
@@ -96,13 +104,10 @@ public class CustomTextRenderer implements TextRenderer {
 
         double width;
         if (shadow) {
-            int preShadowA = SHADOW_COLOR.a;
-            SHADOW_COLOR.a = (int) (color.a / 255.0 * preShadowA);
+            shadowColor.a = (int) (color.a / 255.0 * SHADOW_COLOR.a);
 
-            width = font.render(mesh, text, x + fontScale * scale / 1.5, y + fontScale * scale / 1.5, SHADOW_COLOR, scale / 1.5);
+            width = font.render(mesh, text, x + fontScale * scale / 1.5, y + fontScale * scale / 1.5, shadowColor, scale / 1.5);
             font.render(mesh, text, x, y, color, scale / 1.5);
-
-            SHADOW_COLOR.a = preShadowA;
         } else {
             width = font.render(mesh, text, x, y, color, scale / 1.5);
         }
@@ -120,25 +125,40 @@ public class CustomTextRenderer implements TextRenderer {
     public void end() {
         if (!building) throw new RuntimeException("CustomTextRenderer.end() called without calling begin()");
 
-        if (!scaleOnly) {
-            mesh.end();
-            font.uploadPendingGlyphs();
+        try {
+            if (!scaleOnly) {
+                mesh.end();
+                font.uploadPendingGlyphs();
 
-            MeshRenderer.begin()
-                .attachments(Minecraft.getInstance().getMainRenderTarget())
-                .pipeline(MeteorRenderPipelines.UI_TEXT)
-                .mesh(mesh)
-                .sampler("u_Texture", font.texture.getTextureView(), font.texture.getSampler())
-                .end();
+                MeshRenderer.begin()
+                    .attachments(Minecraft.getInstance().getMainRenderTarget())
+                    .pipeline(MeteorRenderPipelines.UI_TEXT)
+                    .mesh(mesh)
+                    .sampler("u_Texture", font.texture.getTextureView(), font.texture.getSampler())
+                    .end();
+            }
+        } finally {
+            building = false;
+            scaleOnly = false;
+            scale = 1;
         }
+    }
 
-        building = false;
-        scale = 1;
+    public Font createFont(int height) {
+        if (destroyed) throw new IllegalStateException("CustomTextRenderer has already been destroyed.");
+        return new Font(fontBuffers, height);
     }
 
     public void destroy() {
-        for (Font font : this.fonts) {
-            font.texture.close();
+        if (destroyed) return;
+
+        closeFonts();
+        destroyed = true;
+    }
+
+    private void closeFonts() {
+        for (Font font : fonts) {
+            if (font != null) font.close();
         }
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/renderer/text/Font.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/text/Font.java
@@ -17,24 +17,50 @@ import org.lwjgl.system.MemoryStack;
 
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
+import java.util.ArrayList;
+import java.util.List;
 
 public class Font {
     public final Texture texture;
     private final int height;
     private final float scale;
     private final float ascent;
+    private final ByteBuffer bitmap;
+    private final List<FontData> fonts = new ArrayList<>();
     private final Int2ObjectOpenHashMap<CharData> charMap = new Int2ObjectOpenHashMap<>();
     private static final int size = 2048;
+    private static final int padding = 2;
+
+    private int packX;
+    private int packY;
+    private int rowHeight;
+    private boolean textureFull;
+    private boolean dirty;
 
     public Font(ByteBuffer buffer, int height) {
+        this(List.of(buffer), height);
+    }
+
+    public Font(List<ByteBuffer> buffers, int height) {
         this.height = height;
 
-        // Initialize font
-        STBTTFontinfo fontInfo = STBTTFontinfo.create();
-        STBTruetype.stbtt_InitFont(fontInfo, buffer);
+        // Initialize fonts
+        for (ByteBuffer buffer : buffers) {
+            STBTTFontinfo fontInfo = STBTTFontinfo.create();
+            if (STBTruetype.stbtt_InitFont(fontInfo, buffer)) {
+                fonts.add(new FontData(buffer, fontInfo, STBTruetype.stbtt_ScaleForPixelHeight(fontInfo, height)));
+            }
+        }
+
+        if (fonts.isEmpty()) {
+            throw new IllegalArgumentException("No valid fonts were provided.");
+        }
+
+        FontData primaryFont = fonts.get(0);
+        STBTTFontinfo fontInfo = primaryFont.info;
 
         // Allocate buffers
-        ByteBuffer bitmap = BufferUtils.createByteBuffer(size * size);
+        bitmap = BufferUtils.createByteBuffer(size * size);
         STBTTPackedchar.Buffer[] cdata = {
             STBTTPackedchar.create(95), // Basic Latin
             STBTTPackedchar.create(96), // Latin 1 Supplement
@@ -59,13 +85,13 @@ public class Font {
         packRange.flip();
 
         // write and finish
-        STBTruetype.stbtt_PackFontRanges(packContext, buffer, 0, packRange);
+        STBTruetype.stbtt_PackFontRanges(packContext, primaryFont.buffer, 0, packRange);
         STBTruetype.stbtt_PackEnd(packContext);
 
         // Create texture object and get font scale
         texture = new Texture(size, size, TextureFormat.RED8, FilterMode.LINEAR, FilterMode.LINEAR);
         texture.upload(bitmap);
-        scale = STBTruetype.stbtt_ScaleForPixelHeight(fontInfo, height);
+        scale = primaryFont.scale;
 
         // Get font vertical ascent
         try (MemoryStack stack = MemoryStack.stackPush()) {
@@ -74,6 +100,7 @@ public class Font {
             this.ascent = ascent.get(0);
         }
 
+        int usedY = 0;
         for (int i = 0; i < cdata.length; i++) {
             STBTTPackedchar.Buffer cbuf = cdata[i];
             int offset = packRange.get(i).first_unicode_codepoint_in_range();
@@ -95,26 +122,52 @@ public class Font {
                     packedChar.y1() * iph,
                     packedChar.xadvance()
                 ));
+
+                usedY = Math.max(usedY, packedChar.y1());
             }
         }
+
+        packY = Math.min(usedY + padding, size);
     }
 
     public double getWidth(String string, int length) {
         double width = 0;
+        int end = Math.min(length, string.length());
 
-        for (int i = 0; i < length; i++) {
-            int cp = string.charAt(i);
-            CharData c = charMap.get(cp);
+        for (int i = 0; i < end; ) {
+            int cp = codePointAt(string, i, end);
+            CharData c = getCharData(cp);
             if (c == null) c = charMap.get(32);
 
             width += c.xAdvance;
+            i += Character.charCount(cp);
         }
 
         return width;
     }
 
+    public boolean hasGlyphs(String string, int length) {
+        int end = Math.min(length, string.length());
+
+        for (int i = 0; i < end; ) {
+            int cp = codePointAt(string, i, end);
+            if (getCharData(cp) == null) return false;
+
+            i += Character.charCount(cp);
+        }
+
+        return true;
+    }
+
     public int getHeight() {
         return height;
+    }
+
+    public void uploadPendingGlyphs() {
+        if (!dirty) return;
+
+        texture.upload(bitmap);
+        dirty = false;
     }
 
     public double render(MeshBuilder mesh, String string, double x, double y, Color color, double scale) {
@@ -123,9 +176,9 @@ public class Font {
         int length = string.length();
         mesh.ensureCapacity(length * 4, length * 6);
 
-        for (int i = 0; i < length; i++) {
-            int cp = string.charAt(i);
-            CharData c = charMap.get(cp);
+        for (int i = 0; i < length; ) {
+            int cp = string.codePointAt(i);
+            CharData c = getCharData(cp);
             if (c == null) c = charMap.get(32);
 
             mesh.quad(
@@ -136,10 +189,129 @@ public class Font {
             );
 
             x += c.xAdvance * scale;
+            i += Character.charCount(cp);
         }
 
         return x;
     }
+
+    private CharData getCharData(int cp) {
+        CharData c = charMap.get(cp);
+        if (c != null) return c;
+
+        c = loadGlyph(cp);
+        if (c != null) charMap.put(cp, c);
+
+        return c;
+    }
+
+    private CharData loadGlyph(int cp) {
+        if (textureFull) return null;
+
+        FontData font = findFont(cp);
+        if (font == null) return null;
+
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            IntBuffer advanceWidth = stack.mallocInt(1);
+            IntBuffer x0 = stack.mallocInt(1);
+            IntBuffer y0 = stack.mallocInt(1);
+            IntBuffer x1 = stack.mallocInt(1);
+            IntBuffer y1 = stack.mallocInt(1);
+
+            STBTruetype.stbtt_GetCodepointHMetrics(font.info, cp, advanceWidth, null);
+            STBTruetype.stbtt_GetCodepointBitmapBox(font.info, cp, font.scale, font.scale, x0, y0, x1, y1);
+
+            int bitmapWidth = x1.get(0) - x0.get(0);
+            int bitmapHeight = y1.get(0) - y0.get(0);
+            float xAdvance = advanceWidth.get(0) * font.scale;
+
+            if (bitmapWidth <= 0 || bitmapHeight <= 0) {
+                return new CharData(0, 0, 0, 0, 0, 0, 0, 0, xAdvance);
+            }
+
+            if (!reserve(bitmapWidth, bitmapHeight)) return null;
+
+            int glyphX = packX + padding;
+            int glyphY = packY + padding;
+            ByteBuffer glyphBitmap = BufferUtils.createByteBuffer(bitmapWidth * bitmapHeight);
+
+            STBTruetype.stbtt_MakeCodepointBitmap(font.info, glyphBitmap, bitmapWidth, bitmapHeight, bitmapWidth, font.scale, font.scale, cp);
+
+            for (int row = 0; row < bitmapHeight; row++) {
+                int src = row * bitmapWidth;
+                int dst = (glyphY + row) * size + glyphX;
+
+                for (int col = 0; col < bitmapWidth; col++) {
+                    bitmap.put(dst + col, glyphBitmap.get(src + col));
+                }
+            }
+
+            float ipw = 1f / size;
+            float iph = 1f / size;
+
+            CharData charData = new CharData(
+                x0.get(0),
+                y0.get(0),
+                x1.get(0),
+                y1.get(0),
+                glyphX * ipw,
+                glyphY * iph,
+                (glyphX + bitmapWidth) * ipw,
+                (glyphY + bitmapHeight) * iph,
+                xAdvance
+            );
+
+            packX += bitmapWidth + padding * 2;
+            rowHeight = Math.max(rowHeight, bitmapHeight + padding * 2);
+
+            dirty = true;
+            return charData;
+        }
+    }
+
+    private boolean reserve(int bitmapWidth, int bitmapHeight) {
+        int requiredWidth = bitmapWidth + padding * 2;
+        int requiredHeight = bitmapHeight + padding * 2;
+
+        if (requiredWidth > size || requiredHeight > size) {
+            textureFull = true;
+            return false;
+        }
+
+        if (packX + requiredWidth > size) {
+            packX = 0;
+            packY += rowHeight;
+            rowHeight = 0;
+        }
+
+        if (packY + requiredHeight > size) {
+            textureFull = true;
+            return false;
+        }
+
+        return true;
+    }
+
+    private FontData findFont(int cp) {
+        for (FontData font : fonts) {
+            if (STBTruetype.stbtt_FindGlyphIndex(font.info, cp) != 0) return font;
+        }
+
+        return null;
+    }
+
+    private static int codePointAt(String string, int index, int end) {
+        char c = string.charAt(index);
+
+        if (Character.isHighSurrogate(c) && index + 1 < end) {
+            char c2 = string.charAt(index + 1);
+            if (Character.isLowSurrogate(c2)) return Character.toCodePoint(c, c2);
+        }
+
+        return c;
+    }
+
+    private record FontData(ByteBuffer buffer, STBTTFontinfo info, float scale) {}
 
     private record CharData(float x0, float y0, float x1, float y1, float u0, float v0, float u1, float v1, float xAdvance) {}
 }

--- a/src/main/java/meteordevelopment/meteorclient/renderer/text/Font.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/text/Font.java
@@ -7,6 +7,7 @@ package meteordevelopment.meteorclient.renderer.text;
 
 import com.mojang.blaze3d.textures.FilterMode;
 import com.mojang.blaze3d.textures.TextureFormat;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import meteordevelopment.meteorclient.renderer.MeshBuilder;
 import meteordevelopment.meteorclient.renderer.Texture;
@@ -19,48 +20,56 @@ import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
-public class Font {
+public class Font implements AutoCloseable {
+    private static final int ATLAS_SIZE = 2048;
+    private static final int GLYPH_PADDING = 2;
+    private static final int SPACE_CODE_POINT = ' ';
+
     public final Texture texture;
+
     private final int height;
     private final float scale;
     private final float ascent;
     private final ByteBuffer bitmap;
-    private final List<FontData> fonts = new ArrayList<>();
+    private final List<FontData> fonts;
     private final Int2ObjectOpenHashMap<CharData> charMap = new Int2ObjectOpenHashMap<>();
-    private static final int size = 2048;
-    private static final int padding = 2;
+    private final Int2ObjectOpenHashMap<GlyphMetrics> metricsMap = new Int2ObjectOpenHashMap<>();
+    private final IntOpenHashSet missingGlyphs = new IntOpenHashSet();
+    private final IntOpenHashSet unpackableGlyphs = new IntOpenHashSet();
 
     private int packX;
     private int packY;
     private int rowHeight;
-    private boolean textureFull;
     private boolean dirty;
+    private boolean closed;
 
     public Font(ByteBuffer buffer, int height) {
         this(List.of(buffer), height);
     }
 
     public Font(List<ByteBuffer> buffers, int height) {
+        if (height <= 0) throw new IllegalArgumentException("Font height must be positive.");
+        if (buffers.isEmpty()) throw new IllegalArgumentException("At least one font buffer is required.");
+
         this.height = height;
 
-        // Initialize fonts
-        for (ByteBuffer buffer : buffers) {
-            STBTTFontinfo fontInfo = STBTTFontinfo.create();
-            if (STBTruetype.stbtt_InitFont(fontInfo, buffer)) {
-                fonts.add(new FontData(buffer, fontInfo, STBTruetype.stbtt_ScaleForPixelHeight(fontInfo, height)));
-            }
+        List<FontData> loadedFonts = new ArrayList<>(buffers.size());
+        FontData primaryFont = createFontData(buffers.get(0), height);
+        if (primaryFont == null) throw new IllegalArgumentException("The primary font buffer is invalid.");
+
+        loadedFonts.add(primaryFont);
+        for (int i = 1; i < buffers.size(); i++) {
+            FontData fallbackFont = createFontData(buffers.get(i), height);
+            if (fallbackFont != null) loadedFonts.add(fallbackFont);
         }
 
-        if (fonts.isEmpty()) {
-            throw new IllegalArgumentException("No valid fonts were provided.");
-        }
-
-        FontData primaryFont = fonts.get(0);
+        fonts = List.copyOf(loadedFonts);
         STBTTFontinfo fontInfo = primaryFont.info;
 
         // Allocate buffers
-        bitmap = BufferUtils.createByteBuffer(size * size);
+        bitmap = BufferUtils.createByteBuffer(ATLAS_SIZE * ATLAS_SIZE);
         STBTTPackedchar.Buffer[] cdata = {
             STBTTPackedchar.create(95), // Basic Latin
             STBTTPackedchar.create(96), // Latin 1 Supplement
@@ -72,7 +81,10 @@ public class Font {
 
         // create and initialise packing context
         STBTTPackContext packContext = STBTTPackContext.create();
-        STBTruetype.stbtt_PackBegin(packContext, bitmap, size, size, 0 ,1);
+        if (!STBTruetype.stbtt_PackBegin(packContext, bitmap, ATLAS_SIZE, ATLAS_SIZE, 0, 1)) {
+            throw new IllegalStateException("Failed to initialize the font atlas packer.");
+        }
+        STBTruetype.stbtt_PackSetSkipMissingCodepoints(packContext, true);
 
         // create the pack range, populate with the specific packing ranges
         STBTTPackRange.Buffer packRange = STBTTPackRange.create(cdata.length);
@@ -85,11 +97,16 @@ public class Font {
         packRange.flip();
 
         // write and finish
-        STBTruetype.stbtt_PackFontRanges(packContext, primaryFont.buffer, 0, packRange);
-        STBTruetype.stbtt_PackEnd(packContext);
+        try {
+            // A false return value means at least one glyph did not fit. Successfully packed
+            // glyphs are still usable; the remaining ones are loaded lazily below.
+            STBTruetype.stbtt_PackFontRanges(packContext, primaryFont.buffer, 0, packRange);
+        } finally {
+            STBTruetype.stbtt_PackEnd(packContext);
+        }
 
         // Create texture object and get font scale
-        texture = new Texture(size, size, TextureFormat.RED8, FilterMode.LINEAR, FilterMode.LINEAR);
+        texture = new Texture(ATLAS_SIZE, ATLAS_SIZE, TextureFormat.RED8, FilterMode.LINEAR, FilterMode.LINEAR);
         texture.upload(bitmap);
         scale = primaryFont.scale;
 
@@ -106,12 +123,16 @@ public class Font {
             int offset = packRange.get(i).first_unicode_codepoint_in_range();
 
             for (int j = 0; j < cbuf.capacity(); j++) {
+                int codePoint = j + offset;
+                if (STBTruetype.stbtt_FindGlyphIndex(primaryFont.info, codePoint) == 0) continue;
+
                 STBTTPackedchar packedChar = cbuf.get(j);
+                if (!isPacked(packedChar)) continue;
 
-                float ipw = 1f / size; // pixel width and height
-                float iph = 1f / size;
+                float ipw = 1f / ATLAS_SIZE; // pixel width and height
+                float iph = 1f / ATLAS_SIZE;
 
-                charMap.put(j + offset, new CharData(
+                charMap.put(codePoint, new CharData(
                     packedChar.xoff(),
                     packedChar.yoff(),
                     packedChar.xoff2(),
@@ -127,36 +148,22 @@ public class Font {
             }
         }
 
-        packY = Math.min(usedY + padding, size);
+        packY = Math.min(usedY + GLYPH_PADDING, ATLAS_SIZE);
     }
 
     public double getWidth(String string, int length) {
+        ensureOpen();
+
         double width = 0;
         int end = Math.min(length, string.length());
 
         for (int i = 0; i < end; ) {
             int cp = codePointAt(string, i, end);
-            CharData c = getCharData(cp);
-            if (c == null) c = charMap.get(32);
-
-            width += c.xAdvance;
+            width += getAdvance(cp);
             i += Character.charCount(cp);
         }
 
         return width;
-    }
-
-    public boolean hasGlyphs(String string, int length) {
-        int end = Math.min(length, string.length());
-
-        for (int i = 0; i < end; ) {
-            int cp = codePointAt(string, i, end);
-            if (getCharData(cp) == null) return false;
-
-            i += Character.charCount(cp);
-        }
-
-        return true;
     }
 
     public int getHeight() {
@@ -164,6 +171,7 @@ public class Font {
     }
 
     public void uploadPendingGlyphs() {
+        ensureOpen();
         if (!dirty) return;
 
         texture.upload(bitmap);
@@ -171,6 +179,7 @@ public class Font {
     }
 
     public double render(MeshBuilder mesh, String string, double x, double y, Color color, double scale) {
+        ensureOpen();
         y += ascent * this.scale * scale;
 
         int length = string.length();
@@ -179,75 +188,110 @@ public class Font {
         for (int i = 0; i < length; ) {
             int cp = string.codePointAt(i);
             CharData c = getCharData(cp);
-            if (c == null) c = charMap.get(32);
 
-            mesh.quad(
-                mesh.vec2(x + c.x0 * scale, y + c.y0 * scale).vec2(c.u0, c.v0).color(color).next(),
-                mesh.vec2(x + c.x0 * scale, y + c.y1 * scale).vec2(c.u0, c.v1).color(color).next(),
-                mesh.vec2(x + c.x1 * scale, y + c.y1 * scale).vec2(c.u1, c.v1).color(color).next(),
-                mesh.vec2(x + c.x1 * scale, y + c.y0 * scale).vec2(c.u1, c.v0).color(color).next()
-            );
+            if (c != null && c.hasBitmap()) {
+                mesh.quad(
+                    mesh.vec2(x + c.x0 * scale, y + c.y0 * scale).vec2(c.u0, c.v0).color(color).next(),
+                    mesh.vec2(x + c.x0 * scale, y + c.y1 * scale).vec2(c.u0, c.v1).color(color).next(),
+                    mesh.vec2(x + c.x1 * scale, y + c.y1 * scale).vec2(c.u1, c.v1).color(color).next(),
+                    mesh.vec2(x + c.x1 * scale, y + c.y0 * scale).vec2(c.u1, c.v0).color(color).next()
+                );
+            }
 
-            x += c.xAdvance * scale;
+            x += (c != null ? c.xAdvance : getAdvance(cp)) * scale;
             i += Character.charCount(cp);
         }
 
         return x;
     }
 
+    @Override
+    public void close() {
+        if (closed) return;
+
+        texture.close();
+        closed = true;
+    }
+
     private CharData getCharData(int cp) {
         CharData c = charMap.get(cp);
         if (c != null) return c;
+        if (unpackableGlyphs.contains(cp)) return null;
 
-        c = loadGlyph(cp);
-        if (c != null) charMap.put(cp, c);
+        GlyphMetrics metrics = getGlyphMetrics(cp);
+        if (metrics == null) return null;
+
+        c = loadGlyph(cp, metrics);
+        if (c != null) {
+            charMap.put(cp, c);
+        } else {
+            unpackableGlyphs.add(cp);
+        }
 
         return c;
     }
 
-    private CharData loadGlyph(int cp) {
-        if (textureFull) return null;
+    private float getAdvance(int cp) {
+        CharData data = charMap.get(cp);
+        if (data != null) return data.xAdvance;
+
+        GlyphMetrics metrics = getGlyphMetrics(cp);
+        if (metrics != null) return metrics.xAdvance;
+
+        if (cp != SPACE_CODE_POINT) return getAdvance(SPACE_CODE_POINT);
+        return 0;
+    }
+
+    private GlyphMetrics getGlyphMetrics(int cp) {
+        GlyphMetrics metrics = metricsMap.get(cp);
+        if (metrics != null) return metrics;
+        if (missingGlyphs.contains(cp)) return null;
 
         FontData font = findFont(cp);
-        if (font == null) return null;
+        if (font == null) {
+            missingGlyphs.add(cp);
+            return null;
+        }
 
         try (MemoryStack stack = MemoryStack.stackPush()) {
             IntBuffer advanceWidth = stack.mallocInt(1);
+            STBTruetype.stbtt_GetCodepointHMetrics(font.info, cp, advanceWidth, null);
+
+            metrics = new GlyphMetrics(font, advanceWidth.get(0) * font.scale);
+            metricsMap.put(cp, metrics);
+            return metrics;
+        }
+    }
+
+    private CharData loadGlyph(int cp, GlyphMetrics metrics) {
+        FontData font = metrics.font;
+
+        try (MemoryStack stack = MemoryStack.stackPush()) {
             IntBuffer x0 = stack.mallocInt(1);
             IntBuffer y0 = stack.mallocInt(1);
             IntBuffer x1 = stack.mallocInt(1);
             IntBuffer y1 = stack.mallocInt(1);
 
-            STBTruetype.stbtt_GetCodepointHMetrics(font.info, cp, advanceWidth, null);
             STBTruetype.stbtt_GetCodepointBitmapBox(font.info, cp, font.scale, font.scale, x0, y0, x1, y1);
 
             int bitmapWidth = x1.get(0) - x0.get(0);
             int bitmapHeight = y1.get(0) - y0.get(0);
-            float xAdvance = advanceWidth.get(0) * font.scale;
 
             if (bitmapWidth <= 0 || bitmapHeight <= 0) {
-                return new CharData(0, 0, 0, 0, 0, 0, 0, 0, xAdvance);
+                return new CharData(0, 0, 0, 0, 0, 0, 0, 0, metrics.xAdvance);
             }
 
             if (!reserve(bitmapWidth, bitmapHeight)) return null;
 
-            int glyphX = packX + padding;
-            int glyphY = packY + padding;
-            ByteBuffer glyphBitmap = BufferUtils.createByteBuffer(bitmapWidth * bitmapHeight);
+            int glyphX = packX + GLYPH_PADDING;
+            int glyphY = packY + GLYPH_PADDING;
 
-            STBTruetype.stbtt_MakeCodepointBitmap(font.info, glyphBitmap, bitmapWidth, bitmapHeight, bitmapWidth, font.scale, font.scale, cp);
+            ByteBuffer glyphTarget = bitmap.duplicate();
+            glyphTarget.position(glyphY * ATLAS_SIZE + glyphX);
+            STBTruetype.stbtt_MakeCodepointBitmap(font.info, glyphTarget.slice(), bitmapWidth, bitmapHeight, ATLAS_SIZE, font.scale, font.scale, cp);
 
-            for (int row = 0; row < bitmapHeight; row++) {
-                int src = row * bitmapWidth;
-                int dst = (glyphY + row) * size + glyphX;
-
-                for (int col = 0; col < bitmapWidth; col++) {
-                    bitmap.put(dst + col, glyphBitmap.get(src + col));
-                }
-            }
-
-            float ipw = 1f / size;
-            float iph = 1f / size;
+            float ipw = 1f / ATLAS_SIZE;
+            float iph = 1f / ATLAS_SIZE;
 
             CharData charData = new CharData(
                 x0.get(0),
@@ -258,11 +302,11 @@ public class Font {
                 glyphY * iph,
                 (glyphX + bitmapWidth) * ipw,
                 (glyphY + bitmapHeight) * iph,
-                xAdvance
+                metrics.xAdvance
             );
 
-            packX += bitmapWidth + padding * 2;
-            rowHeight = Math.max(rowHeight, bitmapHeight + padding * 2);
+            packX += bitmapWidth + GLYPH_PADDING * 2;
+            rowHeight = Math.max(rowHeight, bitmapHeight + GLYPH_PADDING * 2);
 
             dirty = true;
             return charData;
@@ -270,24 +314,18 @@ public class Font {
     }
 
     private boolean reserve(int bitmapWidth, int bitmapHeight) {
-        int requiredWidth = bitmapWidth + padding * 2;
-        int requiredHeight = bitmapHeight + padding * 2;
+        int requiredWidth = bitmapWidth + GLYPH_PADDING * 2;
+        int requiredHeight = bitmapHeight + GLYPH_PADDING * 2;
 
-        if (requiredWidth > size || requiredHeight > size) {
-            textureFull = true;
-            return false;
-        }
+        if (requiredWidth > ATLAS_SIZE || requiredHeight > ATLAS_SIZE) return false;
 
-        if (packX + requiredWidth > size) {
+        if (packX + requiredWidth > ATLAS_SIZE) {
             packX = 0;
             packY += rowHeight;
             rowHeight = 0;
         }
 
-        if (packY + requiredHeight > size) {
-            textureFull = true;
-            return false;
-        }
+        if (packY + requiredHeight > ATLAS_SIZE) return false;
 
         return true;
     }
@@ -298,6 +336,24 @@ public class Font {
         }
 
         return null;
+    }
+
+    private static FontData createFontData(ByteBuffer source, int height) {
+        ByteBuffer buffer = Objects.requireNonNull(source, "Font buffer cannot be null.").duplicate();
+        STBTTFontinfo info = STBTTFontinfo.create();
+        if (!STBTruetype.stbtt_InitFont(info, buffer)) return null;
+
+        return new FontData(buffer, info, STBTruetype.stbtt_ScaleForPixelHeight(info, height));
+    }
+
+    private static boolean isPacked(STBTTPackedchar packedChar) {
+        return packedChar.x0() != packedChar.x1()
+            || packedChar.y0() != packedChar.y1()
+            || packedChar.xadvance() != 0;
+    }
+
+    private void ensureOpen() {
+        if (closed) throw new IllegalStateException("Font has already been closed.");
     }
 
     private static int codePointAt(String string, int index, int end) {
@@ -313,5 +369,11 @@ public class Font {
 
     private record FontData(ByteBuffer buffer, STBTTFontinfo info, float scale) {}
 
-    private record CharData(float x0, float y0, float x1, float y1, float u0, float v0, float u1, float v1, float xAdvance) {}
+    private record GlyphMetrics(FontData font, float xAdvance) {}
+
+    private record CharData(float x0, float y0, float x1, float y1, float u0, float v0, float u1, float v1, float xAdvance) {
+        private boolean hasBitmap() {
+            return x0 != x1 && y0 != y1;
+        }
+    }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/HudRenderer.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/HudRenderer.java
@@ -85,6 +85,8 @@ public class HudRenderer {
                 FontHolder fontHolder = it.next();
 
                 if (fontHolder.visited) {
+                    fontHolder.font.uploadPendingGlyphs();
+
                     MeshRenderer.begin()
                         .attachments(mc.getMainRenderTarget())
                         .pipeline(MeteorRenderPipelines.UI_TEXT)
@@ -302,8 +304,8 @@ public class HudRenderer {
 
     private static FontHolder loadFont(int height) {
         try {
-            ByteBuffer buffer = Fonts.RENDERER.fontFace.readToDirectByteBuffer();
-            return new FontHolder(new Font(buffer, height));
+            List<ByteBuffer> buffers = Fonts.readFontBuffers(Fonts.RENDERER.fontFace);
+            return new FontHolder(new Font(buffers, height));
         } catch (IOException e) {
             throw new RuntimeException("Failed to load font: " + Fonts.RENDERER.fontFace, e);
         }

--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/HudRenderer.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/HudRenderer.java
@@ -8,6 +8,7 @@ package meteordevelopment.meteorclient.systems.hud;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.cache.RemovalCause;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import meteordevelopment.meteorclient.MeteorClient;
@@ -28,8 +29,6 @@ import net.minecraft.world.item.ItemStack;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
 
-import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -44,16 +43,21 @@ public class HudRenderer {
 
     private final Hud hud = Hud.get();
     private final List<Runnable> postTasks = new ArrayList<>();
+    private final Color shadowColor = new Color(CustomTextRenderer.SHADOW_COLOR);
 
     private final Int2ObjectMap<FontHolder> fontsInUse = new Int2ObjectOpenHashMap<>();
     private final LoadingCache<Integer, FontHolder> fontCache = CacheBuilder.newBuilder()
         .maximumSize(4)
         .expireAfterAccess(Duration.ofMinutes(10))
         .removalListener(notification -> {
-            if (notification.wasEvicted())
+            if (notification.getCause() != RemovalCause.EXPLICIT)
                 ((FontHolder) notification.getValue()).destroy();
         })
         .build(CacheLoader.from(HudRenderer::loadFont));
+
+    private boolean frameActive;
+    private boolean customFontForFrame;
+    private boolean fontResetPending;
 
     public GuiGraphicsExtractor graphics;
     public double delta;
@@ -63,54 +67,69 @@ public class HudRenderer {
     }
 
     public void begin(GuiGraphicsExtractor graphics) {
+        if (frameActive) throw new IllegalStateException("HudRenderer.begin() called twice");
+
         Renderer2D.COLOR.begin();
 
         this.graphics = graphics;
         this.delta = Utils.frameTime;
+        this.customFontForFrame = hud.hasCustomFont();
 
         graphics.nextStratum();
 
-        if (!hud.hasCustomFont()) {
+        if (!customFontForFrame) {
             VanillaTextRenderer.INSTANCE.scaleIndividually = true;
             VanillaTextRenderer.INSTANCE.begin();
         }
+
+        frameActive = true;
     }
 
     public void end() {
-        Renderer2D.COLOR.render();
+        if (!frameActive) throw new IllegalStateException("HudRenderer.end() called without calling begin()");
 
-        if (hud.hasCustomFont()) {
-            // Render fonts that were visited this frame and move to cache which weren't visited
-            for (Iterator<FontHolder> it = fontsInUse.values().iterator(); it.hasNext(); ) {
-                FontHolder fontHolder = it.next();
+        try {
+            Renderer2D.COLOR.render();
 
-                if (fontHolder.visited) {
-                    fontHolder.font.uploadPendingGlyphs();
+            if (customFontForFrame) {
+                // Render fonts that were visited this frame and move to cache which weren't visited
+                for (Iterator<FontHolder> it = fontsInUse.values().iterator(); it.hasNext(); ) {
+                    FontHolder fontHolder = it.next();
 
-                    MeshRenderer.begin()
-                        .attachments(mc.getMainRenderTarget())
-                        .pipeline(MeteorRenderPipelines.UI_TEXT)
-                        .mesh(fontHolder.getMesh())
-                        .sampler("u_Texture", fontHolder.font.texture.getTextureView(), fontHolder.font.texture.getSampler())
-                        .end();
-                } else {
-                    it.remove();
-                    fontCache.put(fontHolder.font.getHeight(), fontHolder);
+                    if (fontHolder.visited) {
+                        fontHolder.font.uploadPendingGlyphs();
+
+                        MeshRenderer.begin()
+                            .attachments(mc.getMainRenderTarget())
+                            .pipeline(MeteorRenderPipelines.UI_TEXT)
+                            .mesh(fontHolder.getMesh())
+                            .sampler("u_Texture", fontHolder.font.texture.getTextureView(), fontHolder.font.texture.getSampler())
+                            .end();
+                    } else {
+                        it.remove();
+                        fontCache.put(fontHolder.font.getHeight(), fontHolder);
+                    }
+
+                    fontHolder.visited = false;
                 }
-
-                fontHolder.visited = false;
+            } else {
+                VanillaTextRenderer.INSTANCE.end();
+                VanillaTextRenderer.INSTANCE.scaleIndividually = false;
             }
-        } else {
-            VanillaTextRenderer.INSTANCE.end();
-            VanillaTextRenderer.INSTANCE.scaleIndividually = false;
+
+            for (Runnable task : postTasks) task.run();
+
+            graphics.nextStratum();
+        } finally {
+            postTasks.clear();
+            graphics = null;
+            frameActive = false;
+
+            if (fontResetPending) {
+                resetFonts();
+                fontResetPending = false;
+            }
         }
-
-        for (Runnable task : postTasks) task.run();
-        postTasks.clear();
-
-        graphics.nextStratum();
-
-        graphics = null;
     }
 
     public void line(double x1, double y1, double x2, double y2, Color color) {
@@ -138,7 +157,7 @@ public class HudRenderer {
     public double text(String text, double x, double y, Color color, boolean shadow, double scale) {
         if (scale == -1) scale = hud.getTextScale();
 
-        if (!hud.hasCustomFont()) {
+        if (!usesCustomFont()) {
             VanillaTextRenderer.INSTANCE.scale = scale * 2;
             return VanillaTextRenderer.INSTANCE.render(text, x, y, color, shadow);
         }
@@ -151,13 +170,10 @@ public class HudRenderer {
         double width;
 
         if (shadow) {
-            int preShadowA = CustomTextRenderer.SHADOW_COLOR.a;
-            CustomTextRenderer.SHADOW_COLOR.a = (int) (color.a / 255.0 * preShadowA);
+            shadowColor.a = (int) (color.a / 255.0 * CustomTextRenderer.SHADOW_COLOR.a);
 
-            width = font.render(mesh, text, x + 1, y + 1, CustomTextRenderer.SHADOW_COLOR, scale);
+            width = font.render(mesh, text, x + 1, y + 1, shadowColor, scale);
             font.render(mesh, text, x, y, color, scale);
-
-            CustomTextRenderer.SHADOW_COLOR.a = preShadowA;
         } else {
             width = font.render(mesh, text, x, y, color, scale);
         }
@@ -172,7 +188,7 @@ public class HudRenderer {
     public double textWidth(String text, boolean shadow, double scale) {
         if (text.isEmpty()) return 0;
 
-        if (hud.hasCustomFont()) {
+        if (usesCustomFont()) {
             double width = getFont(scale).getWidth(text, text.length());
             return (width + (shadow ? 1 : 0)) * (scale == -1 ? hud.getTextScale() : scale) + (shadow ? 1 : 0);
         }
@@ -194,7 +210,7 @@ public class HudRenderer {
     }
 
     public double textHeight(boolean shadow, double scale) {
-        if (hud.hasCustomFont()) {
+        if (usesCustomFont()) {
             double height = getFont(scale).getHeight() + 1;
             return (height + (shadow ? 1 : 0)) * (scale == -1 ? hud.getTextScale() : scale);
         }
@@ -291,8 +307,21 @@ public class HudRenderer {
         return getFontHolder(scale, false).font;
     }
 
+    private boolean usesCustomFont() {
+        return frameActive ? customFontForFrame : hud.hasCustomFont();
+    }
+
     @EventHandler
     private void onCustomFontChanged(CustomFontChangedEvent event) {
+        if (frameActive) {
+            fontResetPending = true;
+            return;
+        }
+
+        resetFonts();
+    }
+
+    private void resetFonts() {
         // Need to destroy both fonts in use and in cache because they were not evicted from the cache automatically
         for (FontHolder fontHolder : fontsInUse.values()) fontHolder.destroy();
         for (FontHolder fontHolder : fontCache.asMap().values()) fontHolder.destroy();
@@ -303,12 +332,7 @@ public class HudRenderer {
     }
 
     private static FontHolder loadFont(int height) {
-        try {
-            List<ByteBuffer> buffers = Fonts.readFontBuffers(Fonts.RENDERER.fontFace);
-            return new FontHolder(new Font(buffers, height));
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to load font: " + Fonts.RENDERER.fontFace, e);
-        }
+        return new FontHolder(Fonts.RENDERER.createFont(height));
     }
 
     private static class FontHolder {
@@ -328,7 +352,7 @@ public class HudRenderer {
         }
 
         public void destroy() {
-            font.texture.close();
+            font.close();
         }
     }
 }


### PR DESCRIPTION
Fixes custom text rendering for glyphs that are not present in the selected Meteor font, such as Chinese characters.

The previous custom font renderer pre-packed a fixed set of Latin, Greek, Cyrillic, and symbol ranges. Characters outside those ranges could not render even when the OS had a suitable font installed.

Changes:
- load an available system fallback font for common CJK font families
- let Font use multiple font buffers
- lazily pack missing glyphs into the texture atlas
- upload pending glyphs before GUI/HUD custom text rendering
- handle Unicode code points instead of only Java char values

Validation:
- ./gradlew.bat build --stacktrace passes

This PR is based on master and does not include the Minecraft 26.2 update branch.