### PR TITLE
Fixed binds without modifiers not matching while a modifier is held

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/Modules.java
@@ -279,7 +279,20 @@ public class Modules extends System<Modules> {
     private void onAction(boolean isKey, int value, int modifiers, boolean isPress) {
         if (mc.gui.screen() != null || Input.isKeyPressed(InputConstants.KEY_F3)) return;
 
+        // A bind with modifiers takes precedence over one without, so pressing Ctrl + G does not
+        // also toggle a module bound to plain G.
+        boolean modifierBindMatched = false;
+
         for (Module module : moduleInstances.values()) {
+            if (module.keybind.hasMods() && module.keybind.matches(isKey, value, modifiers)) {
+                modifierBindMatched = true;
+                break;
+            }
+        }
+
+        for (Module module : moduleInstances.values()) {
+            if (modifierBindMatched && !module.keybind.hasMods()) continue;
+
             if (module.keybind.matches(isKey, value, modifiers) && (isPress || (module.toggleOnBindRelease && module.isActive()))) {
                 module.toggle();
                 module.sendToggledMsg();

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/Keybind.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/Keybind.java
@@ -149,8 +149,10 @@ public class Keybind implements ISerializable<Keybind>, ICopyable<Keybind> {
 
     public boolean matches(InputConstants.Key key, Set<Modifier> modifiers) {
         if (!isSet() || !this.key.equals(key)) return false;
-        if (!hasMods()) return modifiers.stream().noneMatch(m -> m == Modifier.SHIFT || m == Modifier.CONTROL || m == Modifier.ALT || m == Modifier.SUPER);
-        return this.modifiers.equals(modifiers);
+        // Modifiers held for other reasons (sneaking, sprinting, or the bound key being a modifier
+        // itself, which sets its own bit on press) must not stop a bind without modifiers from
+        // matching. Binds that do have modifiers take precedence, see Modules#onAction.
+        return !hasMods() || this.modifiers.equals(modifiers);
     }
 
     public boolean matches(boolean isKey, int value, int modifiers) {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Since 56a7703 ("Fixed modifier keybinds triggering non modifier varients", #6586), a keybind
that has no modifiers only matches when *no* modifier at all is held:

```java
if (!hasMods()) return modifiers.stream().noneMatch(m -> m == Modifier.SHIFT || m == Modifier.CONTROL || m == Modifier.ALT || m == Modifier.SUPER);
```

That breaks two ordinary cases:

**1. Binds on a bare modifier key never trigger.** `KeyboardHandlerMixin` deliberately sets a
modifier key's own bit on its press event (the workaround for glfw/glfw#1630), so pressing
Left Alt arrives as `key=342, modifiers=MOD_ALT`. A module bound to plain Left Alt therefore
never matches on press. Mine (Free Look on Left Alt) went dead after updating, and only
toggling from the module list still worked. Release does match, but that path only fires for
`toggleOnBindRelease`.

**2. Any bind dies while a modifier is held for an unrelated reason.** Sneaking holds Shift,
sprinting holds Ctrl. Press a plain bind during either and it no longer matches.

The underlying issue is that #6586 treats a held modifier as disqualifying, when what it
actually wanted is for `Ctrl + G` not to *also* trigger a module bound to plain `G`. That is a
question of precedence between binds, not of what the bind itself matches, so this moves it to
where the binds are dispatched:

- `Keybind#matches` goes back to ignoring modifiers for a bind that has none.
- `Modules#onAction` first checks whether any module's bind *with* modifiers matches the event;
  if one does, binds without modifiers are skipped for that event.

`Ctrl + G` still fires only the chorded bind, `G` alone still fires the plain one, and plain
binds work again while sneaking, sprinting, or when the bound key is itself a modifier.

## Related issues

Regression from #6586 (56a7703).

# How Has This Been Tested?

Built and run on 26.2 (production, Fabric) with Free Look bound to plain Left Alt:

- Tapping Alt toggles the module again. Verified at the dispatch level too, by logging
  `Modules#onAction`: the press arrives as `value=342 mods=4` and now matches, where before it
  did not.
- Ctrl held (sprinting) or Shift held (sneaking) + Alt still toggles it.
- With one module bound to `G` and another to `Ctrl + G`: `Ctrl + G` toggles only the chorded
  module, `G` alone toggles only the plain one.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
