### PR TITLE
prevent profile imports overwriting other profiles

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/ProfilesTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/ProfilesTab.java
@@ -148,8 +148,9 @@ public class ProfilesTab extends Tab {
             CompoundTag nbt = NbtIo.read(profileFile.toPath());
 
             Profile p = new Profile();
-            if (!p.name.set(nbt.getStringOr("name", profileFile.getName())) || p.name.get().isEmpty()) return null;
-            File profileFolder = p.getFile().getCanonicalFile();
+            if (!p.name.set(nbt.getStringOr("name", profileFile.getName()))) return null;
+            File profileFolder = p.getSafeFile();
+            if (profileFolder == null) return null;
             //noinspection ResultOfMethodCallIgnored
             profileFolder.mkdirs();
 
@@ -214,7 +215,7 @@ public class ProfilesTab extends Tab {
 
             WButton save = add(theme.button(isNew ? "Create" : "Save")).expandX().widget();
             save.action = () -> {
-                if (profile.name.get().isEmpty()) return;
+                if (profile.getSafeFile() == null) return;
 
                 if (isNew) {
                     for (Profile p : Profiles.get()) {

--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/ProfilesTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/ProfilesTab.java
@@ -148,14 +148,16 @@ public class ProfilesTab extends Tab {
             CompoundTag nbt = NbtIo.read(profileFile.toPath());
 
             Profile p = new Profile();
-            p.name.set(nbt.getStringOr("name", profileFile.getName()));
+            if (!p.name.set(nbt.getStringOr("name", profileFile.getName())) || p.name.get().isEmpty()) return null;
+            File profileFolder = p.getFile().getCanonicalFile();
             //noinspection ResultOfMethodCallIgnored
-            p.getFile().mkdirs();
+            profileFolder.mkdirs();
 
             nbt.remove("name");
             for (var entry : nbt.entrySet()) {
                 String filename = entry.getKey();
                 if (!filename.endsWith(".nbt")) continue;
+                if (filename.contains("/") || filename.contains("\\") || new File(filename).isAbsolute()) continue;
 
                 switch (filename) {
                     case "hud.nbt" -> p.hud.set(true);
@@ -166,8 +168,8 @@ public class ProfilesTab extends Tab {
                     }
                 }
 
-                File f = new File(p.getFile(), filename).getCanonicalFile();
-                if (!f.toPath().startsWith(Profiles.FOLDER.getCanonicalFile().toPath())) continue;
+                File f = new File(profileFolder, filename).getCanonicalFile();
+                if (!f.toPath().startsWith(profileFolder.toPath())) continue;
 
                 NbtIo.writeUnnamedTagWithFallback(entry.getValue(), new DataOutputStream(new FileOutputStream(f)));
             }

--- a/src/main/java/meteordevelopment/meteorclient/systems/profiles/Profile.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/profiles/Profile.java
@@ -78,7 +78,8 @@ public class Profile implements ISerializable<Profile> {
     }
 
     public void load() {
-        File folder = getFile();
+        File folder = getSafeFile();
+        if (folder == null) return;
 
         if (hud.get()) Hud.get().load(folder);
         if (macros.get()) Macros.get().load(folder);
@@ -87,7 +88,8 @@ public class Profile implements ISerializable<Profile> {
     }
 
     public void save() {
-        File folder = getFile();
+        File folder = getSafeFile();
+        if (folder == null) return;
 
         if (hud.get()) Hud.get().save(folder);
         if (macros.get()) Macros.get().save(folder);
@@ -97,7 +99,8 @@ public class Profile implements ISerializable<Profile> {
 
     public void delete() {
         try {
-            FileUtils.deleteDirectory(getFile());
+            File folder = getSafeFile();
+            if (folder != null) FileUtils.deleteDirectory(folder);
         } catch (IOException e) {
             MeteorClient.LOG.error("Error deleting profile {}", name.get(), e);
         }
@@ -105,6 +108,20 @@ public class Profile implements ISerializable<Profile> {
 
     public File getFile() {
         return new File(Profiles.FOLDER, name.get());
+    }
+
+    public File getSafeFile() {
+        try {
+            File folder = getFile().getCanonicalFile();
+            File profilesFolder = Profiles.FOLDER.getCanonicalFile();
+
+            if (name.get().isEmpty() || !profilesFolder.equals(folder.getParentFile())) return null;
+
+            return folder;
+        } catch (IOException e) {
+            MeteorClient.LOG.error("Error resolving profile {}", name.get(), e);
+            return null;
+        }
     }
 
     @Override


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description
This is just a simple tightening patch for profile import path validation. The previous commit fixed the actual issue, but that still allowed traversal into other profiles using NBT keys like ../OtherProfile/modules.nbt.

## Related issues
Partially #6500

# How Has This Been Tested?
Tested with a profile which overwrites another profiles, profile is shared on discord 

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
