### PR TITLE
Waypoint death coords message suggest teleport command if OP

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/utils/player/ChatUtils.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/player/ChatUtils.java
@@ -14,6 +14,7 @@ import meteordevelopment.meteorclient.utils.PostInit;
 import meteordevelopment.meteorclient.utils.misc.text.MeteorClickEvent;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.*;
+import net.minecraft.server.permissions.Permissions;
 import net.minecraft.util.Tuple;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.Nullable;
@@ -265,7 +266,17 @@ public class ChatUtils {
         String coordsString = String.format("(highlight)(underline)%.0f, %.0f, %.0f(default)", pos.x, pos.y, pos.z);
         MutableComponent coordsText = formatMsg(coordsString, ChatFormatting.GRAY);
 
-        if (BaritoneUtils.IS_AVAILABLE) {
+        if (mc.player.permissions().hasPermission(Permissions.COMMANDS_GAMEMASTER)) {
+            Style style = coordsText.getStyle().applyFormats(ChatFormatting.BOLD)
+                .withHoverEvent(new HoverEvent.ShowText(
+                    Component.literal("Teleport to coordinates")
+                ))
+                .withClickEvent(new ClickEvent.SuggestCommand(
+                    String.format("/tp @s %d %d %d", (int) pos.x, (int) pos.y, (int) pos.z)
+                ));
+
+            coordsText.setStyle(style);
+        } else if (BaritoneUtils.IS_AVAILABLE) {
             Style style = coordsText.getStyle().applyFormats(ChatFormatting.BOLD)
                 .withHoverEvent(new HoverEvent.ShowText(
                     Component.literal("Set as Baritone goal")


### PR DESCRIPTION
## Type of change
- [x] New feature

## Description
If the player has OP, the Waypoint died at message will suggest a teleport command rather than a baritone goto.

<img width="1920" height="1136" alt="2026-07-31_18 23 15" src="https://github.com/user-attachments/assets/57894e08-0a5a-4e96-a1b2-96f6f9859470" />