### PR TITLE
Fix BetterChat anti-spam Network Protocol Error

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/ChatComponentAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ChatComponentAccessor.java
@@ -9,6 +9,7 @@ import net.minecraft.client.gui.components.ChatComponent;
 import net.minecraft.client.multiplayer.chat.GuiMessage;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.gen.Invoker;
 
 import java.util.List;
 
@@ -19,4 +20,7 @@ public interface ChatComponentAccessor {
 
     @Accessor("allMessages")
     List<GuiMessage> meteor$getAllMessages();
+
+    @Invoker("refreshTrimmedMessages")
+    void meteor$refreshTrimmedMessages();
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterChat.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/BetterChat.java
@@ -363,21 +363,8 @@ public class BetterChat extends Module {
         }
 
         if (returnText != null) {
-            List<GuiMessage.Line> visible = ((ChatComponentAccessor) mc.gui.getChat()).meteor$getTrimmedMessages();
-
-            int start = -1;
-            for (int i = 0; i < messageIndex; i++) {
-                start += lines.getInt(i);
-            }
-
-            int i = lines.getInt(messageIndex);
-            while (i > 0) {
-                visible.remove(start + 1);
-                i--;
-            }
-
             messages.remove(messageIndex);
-            lines.removeInt(messageIndex);
+            ((ChatComponentAccessor) mc.gui.getChat()).meteor$refreshTrimmedMessages();
         }
 
         return returnText;


### PR DESCRIPTION
## Type of change

* [x] Bug fix
* [ ] New feature

## Description

Fixed a BetterChat anti-spam issue that could cause a Network Protocol Error and disconnect when duplicate chat messages were merged while the chat line state was out of sync.

```text
Description: Packet handling error

java.lang.IndexOutOfBoundsException: Index 11 out of bounds for length 10
    at java.base/java.util.ArrayList.remove(ArrayList.java:551)
    at meteordevelopment.meteorclient.systems.modules.misc.BetterChat.appendAntiSpam(BetterChat.java:374)
    at meteordevelopment.meteorclient.systems.modules.misc.BetterChat.onMessageReceive(BetterChat.java:286)

-- Incoming Packet --
Type: clientbound/minecraft:system_chat
Is Terminal: false
Is Skippable: true
```

BetterChat previously removed visible chat lines manually using cached line counts when anti-spam merged a duplicate message. If the cached line count no longer matched the actual trimmed chat list, it could try to remove an invalid index during system chat packet handling, causing Minecraft to show a Network Protocol Error and disconnect from the server.

After removing the duplicate message from chat history, BetterChat now refreshes the trimmed chat messages through Minecraft's normal refresh path instead of manually removing visible lines by index.

## Related issues

None

# How Has This Been Tested?

Tested by sending duplicate chat messages with BetterChat anti-spam enabled and confirming that duplicate messages are merged without causing a Network Protocol Error or disconnect.

# Checklist:

* [x] My code follows the style guidelines of this project.
* [ ] I have added comments to my code in more complex areas.
* [x] I have tested the code in both development and production environments.