### PR TITLE
Fix StashFinder count equality check

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/StashFinder.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/StashFinder.java
@@ -509,7 +509,7 @@ public class StashFinder extends Module {
 
         public boolean countsEqual(Chunk c) {
             if (c == null) return false;
-            return chests != c.chests || barrels != c.barrels || shulkers != c.shulkers || enderChests != c.enderChests || furnaces != c.furnaces || dispensersDroppers != c.dispensersDroppers || hoppers != c.hoppers;
+            return chests == c.chests && barrels == c.barrels && shulkers == c.shulkers && enderChests == c.enderChests && furnaces == c.furnaces && dispensersDroppers == c.dispensersDroppers && hoppers == c.hoppers;
         }
 
         @Override


### PR DESCRIPTION
## Type of change

- [x] Bug fix

## Description

Correct storage count equality so unchanged stashes do not trigger duplicate notifications and changed stashes do.

## Testing

- `git diff --check`