### PR TITLE
Fix TheAltening authentication

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/accounts/types/TheAlteningAccount.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/accounts/types/TheAlteningAccount.java
@@ -7,18 +7,18 @@ package meteordevelopment.meteorclient.systems.accounts.types;
 
 import com.mojang.authlib.Environment;
 import com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService;
-import de.florianreuth.waybackauthlib.InvalidCredentialsException;
-import de.florianreuth.waybackauthlib.WaybackAuthLib;
 import meteordevelopment.meteorclient.MeteorClient;
 import meteordevelopment.meteorclient.systems.accounts.Account;
 import meteordevelopment.meteorclient.systems.accounts.AccountType;
 import meteordevelopment.meteorclient.systems.accounts.TokenAccount;
 import meteordevelopment.meteorclient.utils.misc.NbtException;
+import meteordevelopment.meteorclient.utils.network.Http;
+import com.mojang.util.UndashedUuid;
 import net.minecraft.client.User;
 import net.minecraft.nbt.CompoundTag;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import static meteordevelopment.meteorclient.MeteorClient.mc;
 
@@ -26,7 +26,7 @@ public class TheAlteningAccount extends Account<TheAlteningAccount> implements T
     private static final Environment ENVIRONMENT = new Environment("http://sessionserver.thealtening.com", "http://authserver.thealtening.com", "https://api.mojang.com", "The Altening");
     private static final YggdrasilAuthenticationService SERVICE = new YggdrasilAuthenticationService(mc.getProxy(), ENVIRONMENT);
     private String token;
-    private @Nullable WaybackAuthLib auth;
+    private String accessToken;
 
     public TheAlteningAccount(String token) {
         super(AccountType.TheAltening, token);
@@ -35,19 +35,19 @@ public class TheAlteningAccount extends Account<TheAlteningAccount> implements T
 
     @Override
     public boolean fetchInfo() {
-        auth = getAuth();
-
         try {
-            auth.logIn();
+            AuthResponse res = authenticate();
+            if (res == null || res.accessToken == null || res.selectedProfile == null) {
+                MeteorClient.LOG.error("Invalid TheAltening credentials.");
+                return false;
+            }
 
-            cache.username = auth.getCurrentProfile().name();
-            cache.uuid = auth.getCurrentProfile().id().toString();
+            accessToken = res.accessToken;
+            cache.username = res.selectedProfile.name;
+            cache.uuid = res.selectedProfile.id;
             cache.loadHead();
 
             return true;
-        } catch (InvalidCredentialsException _) {
-            MeteorClient.LOG.error("Invalid TheAltening credentials.");
-            return false;
         } catch (Exception _) {
             MeteorClient.LOG.error("Failed to fetch info for TheAltening account!");
             return false;
@@ -56,11 +56,11 @@ public class TheAlteningAccount extends Account<TheAlteningAccount> implements T
 
     @Override
     public boolean login() {
-        if (auth == null) return false;
+        if (accessToken == null || cache.username.isEmpty() || cache.uuid.isEmpty()) return false;
         applyLoginEnvironment(SERVICE);
 
         try {
-            setSession(new User(auth.getCurrentProfile().name(), auth.getCurrentProfile().id(), auth.getAccessToken(), Optional.empty(), Optional.empty()));
+            setSession(new User(cache.username, UndashedUuid.fromStringLenient(cache.uuid), accessToken, Optional.empty(), Optional.empty()));
             return true;
         } catch (Exception _) {
             MeteorClient.LOG.error("Failed to login with TheAltening.");
@@ -68,13 +68,10 @@ public class TheAlteningAccount extends Account<TheAlteningAccount> implements T
         }
     }
 
-    private WaybackAuthLib getAuth() {
-        WaybackAuthLib auth = new WaybackAuthLib(ENVIRONMENT.servicesHost());
-
-        auth.setUsername(name);
-        auth.setPassword("Meteor on Crack!");
-
-        return auth;
+    private AuthResponse authenticate() {
+        return Http.post(ENVIRONMENT.servicesHost() + "/authenticate")
+            .bodyJson(new AuthRequest("MINECRAFT", token, "LiquidBounce", UUID.randomUUID().toString(), true))
+            .sendJson(AuthResponse.class);
     }
 
     @Override
@@ -104,5 +101,17 @@ public class TheAlteningAccount extends Account<TheAlteningAccount> implements T
         cache.fromTag(tag.getCompound("cache").get());
 
         return this;
+    }
+
+    private record AuthRequest(String agent, String username, String password, String clientToken, boolean requestUser) {}
+
+    private static class AuthResponse {
+        public String accessToken;
+        public AuthProfile selectedProfile;
+    }
+
+    private static class AuthProfile {
+        public String id;
+        public String name;
     }
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/accounts/types/TheAlteningAccount.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/accounts/types/TheAlteningAccount.java
@@ -70,7 +70,7 @@ public class TheAlteningAccount extends Account<TheAlteningAccount> implements T
 
     private AuthResponse authenticate() {
         return Http.post(ENVIRONMENT.servicesHost() + "/authenticate")
-            .bodyJson(new AuthRequest("MINECRAFT", token, "LiquidBounce", UUID.randomUUID().toString(), true))
+            .bodyJson(new AuthRequest("MINECRAFT", token, "Meteor on Crack!", UUID.randomUUID().toString(), true))
             .sendJson(AuthResponse.class);
     }
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Fixes TheAltening account authentication by replacing the old `WaybackAuthLib` login path with a direct Yggdrasil-compatible `/authenticate` request.

## Related issues

None

# How Has This Been Tested?

Tested in a production client environment with TheAltening login. Authentication succeeds; Mojang profile key fetch may still return `401`.


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
