### PR TITLE
feat(AutoEat): add pause-autofish setting

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoEat.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AutoEat.java
@@ -73,6 +73,13 @@ public class AutoEat extends Module {
         .build()
     );
 
+    private final Setting<Boolean> pauseAutoFish = sgGeneral.add(new BoolSetting.Builder()
+        .name("pause-autofish")
+        .description("Pause AutoFish when eating.")
+        .defaultValue(true)
+        .build()
+    );
+
     private final Setting<Boolean> searchInventory = sgGeneral.add(new BoolSetting.Builder()
         .name("search-inventory")
         .description("Search the full inventory for food, not only the hotbar.")
@@ -121,6 +128,7 @@ public class AutoEat extends Module {
 
     private final List<Class<? extends Module>> wasAura = new ReferenceArrayList<>();
     private boolean wasBaritone = false;
+    private boolean wasAutoFish = false;
 
     public AutoEat() {
         super(Categories.Player, "auto-eat", "Automatically eats food.");
@@ -200,6 +208,15 @@ public class AutoEat extends Module {
             wasBaritone = true;
             PathManagers.get().pause();
         }
+
+        // Pause autofish
+        if (pauseAutoFish.get()) {
+            Module autoFish = Modules.get().get(AutoFish.class);
+            if (autoFish != null && autoFish.isActive()) {
+                wasAutoFish = true;
+                autoFish.toggle();
+            }
+        }
     }
 
     private void eat() {
@@ -229,6 +246,15 @@ public class AutoEat extends Module {
         if (pauseBaritone.get() && wasBaritone) {
             wasBaritone = false;
             PathManagers.get().resume();
+        }
+
+        // Resume autofish
+        if (pauseAutoFish.get() && wasAutoFish) {
+            wasAutoFish = false;
+            Module autoFish = Modules.get().get(AutoFish.class);
+            if (autoFish != null) {
+                autoFish.enable();
+            }
         }
     }
 


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Adds a `pause-autofish` setting to `AutoEat` (enabled by default), mirroring the behavior of `pause-auras` and `pause-baritone`.

When both `AutoEat` and `AutoFish` are active, `AutoFish` continually swaps back to the fishing rod whenever `AutoEat` selects food, while `AutoEat` holds down the `keyUse` input. This creates an endless hotbar tug-of-war and rapid casting loop that prevents the player from eating.

With this option enabled:
- `AutoEat.startEating()` automatically pauses `AutoFish` if it is active.
- `AutoEat.stopEating()` and `onDeactivate()` restore `AutoFish` once eating is complete or if `AutoEat` is toggled off.

## Related issues



# How Has This Been Tested?

Compiled with Fabric Loom / Gradle and tested in-game to verify that AutoFish pauses cleanly when hunger/health triggers AutoEat, food is consumed without hotbar conflict, and AutoFish resumes immediately after eating.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.