### PR TITLE
Add baritone prefix to starscript

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/MeteorStarscript.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/MeteorStarscript.java
@@ -104,6 +104,7 @@ public class MeteorStarscript {
                 .set("process", MeteorStarscript::baritoneProcess)
                 .set("process_name", MeteorStarscript::baritoneProcessName)
                 .set("eta", MeteorStarscript::baritoneETA)
+                .set("prefix", MeteorStarscript::baritonePrefix)
             );
         }
 
@@ -455,6 +456,10 @@ public class MeteorStarscript {
         if (mc.player == null) return Value.number(0);
         Optional<Double> ticksTillGoal = BaritoneAPI.getProvider().getPrimaryBaritone().getPathingBehavior().estimatedTicksToGoal();
         return ticksTillGoal.map(aDouble -> Value.number(aDouble / 20)).orElseGet(() -> Value.number(0));
+    }
+
+    private static Value baritonePrefix() {
+        return Value.string(BaritoneAPI.getSettings().prefix.value);
     }
 
     private static Value oppositeX(boolean camera) {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Add a Starscript value that contains Baritone's command prefix. Useful for macros.

# How Has This Been Tested?

<img width="480" height="270" alt="Macro settings showing the use of {baritone.prefix}" src="https://github.com/user-attachments/assets/c0307f63-071b-4de8-ab2a-13dc709dbda9" />
<img width="335" height="64" alt="The macro working (chat message by baritone confirming action)" src="https://github.com/user-attachments/assets/709e3218-3799-4fab-93fd-3de1d5002975" />

I also tested changing the baritone prefix, and the value changed accordingly.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
No comments needed
- [ ] I have tested the code in both development and production environments.
Do I need to add test cases to this?