### PR TITLE
lower jar size by excluding redundant transitive libraries

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,7 +94,10 @@ dependencies {
     jij(libs.netty.handler.proxy) { isTransitive = false }
     jij(libs.netty.codec.socks) { isTransitive = false }
     jij(libs.waybackauthlib)
-    jij(libs.minecraft.auth)
+    jij(libs.minecraft.auth) {
+        exclude("com.google.code.gson")
+        exclude("com.google.errorprone")
+    }
 }
 
 java {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Crobination

## Description

remove redundant gson lib & unneeded annotation lib from being transitively jij'd into the jar
file size: 5222 KiB -> 4934 KiB (6% smaller)

## Related issues

the big issue of big filesize

# How Has This Been Tested?

the J (yes i ran it in launcher)

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have added comments to my code in more complex areas.
- [X] I have tested the code in both development and production environments.
