### PR TITLE
Fix Player Model HUD corrupting entity head rotation

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/HudRenderer.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/HudRenderer.java
@@ -241,8 +241,8 @@ public class HudRenderer {
         entity.yBodyRot = previousBodyYaw;
         entity.setYRot(previousYaw);
         entity.setXRot(previousPitch);
-        entity.yHeadRot = lastLastHeadYaw;
-        entity.yHeadRotO = lastHeadYaw;
+        entity.yHeadRot = lastHeadYaw;
+        entity.yHeadRotO = lastLastHeadYaw;
 
         float s = 1.0f / mc.getWindow().getGuiScale();
         int x1 = (int) (x * s);


### PR DESCRIPTION
## Type of change
- [x] Bug fix

## Description
`HudRenderer.entity()` temporarily overwrites the rendered entity's rotation fields to pose the Player Model HUD element, then restores them. The restore of the head-yaw fields was swapped:
- `yHeadRot` (current) was restored from the saved *previous* value
- `yHeadRotO` (previous) was restored from the saved *current* value

So every frame the element is drawn, the entity's current and previous head yaw are exchanged, corrupting the head-rotation interpolation used by the world renderer. `yBodyRot` is restored correctly, so only head rotation is affected. This restores each field to its own saved value.

## Related issues
None linked, reproducible whenever the Player Model HUD element is enabled.

# How Has This Been Tested?
With the Player Model element enabled, head/body rotation visibly stutters when turning in a boat or on a horse and when looking at your own head in F5. Disabling only the Player Model element in HUD stops it. After this change the stuttering is gone and the element still renders correctly.

# Checklist:
- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.