### PR TITLE
Adjustment to ArmorHud Text

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ArmorHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/ArmorHud.java
@@ -5,7 +5,6 @@
 
 package meteordevelopment.meteorclient.systems.hud.elements;
 
-import meteordevelopment.meteorclient.renderer.text.TextRenderer;
 import meteordevelopment.meteorclient.settings.*;
 import meteordevelopment.meteorclient.systems.hud.Hud;
 import meteordevelopment.meteorclient.systems.hud.HudElement;
@@ -33,7 +32,7 @@ public class ArmorHud extends HudElement {
         .name("orientation")
         .description("How to display armor.")
         .defaultValue(Orientation.Horizontal)
-        .onChanged(_ -> calculateSize())
+        .onChanged(_ -> calculateSize(HudRenderer.INSTANCE))
         .build()
     );
 
@@ -57,7 +56,7 @@ public class ArmorHud extends HudElement {
         .name("durability")
         .description("How to display armor durability.")
         .defaultValue(Durability.Bar)
-        .onChanged(_ -> calculateSize())
+        .onChanged(_ -> calculateSize(HudRenderer.INSTANCE))
         .build()
     );
 
@@ -83,7 +82,7 @@ public class ArmorHud extends HudElement {
         .name("custom-scale")
         .description("Applies a custom scale to this hud element.")
         .defaultValue(false)
-        .onChanged(_ -> calculateSize())
+        .onChanged(_ -> calculateSize(HudRenderer.INSTANCE))
         .build()
     );
 
@@ -92,7 +91,7 @@ public class ArmorHud extends HudElement {
         .description("Custom scale.")
         .visible(customScale::get)
         .defaultValue(2)
-        .onChanged(_ -> calculateSize())
+        .onChanged(_ -> calculateSize(HudRenderer.INSTANCE))
         .min(0.5)
         .sliderRange(0.5, 3)
         .build()
@@ -118,26 +117,94 @@ public class ArmorHud extends HudElement {
     public ArmorHud() {
         super(INFO);
 
-        calculateSize();
+        calculateSize(HudRenderer.INSTANCE);
     }
 
-    private void calculateSize() {
+    @Override
+    public void tick(HudRenderer renderer) {
+        calculateSize(renderer);
+    }
+
+    private boolean showsDurabilityText() {
+        return durability.get() == Durability.Total || durability.get() == Durability.Percentage;
+    }
+
+    private double getIconSize() {
+        return 16 * getScale();
+    }
+
+    private double getPadding() {
+        return 2 * getScale();
+    }
+
+    // Durability text scale relative to the icon scale: 1x (normal HUD text scale) at the default
+    // icon scale, growing/shrinking as the icon's custom scale changes. Uses a square root so the
+    // text doesn't grow as aggressively as the icon does at the higher end of the scale slider.
+    private double getTextScale() {
+        return Math.sqrt(getScale() / scale.getDefaultValue().floatValue()) * Hud.get().getTextScale();
+    }
+
+    // Spacing between items along the main layout axis: columns in Horizontal, rows in Vertical.
+    // The durability text doesn't affect this since it's drawn on the cross axis (below in Horizontal,
+    // to the right in Vertical), not between items.
+    private double getItemStride() {
+        return getIconSize() + getPadding();
+    }
+
+    private ItemStack[] getArmorItems() {
+        // default order is from boots to helmet
+        return flipOrder.get() ?
+            new ItemStack[]{getItem(EquipmentSlot.HEAD), getItem(EquipmentSlot.CHEST), getItem(EquipmentSlot.LEGS), getItem(EquipmentSlot.FEET)} :
+            new ItemStack[]{getItem(EquipmentSlot.FEET), getItem(EquipmentSlot.LEGS), getItem(EquipmentSlot.CHEST), getItem(EquipmentSlot.HEAD)};
+    }
+
+    private String getDurabilityText(ItemStack itemStack) {
+        return switch (durability.get()) {
+            case Total -> Integer.toString(itemStack.getMaxDamage() - itemStack.getDamageValue());
+            case Percentage ->
+                Integer.toString(Math.round(((itemStack.getMaxDamage() - itemStack.getDamageValue()) * 100f) / (float) itemStack.getMaxDamage()));
+            default -> "";
+        };
+    }
+
+    // Widest durability text among the currently displayed items, used to size the Vertical orientation's width.
+    private double getMaxDurabilityTextWidth(HudRenderer renderer) {
+        double maxWidth = 0;
+
+        for (ItemStack stack : getArmorItems()) {
+            if (!stack.isDamageableItem()) continue;
+            maxWidth = Math.max(maxWidth, renderer.textWidth(getDurabilityText(stack), durabilityShadow.get(), getTextScale()));
+        }
+
+        return maxWidth;
+    }
+
+    private void calculateSize(HudRenderer renderer) {
+        double iconSize = getIconSize();
+        double stride = getItemStride();
+        boolean showsText = showsDurabilityText();
+
         switch (orientation.get()) {
-            // Four item stacks plus
-            case Horizontal -> setSize((16 * 4 + 2 * 4) * getScale(), 16 * getScale());
-            case Vertical -> setSize(16 * getScale(), (16 * 4 + 2 * 4) * getScale());
+            case Horizontal -> {
+                // Text sits below each icon, so it grows the box's height.
+                double height = iconSize;
+                if (showsText) height += getPadding() + renderer.textHeight(durabilityShadow.get(), getTextScale());
+                setSize(stride * 4, height);
+            }
+            case Vertical -> {
+                // Text sits to the right of each icon, so it grows the box's width instead of its height.
+                double width = iconSize;
+                if (showsText) width += getPadding() + getMaxDurabilityTextWidth(renderer);
+                setSize(width, stride * 4);
+            }
         }
     }
 
     @Override
     public void render(HudRenderer renderer) {
+        ItemStack[] armor = getArmorItems();
+
         int emptySlots = 0;
-
-        // default order is from boots to helmet
-        ItemStack[] armor = flipOrder.get() ?
-            new ItemStack[]{getItem(EquipmentSlot.HEAD), getItem(EquipmentSlot.CHEST), getItem(EquipmentSlot.LEGS), getItem(EquipmentSlot.FEET)} :
-            new ItemStack[]{getItem(EquipmentSlot.FEET), getItem(EquipmentSlot.LEGS), getItem(EquipmentSlot.CHEST), getItem(EquipmentSlot.HEAD)};
-
         for (ItemStack stack : armor) {
             if (stack.isEmpty()) emptySlots++;
         }
@@ -150,40 +217,42 @@ public class ArmorHud extends HudElement {
             double x = this.x;
             double y = this.y;
 
+            double iconSize = getIconSize();
+            double padding = getPadding();
+            double stride = getItemStride();
+            boolean showsText = showsDurabilityText();
+            boolean vertical = orientation.get() == Orientation.Vertical;
+
             double armorX, armorY;
 
             for (int position = 0; position < 4; position++) {
                 ItemStack itemStack = armor[position];
 
-                if (orientation.get() == Orientation.Vertical) {
+                if (vertical) {
                     armorX = x;
-                    armorY = y + position * 18 * getScale();
+                    armorY = y + position * stride;
                 } else {
-                    armorX = x + position * 18 * getScale();
+                    armorX = x + position * stride;
                     armorY = y;
                 }
 
                 renderer.item(itemStack, (int) armorX, (int) armorY, getScale(), (itemStack.isDamageableItem() && durability.get() == Durability.Bar));
 
-                if (itemStack.isDamageableItem() && durability.get() != Durability.Bar && durability.get() != Durability.None) {
-                    String message = switch (durability.get()) {
-                        case Total -> Integer.toString(itemStack.getMaxDamage() - itemStack.getDamageValue());
-                        case Percentage ->
-                            Integer.toString(Math.round(((itemStack.getMaxDamage() - itemStack.getDamageValue()) * 100f) / (float) itemStack.getMaxDamage()));
-                        default -> "err";
-                    };
+                if (itemStack.isDamageableItem() && showsText && durability.get() != Durability.Bar) {
+                    String message = getDurabilityText(itemStack);
+                    double messageWidth = renderer.textWidth(message, durabilityShadow.get(), getTextScale());
+                    double textHeight = renderer.textHeight(durabilityShadow.get(), getTextScale());
 
-                    double messageWidth = renderer.textWidth(message);
-
-                    if (orientation.get() == Orientation.Vertical) {
-                        armorX = x + 8 * getScale() - messageWidth / 2.0;
-                        armorY = y + (18 * position * getScale()) + (18 * getScale() - renderer.textHeight());
+                    double textX, textY;
+                    if (vertical) {
+                        textX = armorX + iconSize + padding;
+                        textY = armorY + iconSize / 2.0 - textHeight / 2.0;
                     } else {
-                        armorX = x + 18 * position * getScale() + 8 * getScale() - messageWidth / 2.0;
-                        armorY = y + (getHeight() - renderer.textHeight());
+                        textX = armorX + iconSize / 2.0 - messageWidth / 2.0;
+                        textY = armorY + iconSize + padding;
                     }
 
-                    TextRenderer.get().render(message, armorX, armorY, durabilityColor.get(), durabilityShadow.get());
+                    renderer.text(message, textX, textY, durabilityColor.get(), durabilityShadow.get(), getTextScale());
                 }
             }
         });


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature

## Description

I use RusherHack with MeteorClient and wanted to migrate completely to MeteorClient. The only thing left was the ArmorHUD. When I tried running the 26.1.2 version the text was behind the icons when showing durability percents. This adjustment is meant to address this. I put the text below the icons instead of on top when horizontal, and to the right if vertical. Also added scaling of the text so that it matches the sizes of the icons as you scale.

## Related issues

[[Mention any issues that this pr relates to.](https://github.com/MeteorDevelopment/meteor-client/issues/6210)](https://github.com/MeteorDevelopment/meteor-client/issues/6210)

# How Has This Been Tested?

<img width="466" height="158" alt="Screenshot 2026-07-04 150157" src="https://github.com/user-attachments/assets/bf418544-0dfd-4692-9ad5-0b125f7705cb" />

This is how it looked in 1.21.4. The text was over the icons.

<img width="382" height="144" alt="Screenshot 2026-07-04 150206" src="https://github.com/user-attachments/assets/8684da03-65ec-4469-a96c-8ec72141a0d1" />

This is how it looks on my machine from current master (26.1.2) The text is behind the icons.

<img width="376" height="140" alt="Screenshot 2026-07-04 150225" src="https://github.com/user-attachments/assets/caacd090-9bf2-4069-b31b-36ec94057446" />

This is after my changes. I put the text below the icons.

<img width="382" height="159" alt="Screenshot 2026-07-04 150248" src="https://github.com/user-attachments/assets/c20d75d9-dcf6-4adb-a8ad-eb6456605b41" />

Also works at scale of 3 (the current max)

<img width="377" height="124" alt="Screenshot 2026-07-04 150256" src="https://github.com/user-attachments/assets/8cc0cfe7-5baa-4cca-9195-8206f32a1aa9" />

Also works at scale of 1 (not the current minimum the minimum looked too tiny on my screen)

<img width="375" height="216" alt="Screenshot 2026-07-04 150310" src="https://github.com/user-attachments/assets/12105ddc-1f45-42d0-841b-d569e094a67e" />

Vertical layout still works

<img width="372" height="209" alt="Screenshot 2026-07-04 150321" src="https://github.com/user-attachments/assets/918fe805-56c5-4090-9ea8-531685453a62" />

Vertical with bars instead of percents still works

<img width="374" height="139" alt="Screenshot 2026-07-04 150328" src="https://github.com/user-attachments/assets/4d6324db-0020-49b8-8e17-8f5ffedd1a35" />

Horizontal with bars still works.

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
