### PR TITLE
feat(AntiAFK): add hotbar switcher and randomizer

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AntiAFK.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/AntiAFK.java
@@ -11,6 +11,7 @@ import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.utils.Utils;
 import meteordevelopment.meteorclient.utils.player.ChatUtils;
+import meteordevelopment.meteorclient.utils.player.InvUtils;
 import meteordevelopment.meteorclient.utils.player.Rotations;
 import meteordevelopment.orbit.EventHandler;
 
@@ -103,6 +104,31 @@ public class AntiAFK extends Module {
         .build()
     );
 
+    private final Setting<Boolean> switchHotbar = sgActions.add(new BoolSetting.Builder()
+        .name("switch-hotbar")
+        .description("Randomly switches active hotbar slots to avoid AFK detection.")
+        .defaultValue(false)
+        .build()
+    );
+
+    private final Setting<Integer> switchDelay = sgActions.add(new IntSetting.Builder()
+        .name("switch-delay")
+        .description("The delay between hotbar switches in seconds.")
+        .defaultValue(5)
+        .min(1)
+        .sliderMax(30)
+        .visible(switchHotbar::get)
+        .build()
+    );
+
+    private final Setting<Boolean> randomHotbarSlot = sgActions.add(new BoolSetting.Builder()
+        .name("random-slot")
+        .description("Switches to a completely random slot instead of sequential.")
+        .defaultValue(true)
+        .visible(switchHotbar::get)
+        .build()
+    );
+
 
     // Messages
 
@@ -151,6 +177,7 @@ public class AntiAFK extends Module {
     private int messageI = 0;
     private int sneakTimer = 0;
     private int strafeTimer = 0;
+    private int hotbarTimer = 0;
     private boolean direction = false;
     private float lastYaw;
 
@@ -163,6 +190,7 @@ public class AntiAFK extends Module {
 
         lastYaw = mc.player.getYRot();
         messageTimer = delay.get() * 20;
+        hotbarTimer = switchDelay.get() * 20;
     }
 
     @Override
@@ -211,6 +239,23 @@ public class AntiAFK extends Module {
                 case Client -> mc.player.setYRot(lastYaw);
                 case Server -> Rotations.rotate(lastYaw, pitch.get(), -15);
             }
+        }
+
+        // Switch Hotbar
+        if (switchHotbar.get() && hotbarTimer-- <= 0) {
+            int currentSlot = mc.player.getInventory().getSelectedSlot();
+            int nextSlot;
+
+            if (randomHotbarSlot.get()) {
+                do {
+                    nextSlot = random.nextInt(9);
+                } while (nextSlot == currentSlot);
+            } else {
+                nextSlot = (currentSlot + 1) % 9;
+            }
+
+            InvUtils.swap(nextSlot, false);
+            hotbarTimer = switchDelay.get() * 20;
         }
 
         // Messages


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Adds `switch-hotbar`, `switch-delay`, and `random-slot` settings to `AntiAFK` under the Actions group.

This feature periodically switches the active hotbar slot (either randomly or sequentially) at a configurable interval to bypass server-side AFK detection checks that look for static held items.

## Related issues



# How Has This Been Tested?

Compiled with Fabric Loom / Gradle 9.6.1 and tested in-game to verify slot switching behavior with both random and sequential modes enabled.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.