### PR TITLE
fix AirPlace conflict with using fireworks to fly

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AirPlace.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AirPlace.java
@@ -123,6 +123,9 @@ public class AirPlace extends Module {
 
     private boolean placeable(ItemStack stack) {
         Item i = stack.getItem();
-        return i instanceof BlockItem || i instanceof SpawnEggItem || i instanceof FireworkRocketItem || i instanceof ArmorStandItem;
+        return i instanceof BlockItem
+            || i instanceof SpawnEggItem
+            || (i instanceof FireworkRocketItem && !mc.player.isFallFlying())
+            || i instanceof ArmorStandItem;
     }
 }


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

When flying with an elytra and AirPlace module is enabled, Fireworks can't be used for propulsion


## Related issues


# How Has This Been Tested?


# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
