### PR TITLE
Fix NullPointerException in FreeLook onDeactivate

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/FreeLook.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/FreeLook.java
@@ -82,7 +82,7 @@ public class FreeLook extends Module {
 
     @Override
     public void onDeactivate() {
-        if (mc.options.getCameraType() != prePers && togglePerspective.get()) mc.options.setCameraType(prePers);
+        if (prePers != null && mc.options.getCameraType() != prePers && togglePerspective.get()) mc.options.setCameraType(prePers);
     }
 
     public boolean playerMode() {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Fixes a crash when disconnecting or deactivating the FreeLook module while `prePers` was null.
The NPE occurred because the module wasn't fully checking if the saved perspective `prePers` existed before trying to instruct Minecraft to use it.

## Related issues

N/A

# How Has This Been Tested?

Tested locally by activating and deactivating the module, and logging into servers where it was being auto-deactivated.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.