### PR TITLE
Added option to gui theme to hide modules screen help text

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/GuiTheme.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/GuiTheme.java
@@ -311,6 +311,8 @@ public abstract class GuiTheme implements ISerializable<GuiTheme> {
 
     public abstract boolean categoryIcons();
 
+    public abstract boolean modulesHelpText();
+
     public abstract boolean hideHUD();
 
     public double textWidth(String text, int length, boolean title) {

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/ModulesScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/ModulesScreen.java
@@ -98,8 +98,7 @@ public class ModulesScreen extends TabScreen {
 
                 int count = 0;
                 for (Pair<Module, String> p : modules) {
-                    if (count >= Config.get().moduleSearchCount.get() || count >= modules.size())
-                        break;
+                    if (count >= Config.get().moduleSearchCount.get() || count >= modules.size()) break;
                     section.add(theme.module(p.getFirst(), p.getSecond())).expandX();
                     count++;
                 }
@@ -114,8 +113,7 @@ public class ModulesScreen extends TabScreen {
 
                 int count = 0;
                 for (Module module : settings) {
-                    if (count >= Config.get().moduleSearchCount.get() || count >= settings.size())
-                        break;
+                    if (count >= Config.get().moduleSearchCount.get() || count >= settings.size()) break;
                     section.add(theme.module(module)).expandX();
                     count++;
                 }
@@ -129,8 +127,7 @@ public class ModulesScreen extends TabScreen {
         searchWindow = w;
 
         if (theme.categoryIcons()) {
-            w.beforeHeaderInit = wContainer -> wContainer.add(theme.item(DisplayItemUtils.toStack(Items.COMPASS)))
-                    .pad(2);
+            w.beforeHeaderInit = wContainer -> wContainer.add(theme.item(DisplayItemUtils.toStack(Items.COMPASS))).pad(2);
         }
 
         c.add(w);
@@ -156,15 +153,12 @@ public class ModulesScreen extends TabScreen {
 
     @Override
     public boolean keyPressed(@NonNull KeyEvent value) {
-        if (locked)
-            return false;
+        if (locked) return false;
 
-        boolean cntrl = MacosUtil.IS_MACOS ? value.modifiers() == GLFW_MOD_SUPER
-                : value.modifiers() == GLFW_MOD_CONTROL;
+        boolean cntrl = MacosUtil.IS_MACOS ? value.modifiers() == GLFW_MOD_SUPER : value.modifiers() == GLFW_MOD_CONTROL;
 
         if (cntrl && value.key() == GLFW_KEY_F) {
-            if (searchWindow != null)
-                searchWindow.setExpanded(true);
+            if (searchWindow != null) searchWindow.setExpanded(true);
             if (searchTextBox != null) {
                 searchTextBox.setFocused(true);
                 searchTextBox.setCursorMax();
@@ -180,8 +174,7 @@ public class ModulesScreen extends TabScreen {
 
     protected Cell<WWindow> createFavorites(WContainer c) {
         boolean hasFavorites = Modules.get().getAll().stream().anyMatch(module -> module.favorite);
-        if (!hasFavorites)
-            return null;
+        if (!hasFavorites) return null;
 
         WWindow w = theme.window("Favorites");
         w.id = "favorites";
@@ -189,8 +182,7 @@ public class ModulesScreen extends TabScreen {
         w.spacing = 0;
 
         if (theme.categoryIcons()) {
-            w.beforeHeaderInit = wContainer -> wContainer.add(theme.item(DisplayItemUtils.toStack(Items.NETHER_STAR)))
-                    .pad(2);
+            w.beforeHeaderInit = wContainer -> wContainer.add(theme.item(DisplayItemUtils.toStack(Items.NETHER_STAR))).pad(2);
         }
 
         Cell<WWindow> cell = c.add(w);
@@ -265,8 +257,7 @@ public class ModulesScreen extends TabScreen {
         protected void refresh() {
             if (favorites == null) {
                 favorites = createFavorites(this);
-                if (favorites != null)
-                    windows.add(favorites.widget());
+                if (favorites != null) windows.add(favorites.widget());
             } else {
                 favorites.widget().clear();
 
@@ -297,13 +288,11 @@ public class ModulesScreen extends TabScreen {
 
                 if (x > windowWidth) {
                     x = windowWidth / 2.0 - cell.width / 2.0;
-                    if (x < 0)
-                        x = 0;
+                    if (x < 0) x = 0;
                 }
                 if (y > windowHeight) {
                     y = windowHeight / 2.0 - cell.height / 2.0;
-                    if (y < 0)
-                        y = 0;
+                    if (y < 0) y = 0;
                 }
 
                 cell.x = x;

--- a/src/main/java/meteordevelopment/meteorclient/gui/screens/ModulesScreen.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/screens/ModulesScreen.java
@@ -48,9 +48,11 @@ public class ModulesScreen extends TabScreen {
         controller = add(new WCategoryController()).widget();
 
         // Help
-        WVerticalList help = add(theme.verticalList()).pad(4).bottom().widget();
-        help.add(theme.label("Left click - Toggle module"));
-        help.add(theme.label("Right click - Open module settings"));
+        if (theme.modulesHelpText()) {
+            WVerticalList help = add(theme.verticalList()).pad(4).bottom().widget();
+            help.add(theme.label("Left click - Toggle module"));
+            help.add(theme.label("Right click - Open module settings"));
+        }
     }
 
     @Override
@@ -96,7 +98,8 @@ public class ModulesScreen extends TabScreen {
 
                 int count = 0;
                 for (Pair<Module, String> p : modules) {
-                    if (count >= Config.get().moduleSearchCount.get() || count >= modules.size()) break;
+                    if (count >= Config.get().moduleSearchCount.get() || count >= modules.size())
+                        break;
                     section.add(theme.module(p.getFirst(), p.getSecond())).expandX();
                     count++;
                 }
@@ -111,7 +114,8 @@ public class ModulesScreen extends TabScreen {
 
                 int count = 0;
                 for (Module module : settings) {
-                    if (count >= Config.get().moduleSearchCount.get() || count >= settings.size()) break;
+                    if (count >= Config.get().moduleSearchCount.get() || count >= settings.size())
+                        break;
                     section.add(theme.module(module)).expandX();
                     count++;
                 }
@@ -125,7 +129,8 @@ public class ModulesScreen extends TabScreen {
         searchWindow = w;
 
         if (theme.categoryIcons()) {
-            w.beforeHeaderInit = wContainer -> wContainer.add(theme.item(DisplayItemUtils.toStack(Items.COMPASS))).pad(2);
+            w.beforeHeaderInit = wContainer -> wContainer.add(theme.item(DisplayItemUtils.toStack(Items.COMPASS)))
+                    .pad(2);
         }
 
         c.add(w);
@@ -151,12 +156,15 @@ public class ModulesScreen extends TabScreen {
 
     @Override
     public boolean keyPressed(@NonNull KeyEvent value) {
-        if (locked) return false;
+        if (locked)
+            return false;
 
-        boolean cntrl = MacosUtil.IS_MACOS ? value.modifiers() == GLFW_MOD_SUPER : value.modifiers() == GLFW_MOD_CONTROL;
+        boolean cntrl = MacosUtil.IS_MACOS ? value.modifiers() == GLFW_MOD_SUPER
+                : value.modifiers() == GLFW_MOD_CONTROL;
 
         if (cntrl && value.key() == GLFW_KEY_F) {
-            if (searchWindow != null) searchWindow.setExpanded(true);
+            if (searchWindow != null)
+                searchWindow.setExpanded(true);
             if (searchTextBox != null) {
                 searchTextBox.setFocused(true);
                 searchTextBox.setCursorMax();
@@ -172,7 +180,8 @@ public class ModulesScreen extends TabScreen {
 
     protected Cell<WWindow> createFavorites(WContainer c) {
         boolean hasFavorites = Modules.get().getAll().stream().anyMatch(module -> module.favorite);
-        if (!hasFavorites) return null;
+        if (!hasFavorites)
+            return null;
 
         WWindow w = theme.window("Favorites");
         w.id = "favorites";
@@ -180,7 +189,8 @@ public class ModulesScreen extends TabScreen {
         w.spacing = 0;
 
         if (theme.categoryIcons()) {
-            w.beforeHeaderInit = wContainer -> wContainer.add(theme.item(DisplayItemUtils.toStack(Items.NETHER_STAR))).pad(2);
+            w.beforeHeaderInit = wContainer -> wContainer.add(theme.item(DisplayItemUtils.toStack(Items.NETHER_STAR)))
+                    .pad(2);
         }
 
         Cell<WWindow> cell = c.add(w);
@@ -255,7 +265,8 @@ public class ModulesScreen extends TabScreen {
         protected void refresh() {
             if (favorites == null) {
                 favorites = createFavorites(this);
-                if (favorites != null) windows.add(favorites.widget());
+                if (favorites != null)
+                    windows.add(favorites.widget());
             } else {
                 favorites.widget().clear();
 
@@ -286,11 +297,13 @@ public class ModulesScreen extends TabScreen {
 
                 if (x > windowWidth) {
                     x = windowWidth / 2.0 - cell.width / 2.0;
-                    if (x < 0) x = 0;
+                    if (x < 0)
+                        x = 0;
                 }
                 if (y > windowHeight) {
                     y = windowHeight / 2.0 - cell.height / 2.0;
-                    if (y < 0) y = 0;
+                    if (y < 0)
+                        y = 0;
                 }
 
                 cell.x = x;

--- a/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/MeteorGuiTheme.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/MeteorGuiTheme.java
@@ -74,6 +74,13 @@ public class MeteorGuiTheme extends GuiTheme {
         .build()
     );
 
+    public final Setting<Boolean> modulesHelpText = sgGeneral.add(new BoolSetting.Builder()
+        .name("modules-help-text")
+        .description("Toggle help text in the modules screen.")
+        .defaultValue(true)
+        .build()
+    );
+
     public final Setting<Boolean> hideHUD = sgGeneral.add(new BoolSetting.Builder()
         .name("hide-HUD")
         .description("Hide HUD when in GUI.")
@@ -383,6 +390,11 @@ public class MeteorGuiTheme extends GuiTheme {
     @Override
     public boolean categoryIcons() {
         return categoryIcons.get();
+    }
+
+    @Override
+    public boolean modulesHelpText() {
+        return modulesHelpText.get();
     }
 
     @Override


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature

## Description

Added an option to gui theme to hide modules screen help text

## Related issues

Resolves #6574 

# How Has This Been Tested?

<img width="888" height="175" alt="image" src="https://github.com/user-attachments/assets/e8d0912c-3ae0-49eb-9019-f29d8ecb94e5" />

<img width="854" height="644" alt="Screenshot 2026-08-15 at 12 35 21 AM" src="https://github.com/user-attachments/assets/79780562-5460-45ad-9759-6f377ab6a51a" />

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
