### PR TITLE
fix: path traversal in profile import allows arbitrary file write

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/ProfilesTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/ProfilesTab.java
@@ -155,6 +155,7 @@ public class ProfilesTab extends Tab {
             nbt.remove("name");
             for (var entry : nbt.entrySet()) {
                 String filename = entry.getKey();
+                if (!filename.endsWith(".nbt")) continue;
 
                 switch (filename) {
                     case "hud.nbt" -> p.hud.set(true);
@@ -167,6 +168,7 @@ public class ProfilesTab extends Tab {
 
                 File f = new File(p.getFile(), filename).getCanonicalFile();
                 if (!f.toPath().startsWith(Profiles.FOLDER.getCanonicalFile().toPath())) continue;
+
                 NbtIo.writeUnnamedTagWithFallback(entry.getValue(), new DataOutputStream(new FileOutputStream(f)));
             }
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/ProfilesTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/ProfilesTab.java
@@ -165,7 +165,8 @@ public class ProfilesTab extends Tab {
                     }
                 }
 
-                File f = new File(p.getFile(), filename);
+                File f = new File(p.getFile(), filename).getCanonicalFile();
+                if (!f.toPath().startsWith(Profiles.FOLDER.getCanonicalFile().toPath())) continue;
                 NbtIo.writeUnnamedTagWithFallback(entry.getValue(), new DataOutputStream(new FileOutputStream(f)));
             }
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/StringSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/StringSetting.java
@@ -33,6 +33,10 @@ public class StringSetting extends Setting<String> {
 
     @Override
     protected boolean isValueValid(String value) {
+        if (filter == null) return true;
+        for (int i = 0; i < value.length(); i++) {
+            if (!filter.test(value, value.charAt(i))) return false;
+        }
         return true;
     }
 

--- a/src/main/java/meteordevelopment/meteorclient/settings/StringSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/StringSetting.java
@@ -35,7 +35,7 @@ public class StringSetting extends Setting<String> {
     protected boolean isValueValid(String value) {
         if (filter == null) return true;
         for (int i = 0; i < value.length(); i++) {
-            if (!filter.test(value, value.charAt(i))) return false;
+            if (!filter.filter(value, value.charAt(i))) return false;
         }
         return true;
     }


### PR DESCRIPTION
Component: ProfilesTab.java -> importProfile() (lines 151, 157-169)

Vulnerability: Path traversal in profile import allows arbitrary file write.

importProfile() takes entry keys from an imported .nbt file and passes them directly to new File(p.getFile(), filename) with no sanitization. The OS resolves .. segments, so a crafted entry key like ../../../mods/evil.jar writes outside the profile directory. The profile name (line 151) has the same issue -- a name like ../../.. shifts the base path itself, bypassing naive checks anchored to p.getFile().

Steps to reproduce:
1. Craft a .nbt compound where one entry key is ../../../<target> and its value is a ByteArrayTag containing arbitrary bytes
2. Open Profiles tab, click Import, select the file
3. The file is written to the resolved path outside the profile directory

Expected: Entry keys that resolve outside the profile directory are rejected.

Actual: No validation, any path the OS accepts gets written, to any file the user has write access to.

Fix: Resolve canonical path after construction and verify it stays under Profiles.FOLDER before opening FileOutputStream.

File f = new File(p.getFile(), filename).getCanonicalFile();
if (!f.toPath().startsWith(Profiles.FOLDER.getCanonicalFile().toPath())) continue;