### PR TITLE
feat(build): add optional Error Prone and NullAway checking

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,14 @@
+import net.ltgt.gradle.errorprone.errorprone
+
 plugins {
     alias(libs.plugins.fabric.loom)
     id("maven-publish")
+    alias(libs.plugins.errorprone)
 }
 
 val archivesBaseName = providers.gradleProperty("archives_base_name").get()
 val mavenGroup = providers.gradleProperty("maven_group").get()
+val runErrorProne = providers.gradleProperty("errorprone").isPresent
 
 base {
     archivesName = archivesBaseName
@@ -98,6 +102,10 @@ dependencies {
         exclude("com.google.code.gson")
         exclude("com.google.errorprone")
     }
+
+    // Error Prone
+    errorprone(libs.errorprone.core)
+    errorprone(libs.nullaway)
 }
 
 java {
@@ -211,6 +219,18 @@ tasks {
                 "-Xlint:unchecked"
             )
         )
+
+        options.errorprone.enabled.set(runErrorProne)
+
+        if (runErrorProne) {
+            options.errorprone {
+                check("NullAway", net.ltgt.gradle.errorprone.CheckSeverity.ERROR)
+                option("NullAway:AnnotatedPackages", "meteordevelopment.meteorclient")
+                option("NullAway:JSpecifyMode", "true")
+                // Event handlers are discovered reflectively by Orbit.
+                option("UnusedMethod:ExcludedAnnotations", "meteordevelopment.orbit.EventHandler")
+            }
+        }
     }
 
     javadoc {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,8 @@ fabric-api = "0.154.2+26.2"
 # Plugins
 # Loom (https://github.com/FabricMC/fabric-loom)
 loom = "1.17-SNAPSHOT"
+# Error Prone Plugin (https://github.com/tbroyer/gradle-errorprone-plugin)
+errorprone-plugin = "5.1.1"
 
 # Mods
 # Baritone (https://github.com/MeteorDevelopment/baritone)
@@ -37,6 +39,12 @@ waybackauthlib = "1.1.0"
 # MinecraftAuth (https://github.com/RaphiMC/MinecraftAuth)
 minecraftauth = "5.0.2"
 
+# Libraries
+# Error Prone (https://github.com/google/error-prone)
+errorprone = "2.50.0"
+# NullAway (https://github.com/uber/NullAway)
+nullaway = "0.14.0"
+
 [libraries]
 # Fabric base
 minecraft = { module = "com.mojang:minecraft", version.ref = "minecraft" }
@@ -60,6 +68,9 @@ netty-handler-proxy = { module = "io.netty:netty-handler-proxy", version.ref = "
 netty-codec-socks = { module = "io.netty:netty-codec-socks", version.ref = "netty" }
 waybackauthlib = { module = "de.florianreuth:waybackauthlib", version.ref = "waybackauthlib" }
 minecraft-auth = { module = "net.raphimc:MinecraftAuth", version.ref = "minecraftauth" }
+errorprone-core = { module = "com.google.errorprone:error_prone_core", version.ref = "errorprone" }
+nullaway = { module = "com.uber.nullaway:nullaway", version.ref = "nullaway" }
 
 [plugins]
 fabric-loom = { id = "net.fabricmc.fabric-loom", version.ref = "loom" }
+errorprone = { id = "net.ltgt.errorprone", version.ref = "errorprone-plugin" }


### PR DESCRIPTION
## Type of change

* [ ] Bug fix
* [x] New feature

## Description

Adds opt-in [Error Prone](https://github.com/google/error-prone) and [NullAway](https://github.com/uber/NullAway) static analysis with [JSpecify](https://github.com/jspecify/jspecify) support.

The checks are enabled with `-Perrorprone`, allowing nullability issues across `meteordevelopment.meteorclient` to be detected without affecting normal builds.

## Related issues

N/A

# How Has This Been Tested?

* `./gradlew build` for a normal build
* `./gradlew build -Perrorprone` for a null-checking build

Both builds complete successfully.

# Checklist:

* [x] My code follows the style guidelines of this project.
* [x] I have added comments to my code in more complex areas.
* [x] I have tested the code in both development and production environments.
