### PR TITLE
Add Auto Reconnect account re-authentication

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/DisconnectedScreenMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/DisconnectedScreenMixin.java
@@ -60,6 +60,7 @@ public abstract class DisconnectedScreenMixin extends Screen {
     public void tick() {
         AutoReconnect autoReconnect = Modules.get().get(AutoReconnect.class);
         if (!autoReconnect.isActive() || autoReconnect.lastServerConnection == null) return;
+        if (autoReconnect.isReAuthInFlight()) return;
 
         if (time <= 0) {
             tryConnecting();

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/AutoReconnect.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/AutoReconnect.java
@@ -8,18 +8,34 @@ package meteordevelopment.meteorclient.systems.modules.misc;
 import it.unimi.dsi.fastutil.Pair;
 import it.unimi.dsi.fastutil.objects.ObjectObjectImmutablePair;
 import meteordevelopment.meteorclient.MeteorClient;
+import meteordevelopment.meteorclient.events.game.OpenScreenEvent;
 import meteordevelopment.meteorclient.events.world.ServerConnectBeginEvent;
 import meteordevelopment.meteorclient.settings.BoolSetting;
 import meteordevelopment.meteorclient.settings.DoubleSetting;
 import meteordevelopment.meteorclient.settings.Setting;
 import meteordevelopment.meteorclient.settings.SettingGroup;
+import meteordevelopment.meteorclient.systems.accounts.Account;
+import meteordevelopment.meteorclient.systems.accounts.AccountCache;
+import meteordevelopment.meteorclient.systems.accounts.Accounts;
+import meteordevelopment.meteorclient.systems.accounts.types.MicrosoftAccount;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.meteorclient.utils.network.MeteorExecutor;
 import meteordevelopment.orbit.EventHandler;
+import net.minecraft.client.User;
+import net.minecraft.client.gui.screens.DisconnectedScreen;
 import net.minecraft.client.multiplayer.resolver.ServerAddress;
 import net.minecraft.client.multiplayer.ServerData;
 
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 public class AutoReconnect extends Module {
+    private static final long REAUTH_COOLDOWN_MS = 30_000;
+
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
 
     public final Setting<Double> time = sgGeneral.add(new DoubleSetting.Builder()
@@ -38,6 +54,16 @@ public class AutoReconnect extends Module {
         .build()
     );
 
+    public final Setting<Boolean> reAuthenticate = sgGeneral.add(new BoolSetting.Builder()
+        .name("re-authenticate")
+        .description("Re-authenticates Microsoft accounts before reconnecting if they are saved in Accounts.")
+        .defaultValue(false)
+        .build()
+    );
+
+    private final AtomicBoolean reAuthInFlight = new AtomicBoolean(false);
+    private final Map<String, Long> lastReAuthAttempt = new ConcurrentHashMap<>();
+
     public Pair<ServerAddress, ServerData> lastServerConnection;
 
     public AutoReconnect() {
@@ -45,10 +71,124 @@ public class AutoReconnect extends Module {
         MeteorClient.EVENT_BUS.subscribe(new StaticListener());
     }
 
+    public boolean isReAuthInFlight() {
+        return reAuthenticate.get() && reAuthInFlight.get();
+    }
+
+    private void tryReAuthenticate() {
+        if (!isActive() || !reAuthenticate.get() || lastServerConnection == null) return;
+
+        User user = mc.getUser();
+        if (user == null) {
+            MeteorClient.LOG.info("Auto Reconnect re-authentication skipped: no current Minecraft session.");
+            return;
+        }
+
+        Account<?> account = findCurrentAccount(user);
+        if (account == null) {
+            MeteorClient.LOG.info("Auto Reconnect re-authentication skipped: no account matches the current session.");
+            return;
+        }
+
+        String accountKey = getAccountKey(account, user);
+        if (isOnCooldown(accountKey)) return;
+
+        if (!(account instanceof MicrosoftAccount microsoftAccount)) {
+            lastReAuthAttempt.put(accountKey, System.currentTimeMillis());
+            MeteorClient.LOG.info("Auto Reconnect re-authentication skipped: account {} is {}, not Microsoft.", getDisplayName(account), account.getType());
+            return;
+        }
+
+        if (!reAuthInFlight.compareAndSet(false, true)) return;
+
+        lastReAuthAttempt.put(accountKey, System.currentTimeMillis());
+        String username = getDisplayName(account);
+        MeteorClient.LOG.info("Auto Reconnect re-authentication started for {}.", username);
+
+        MeteorExecutor.execute(() -> {
+            try {
+                if (microsoftAccount.fetchInfo() && microsoftAccount.login()) {
+                    Accounts.get().save();
+                    lastReAuthAttempt.remove(accountKey);
+                    MeteorClient.LOG.info("Auto Reconnect re-authentication succeeded for {}.", getDisplayName(microsoftAccount));
+                } else {
+                    MeteorClient.LOG.warn("Auto Reconnect re-authentication failed for {}.", username);
+                }
+            } catch (Exception e) {
+                MeteorClient.LOG.warn("Auto Reconnect re-authentication failed for {}.", username, e);
+            } finally {
+                reAuthInFlight.set(false);
+            }
+        });
+    }
+
+    private Account<?> findCurrentAccount(User user) {
+        String currentUuid = normalizeUuid(user.getProfileId());
+        String currentName = normalizeName(user.getName());
+        Account<?> usernameMatch = null;
+
+        for (Account<?> account : Accounts.get()) {
+            AccountCache cache = account.getCache();
+            String accountUuid = normalizeUuid(cache.uuid);
+
+            if (!currentUuid.isEmpty() && currentUuid.equals(accountUuid)) return account;
+
+            if (usernameMatch == null && !currentName.isEmpty() && currentName.equals(normalizeName(cache.username))) {
+                usernameMatch = account;
+            }
+        }
+
+        return usernameMatch;
+    }
+
+    private boolean isOnCooldown(String accountKey) {
+        Long lastAttemptAt = lastReAuthAttempt.get(accountKey);
+        return lastAttemptAt != null && System.currentTimeMillis() - lastAttemptAt < REAUTH_COOLDOWN_MS;
+    }
+
+    private String getAccountKey(Account<?> account, User user) {
+        AccountCache cache = account.getCache();
+        String uuid = normalizeUuid(cache.uuid);
+        if (!uuid.isEmpty()) return "uuid:" + uuid;
+
+        String username = normalizeName(cache.username);
+        if (!username.isEmpty()) return "username:" + username;
+
+        String currentUuid = normalizeUuid(user.getProfileId());
+        if (!currentUuid.isEmpty()) return "current-uuid:" + currentUuid;
+
+        return "current-username:" + normalizeName(user.getName());
+    }
+
+    private String getDisplayName(Account<?> account) {
+        String username = account.getCache().username;
+        if (username != null && !username.isBlank()) return username;
+
+        return account.getType().name();
+    }
+
+    private String normalizeName(String name) {
+        return name == null ? "" : name.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private String normalizeUuid(UUID uuid) {
+        return uuid == null ? "" : normalizeUuid(uuid.toString());
+    }
+
+    private String normalizeUuid(String uuid) {
+        if (uuid == null) return "";
+        return uuid.replace("-", "").trim().toLowerCase(Locale.ROOT);
+    }
+
     private class StaticListener {
         @EventHandler
         private void onGameJoined(ServerConnectBeginEvent event) {
             lastServerConnection = new ObjectObjectImmutablePair<>(event.address, event.info);
+        }
+
+        @EventHandler
+        private void onOpenScreen(OpenScreenEvent event) {
+            if (event.screen instanceof DisconnectedScreen) tryReAuthenticate();
         }
     }
 }


### PR DESCRIPTION
﻿## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Adds an optional `re-authenticate` setting to Auto Reconnect. When enabled, Auto Reconnect finds the current Minecraft session in Meteor's saved Accounts list and refreshes the matching `MicrosoftAccount` before reconnecting.

This is intended to recover from stale Microsoft session tokens during reconnects without changing the existing reconnect behavior for users who leave the option disabled.

## Related issues

N/A

# How Has This Been Tested?

- `./gradlew.bat build`
- Development build: imported existing Meteor account data, logged into the saved Microsoft account, enabled Auto Reconnect and `re-authenticate`, disconnected, and verified the client re-authenticated and rejoined.
- Production build: repeated the same Auto Reconnect + `re-authenticate` flow and verified the client re-authenticated and rejoined.

The following local-only snippet was used to poison the active in-memory session token for testing. It was not included in the committed code:

```java
User user = mc.getUser();
Account.setSession(new User(
    user.getName(),
    user.getProfileId(),
    "meteor-invalid-access-token-" + System.currentTimeMillis(),
    Optional.empty(),
    Optional.empty()
));
```

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
