### PR TITLE
Update AntiAFK.java

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AntiAFK.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AntiAFK.java
@@ -16,6 +16,7 @@ import meteordevelopment.orbit.EventHandler;
 
 import java.util.List;
 import java.util.Random;
+private int jumpCooldown = 0;
 
 public class AntiAFK extends Module {
     private final SettingGroup sgActions = settings.createGroup("Actions");
@@ -176,12 +177,23 @@ public class AntiAFK extends Module {
     @EventHandler
     private void onTick(TickEvent.Pre event) {
         if (!Utils.canUpdate()) return;
-
+        
         // Jump
         if (jump.get()) {
-            if (mc.options.keyJump.isDown()) mc.options.keyJump.setDown(false);
-            else if (random.nextInt(99) == 0) mc.options.keyJump.setDown(true);
+            if (jumpCooldown > 0) {
+                jumpCooldown--;
+            }  
+            else {
+                if (mc.options.keyJump.isDown()) {
+                    mc.options.keyJump.setDown(false);
+                }
+                else if (random.nextInt(99) == 0) { 
+                    mc.options.keyJump.setDown(true);
+                    jumpCooldown = 20; 
+                }
+            }
         }
+        
 
         // Swing
         if (swing.get() && random.nextInt(99) == 0) {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

This PR fixes an issue where the Anti-AFK module's random jump feature could accidentally activate Elytra flight when two consecutive jumps occurred within a short time frame.

### The Problem:
When wearing an Elytra, two jumps happening in quick succession (within < 0.75 seconds) would trigger the Elytra to activate mid-air. This caused the player to start flying and slowly drift from their original position. Over extended AFK periods, this could lead to:
- Moving away from the intended AFK spot
- Falling off high ledges or platforms
- Walking into dangerous areas (lava, void, mobs)

### The Solution:
Added a cooldown system between random jumps:
- Minimum interval between jumps: **20 ticks (1 second)**
- This is longer than the full jump duration in Minecraft (~15 ticks / 0.75 seconds)
- Prevents any possibility of two jumps occurring while the player is still in the air

### Technical Implementation:
```java
private int jumpCooldown = 0;

// In onTick():
if (jump.get()) {
    if (jumpCooldown > 0) {
        jumpCooldown--;
    } else {
        if (mc.options.keyJump.isDown()) {
            mc.options.keyJump.setDown(false);
        } else if (random.nextInt(99) == 0) {
            mc.options.keyJump.setDown(true);
            jumpCooldown = 20; // 1 second cooldown
        }
    }
}