### PR TITLE
clean up profile code

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/ProfilesTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/ProfilesTab.java
@@ -164,8 +164,9 @@ public class ProfilesTab extends Tab {
 
             //noinspection ResultOfMethodCallIgnored
             profileFolder.mkdirs();
-
             nbt.remove("name");
+
+            boolean valid = false;
             for (var entry : nbt.entrySet()) {
                 String filename = entry.getKey();
                 if (!filename.endsWith(".nbt")) continue;
@@ -183,7 +184,12 @@ public class ProfilesTab extends Tab {
                 File f = new File(profileFolder, filename).getCanonicalFile();
                 if (!f.toPath().startsWith(profileFolder.toPath())) continue;
 
+                valid = true;
                 NbtIo.writeUnnamedTagWithFallback(entry.getValue(), new DataOutputStream(new FileOutputStream(f)));
+            }
+
+            if (!valid) {
+                throw new IllegalStateException("Imported file is not a profile.");
             }
 
             Profiles.get().getAll().add(p);

--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/ProfilesTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/ProfilesTab.java
@@ -103,7 +103,7 @@ public class ProfilesTab extends Tab {
                     OkPrompt.create()
                         .title("Failure importing profile")
                         .message("There was an error importing the profile.")
-                        .message("Error: %d", e.getMessage())
+                        .message("Error: %s", e.getMessage())
                         .dontShowAgainCheckboxVisible(false)
                         .show();
                 }

--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/ProfilesTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/ProfilesTab.java
@@ -158,7 +158,7 @@ public class ProfilesTab extends Tab {
             }
 
             File profileFolder = p.getFile().getCanonicalFile();
-            if (!profileFolder.getParent().equals(Profiles.FOLDER.getCanonicalPath())) {
+            if (!profileFolder.getParentFile().equals(Profiles.FOLDER.getCanonicalFile())) {
                 throw new IllegalStateException("Imported profile does not have a valid location.");
             }
 

--- a/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/ProfilesTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/tabs/builtin/ProfilesTab.java
@@ -28,6 +28,7 @@ import meteordevelopment.meteorclient.utils.render.prompts.OkPrompt;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtIo;
+import org.apache.commons.io.FilenameUtils;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.PointerBuffer;
 import org.lwjgl.system.MemoryUtil;
@@ -41,6 +42,7 @@ import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static meteordevelopment.meteorclient.MeteorClient.mc;
 
@@ -98,7 +100,7 @@ public class ProfilesTab extends Tab {
                     if (imported != null)
                         MeteorClient.LOG.info("Successfully imported profile '{}'.", imported.name.get());
                     reload();
-                } catch (IOException e) {
+                } catch (Exception e) {
                     MeteorClient.LOG.error("Error importing profile", e);
                     OkPrompt.create()
                         .title("Failure importing profile")
@@ -146,11 +148,20 @@ public class ProfilesTab extends Tab {
             File profileFile = new File(file);
 
             CompoundTag nbt = NbtIo.read(profileFile.toPath());
+            if (nbt == null) return null;
 
             Profile p = new Profile();
-            if (!p.name.set(nbt.getStringOr("name", profileFile.getName()))) return null;
-            File profileFolder = p.getSafeFile();
-            if (profileFolder == null) return null;
+            Optional<String> parsedName = nbt.getString("name").filter(n -> !n.isEmpty());
+
+            if (parsedName.filter(p.name::set).isEmpty() && !p.name.set(FilenameUtils.removeExtension(profileFile.getName()))) {
+                throw new IllegalStateException("Imported profile does not have a valid name.");
+            }
+
+            File profileFolder = p.getFile().getCanonicalFile();
+            if (!profileFolder.getParent().equals(Profiles.FOLDER.getCanonicalPath())) {
+                throw new IllegalStateException("Imported profile does not have a valid location.");
+            }
+
             //noinspection ResultOfMethodCallIgnored
             profileFolder.mkdirs();
 
@@ -215,7 +226,7 @@ public class ProfilesTab extends Tab {
 
             WButton save = add(theme.button(isNew ? "Create" : "Save")).expandX().widget();
             save.action = () -> {
-                if (profile.getSafeFile() == null) return;
+                if (profile.name.get().isEmpty()) return;
 
                 if (isNew) {
                     for (Profile p : Profiles.get()) {

--- a/src/main/java/meteordevelopment/meteorclient/systems/profiles/Profile.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/profiles/Profile.java
@@ -78,8 +78,7 @@ public class Profile implements ISerializable<Profile> {
     }
 
     public void load() {
-        File folder = getSafeFile();
-        if (folder == null) return;
+        File folder = getFile();
 
         if (hud.get()) Hud.get().load(folder);
         if (macros.get()) Macros.get().load(folder);
@@ -88,8 +87,7 @@ public class Profile implements ISerializable<Profile> {
     }
 
     public void save() {
-        File folder = getSafeFile();
-        if (folder == null) return;
+        File folder = getFile();
 
         if (hud.get()) Hud.get().save(folder);
         if (macros.get()) Macros.get().save(folder);
@@ -99,8 +97,7 @@ public class Profile implements ISerializable<Profile> {
 
     public void delete() {
         try {
-            File folder = getSafeFile();
-            if (folder != null) FileUtils.deleteDirectory(folder);
+            FileUtils.deleteDirectory(getFile());
         } catch (IOException e) {
             MeteorClient.LOG.error("Error deleting profile {}", name.get(), e);
         }
@@ -108,20 +105,6 @@ public class Profile implements ISerializable<Profile> {
 
     public File getFile() {
         return new File(Profiles.FOLDER, name.get());
-    }
-
-    public File getSafeFile() {
-        try {
-            File folder = getFile().getCanonicalFile();
-            File profilesFolder = Profiles.FOLDER.getCanonicalFile();
-
-            if (name.get().isEmpty() || !profilesFolder.equals(folder.getParentFile())) return null;
-
-            return folder;
-        } catch (IOException e) {
-            MeteorClient.LOG.error("Error resolving profile {}", name.get(), e);
-            return null;
-        }
     }
 
     @Override

--- a/src/main/java/meteordevelopment/meteorclient/systems/profiles/Profile.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/profiles/Profile.java
@@ -31,7 +31,7 @@ public class Profile implements ISerializable<Profile> {
     public Setting<String> name = sgGeneral.add(new StringSetting.Builder()
         .name("name")
         .description("The name of the profile.")
-        .filter(Utils::nameFilter)
+        .filter(Utils::fileNameFilter)
         .build()
     );
 

--- a/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/Utils.java
@@ -672,6 +672,10 @@ public class Utils {
         return (character >= 'a' && character <= 'z') || (character >= 'A' && character <= 'Z') || (character >= '0' && character <= '9') || character == '_' || character == '-' || character == '.' || character == ' ';
     }
 
+    public static boolean fileNameFilter(String text, char character) {
+        return (character >= 'a' && character <= 'z') || (character >= 'A' && character <= 'Z') || (character >= '0' && character <= '9') || character == '_' || character == '-' || character == ' ';
+    }
+
     public static boolean ipFilter(String text, char character) {
         if (text.contains(":") && character == ':') return false;
         return (character >= 'a' && character <= 'z') || (character >= 'A' && character <= 'Z') || (character >= '0' && character <= '9') || character == '.' || character == '-' || character == ':';


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature

## Description

- disallow dots in profile names
- fallback to imported file name if parsed profile name is invalid
- replace invalid profiles with `getSafeFile() == null` with errors thrown & reported in the import dialog
- add sanity check for whether the imported nbt file contains any valid locations expected of an exported profile

## Related issues

builds upon #6502 

# How Has This Been Tested?

the J

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
