### PR TITLE
Fix NoFall cancelBounce NPE on integrated server thread

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/EntityMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/EntityMixin.java
@@ -13,6 +13,7 @@ import meteordevelopment.meteorclient.events.entity.player.JumpVelocityMultiplie
 import meteordevelopment.meteorclient.events.entity.player.PlayerMoveEvent;
 import meteordevelopment.meteorclient.mixininterface.ICamera;
 import meteordevelopment.meteorclient.systems.modules.Modules;
+import meteordevelopment.meteorclient.systems.modules.movement.NoFall;
 import meteordevelopment.meteorclient.systems.modules.combat.Hitboxes;
 import meteordevelopment.meteorclient.systems.modules.movement.*;
 import meteordevelopment.meteorclient.systems.modules.movement.elytrafly.ElytraFly;
@@ -161,7 +162,10 @@ public abstract class EntityMixin {
 
     @ModifyReturnValue(method = "isSuppressingBounce", at = @At("RETURN"))
     private boolean cancelBounce(boolean original) {
-        return Modules.get().get(NoFall.class).cancelBounce() || original;
+        if (!Utils.canUpdate()) return original;
+        NoFall noFall = Modules.get().get(NoFall.class);
+        if (noFall == null) return original;
+        return noFall.cancelBounce() || original;
     }
 
     @Inject(method = "turn", at = @At("HEAD"), cancellable = true)


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

The `cancelBounce` mixin on `EntityMixin.isSuppressingBounce` called `Modules.get().get(NoFall.class).cancelBounce()` with no null guard. This mixin runs on every entity's bounce calculation, including on the integrated server thread. When a non-player entity (e.g. a villager) stands on a slime block and the server ticks it, `Modules.get(NoFall.class)` returns `null`, throwing an NPE that crashes the entire game.

Fix: guard with `Utils.canUpdate()` (already used elsewhere in this mixin class) and an explicit null check, returning the original value when NoFall isn't active. No behavior change during normal client play.

Changed file: `src/main/java/meteordevelopment/meteorclient/mixin/EntityMixin.java`

## Related issues

None.

# How Has This Been Tested?

Reproduced the crash on a single-player world with a villager standing on a slime block (crash report: `NullPointerException ... Modules.get(NoFall.class)` in `modifyReturnValue$bpi000$meteor-client$cancelBounce`). Built Meteor from this branch, loaded it in-game, and confirmed the same world now loads and runs without crashing.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
