### PR TITLE
fix(tooltips): fix background rendering with vanilla font

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/gui/renderer/GuiRenderer.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/renderer/GuiRenderer.java
@@ -238,6 +238,10 @@ public class GuiRenderer {
         quad(widget.x, widget.y, widget.width, widget.height, color);
     }
 
+    public void fill(WWidget widget, Color color) {
+        graphics.fill((int) widget.x, (int) widget.y, (int) (widget.x + widget.width), (int) (widget.y + widget.height), color.getPacked());
+    }
+
     public void quad(double x, double y, double width, double height, GuiTexture texture, Color color) {
         rTex.texQuad(x, y, width, height, texture.get(width, height), color);
     }

--- a/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/WMeteorTooltip.java
+++ b/src/main/java/meteordevelopment/meteorclient/gui/themes/meteor/widgets/WMeteorTooltip.java
@@ -8,6 +8,8 @@ package meteordevelopment.meteorclient.gui.themes.meteor.widgets;
 import meteordevelopment.meteorclient.gui.renderer.GuiRenderer;
 import meteordevelopment.meteorclient.gui.themes.meteor.MeteorWidget;
 import meteordevelopment.meteorclient.gui.widgets.WTooltip;
+import meteordevelopment.meteorclient.renderer.text.TextRenderer;
+import meteordevelopment.meteorclient.renderer.text.VanillaTextRenderer;
 
 public class WMeteorTooltip extends WTooltip implements MeteorWidget {
     public WMeteorTooltip(String text) {
@@ -16,6 +18,10 @@ public class WMeteorTooltip extends WTooltip implements MeteorWidget {
 
     @Override
     protected void onRender(GuiRenderer renderer, double mouseX, double mouseY, double delta) {
-        renderer.quad(this, theme().backgroundColor.get());
+        if (TextRenderer.get() == VanillaTextRenderer.INSTANCE) {
+            renderer.fill(this, theme().backgroundColor.get());
+        } else {
+            renderer.quad(this, theme().backgroundColor.get());
+        }
     }
 }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Tooltip background rendered before vanilla text (which draws with a
delay), letting text bleed through. Fixed by drawing the background
the same way when Custom Font is disabled.

## Related issues
closes #6570 

# How Has This Been Tested?

Tested in-game with Custom Font disabled and enabled.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
