### PR TITLE
fix(waypoints): fix text position when custom font disabled

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/WaypointsModule.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/WaypointsModule.java
@@ -137,7 +137,7 @@ public class WaypointsModule extends Module {
             }
 
             // Render
-            NametagUtils.begin(pos);
+            NametagUtils.begin(pos, event.graphics);
 
             // Render icon
             waypoint.renderIcon(-16, -16, a, 32);
@@ -161,7 +161,7 @@ public class WaypointsModule extends Module {
                 TEXT.a = preTextA;
             }
 
-            NametagUtils.end();
+            NametagUtils.end(event.graphics);
         }
 
         Waypoints.get().removeAll(toRemove);


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Waypoint text rendered top-left instead of next to the waypoint when
Custom Font was disabled. Fixed by using `NametagUtils.begin(pos, graphics)`
instead of the 3D-only overload.

## Related issues

closes #6570 

# How Has This Been Tested?

Tested in-game with Custom Font disabled — waypoint text now renders
correctly next to the icon.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
