### PR TITLE
feat: replace AddressCheck with allow-all implementation

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/AddressCheckMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/AddressCheckMixin.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.mixin;
+
+import net.minecraft.client.multiplayer.resolver.AddressCheck;
+import net.minecraft.client.multiplayer.resolver.ResolvedServerAddress;
+import net.minecraft.client.multiplayer.resolver.ServerAddress;
+import org.jspecify.annotations.NullMarked;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@NullMarked
+@Mixin(AddressCheck.class)
+public interface AddressCheckMixin {
+    @Inject(method = "createFromService", at = @At("HEAD"), cancellable = true)
+    private static void onCreateFromService(CallbackInfoReturnable<AddressCheck> cir) {
+        cir.setReturnValue(new AddressCheck() {
+            @Override
+            public boolean isAllowed(ResolvedServerAddress address) {
+                return true;
+            }
+
+            @Override
+            public boolean isAllowed(ServerAddress address) {
+                return true;
+            }
+        });
+    }
+}

--- a/src/main/resources/meteor-client.mixins.json
+++ b/src/main/resources/meteor-client.mixins.json
@@ -16,6 +16,7 @@
     "AbstractMountInventoryMenuAccessor",
     "AbstractSignEditScreenAccessor",
     "AbstractSignRendererMixin",
+    "AddressCheckMixin",
     "ArmorStandRendererMixin",
     "AttackRangeMixin",
     "AvatarRendererMixin",


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

This PR disables the blocklist provided by `MojangBlockListSupplier` via https://sessionserver.mojang.com/blockedservers.
This effectively lets users connect to any blocked server.

## Related issues

None.

# How Has This Been Tested?

Tested via successful connection to `play.6b6t.org`.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
