### PR TITLE
[1.21.11] feat: replace BlockListChecker with allow-all implementation

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/BlockListCheckerMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/BlockListCheckerMixin.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of the Meteor Client distribution (https://github.com/MeteorDevelopment/meteor-client).
+ * Copyright (c) Meteor Development.
+ */
+
+package meteordevelopment.meteorclient.mixin;
+
+import net.minecraft.client.network.Address;
+import net.minecraft.client.network.BlockListChecker;
+import net.minecraft.client.network.ServerAddress;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(BlockListChecker.class)
+public interface BlockListCheckerMixin {
+    @Inject(method = "create", at = @At("HEAD"), cancellable = true)
+    private static void onCreate(CallbackInfoReturnable<BlockListChecker> cir) {
+        cir.setReturnValue(new BlockListChecker() {
+            @Override
+            public boolean isAllowed(Address address) {
+                return true;
+            }
+
+            @Override
+            public boolean isAllowed(ServerAddress address) {
+                return true;
+            }
+        });
+    }
+}

--- a/src/main/resources/meteor-client.mixins.json
+++ b/src/main/resources/meteor-client.mixins.json
@@ -27,6 +27,7 @@
     "BlockEntityRenderManagerMixin",
     "BlockHitResultAccessor",
     "BlockItemMixin",
+    "BlockListCheckerMixin",
     "BlockMixin",
     "BlockModelRendererMixin",
     "BlockRenderLayersMixin",


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Backport of #6517 by @Big-Iron-Cheems for `1.21.11`.

This PR disables the blocklist provided by `MojangBlockListSupplier` via https://sessionserver.mojang.com/blockedservers.
In `1.21.11`, the `AddressCheck` class used on master is mapped as `BlockListChecker`; the behavior remains the same.
This effectively lets users connect to any blocked server.

## Related issues

#6517

# How Has This Been Tested?

- `gradlew.bat clean build` with JDK 21.0.11.
- `runClient` initialized without Mixin target, injection, or application errors.
- Tested in production with Minecraft `1.21.11` and Fabric Loader `0.18.4`.
- Tested via successful connection to `play.6b6t.org` and a normal server.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
