### PR TITLE
BetterTab: add Friends only option.

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/PlayerTabOverlayMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/PlayerTabOverlayMixin.java
@@ -7,6 +7,7 @@ package meteordevelopment.meteorclient.mixin;
 
 import com.llamalad7.mixinextras.sugar.Local;
 import com.llamalad7.mixinextras.sugar.ref.LocalIntRef;
+import java.util.Comparator;
 import meteordevelopment.meteorclient.systems.friends.Friends;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.render.BetterTab;
@@ -41,13 +42,22 @@ public abstract class PlayerTabOverlayMixin {
     private void friendsOnly(CallbackInfoReturnable<List<PlayerInfo>> cir) {
         BetterTab betterTab = Modules.get().get(BetterTab.class);
 
-        if (betterTab.isActive() && betterTab.onlyFriends.get()) {
+        if (betterTab.isActive()) {
             List<PlayerInfo> players = cir.getReturnValue();
-            cir.setReturnValue(players.stream()
-                .filter(
-                    info -> info.getProfile().id().equals(Minecraft.getInstance().player.getUUID()) || Friends.get().isFriend(info)
-                ).toList()
-            );
+
+            if (betterTab.onlyFriends.get()) {
+                players = players.stream()
+                    .filter(info -> info.getProfile().id().equals(Minecraft.getInstance().player.getUUID()) || Friends.get().isFriend(info))
+                    .toList();
+            }
+
+            if (betterTab.friendsFirst.get()) {
+                players = players.stream()
+                    .sorted(Comparator.comparing(info -> !(info.getProfile().id().equals(Minecraft.getInstance().player.getUUID()) || Friends.get().isFriend(info))))
+                    .toList();
+            }
+
+            cir.setReturnValue(players);
         }
     }
 

--- a/src/main/java/meteordevelopment/meteorclient/mixin/PlayerTabOverlayMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/PlayerTabOverlayMixin.java
@@ -7,6 +7,7 @@ package meteordevelopment.meteorclient.mixin;
 
 import com.llamalad7.mixinextras.sugar.Local;
 import com.llamalad7.mixinextras.sugar.ref.LocalIntRef;
+import meteordevelopment.meteorclient.systems.friends.Friends;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.render.BetterTab;
 import net.minecraft.client.Minecraft;
@@ -34,6 +35,20 @@ public abstract class PlayerTabOverlayMixin {
         BetterTab module = Modules.get().get(BetterTab.class);
 
         return module.isActive() ? module.tabSize.get() : count;
+    }
+
+    @Inject(method = "getPlayerInfos", at = @At("RETURN"), cancellable = true)
+    private void friendsOnly(CallbackInfoReturnable<List<PlayerInfo>> cir) {
+        BetterTab betterTab = Modules.get().get(BetterTab.class);
+
+        if (betterTab.isActive() && betterTab.onlyFriends.get()) {
+            List<PlayerInfo> players = cir.getReturnValue();
+            cir.setReturnValue(players.stream()
+                .filter(
+                    info -> info.getProfile().id().equals(Minecraft.getInstance().player.getUUID()) || Friends.get().isFriend(info)
+                ).toList()
+            );
+        }
     }
 
     @Inject(method = "getNameForDisplay", at = @At("HEAD"), cancellable = true)

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BetterTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BetterTab.java
@@ -71,6 +71,14 @@ public class BetterTab extends Module {
         .build()
     );
 
+    public final Setting<Boolean> friendsFirst = sgGeneral.add(new BoolSetting.Builder()
+        .name("show-friends-first")
+        .description("First show friends and yourself in the tablist, then everyone else.")
+        .defaultValue(false)
+        .visible(() -> !onlyFriends.get())
+        .build()
+    );
+
     public final Setting<Boolean> accurateLatency = sgGeneral.add(new BoolSetting.Builder()
         .name("accurate-latency")
         .description("Shows latency as a number in the tablist.")

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BetterTab.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/BetterTab.java
@@ -64,6 +64,13 @@ public class BetterTab extends Module {
         .build()
     );
 
+    public final Setting<Boolean> onlyFriends = sgGeneral.add(new BoolSetting.Builder()
+        .name("show-only-friends")
+        .description("Only show friends and yourself in the tablist, nobody else.")
+        .defaultValue(false)
+        .build()
+    );
+
     public final Setting<Boolean> accurateLatency = sgGeneral.add(new BoolSetting.Builder()
         .name("accurate-latency")
         .description("Shows latency as a number in the tablist.")


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature

## Description

Add friends-only filtering to BetterTab. 9b player count is peaking and I rather just see my friends. I also visit other servers like 6b time to time and they have 600 players time to time, and I rather just only see my friends.

## Related issues

None.

# How Has This Been Tested?
<img width="467" height="320" alt="2026-08-28T16:38:35+00:00" src="https://github.com/user-attachments/assets/960caa36-f83d-4f7d-92f7-ea55783e4659" />

# Checklist:

- [ ] My code follows the style guidelines of this project. (idk how to style the stream api stuff for ur project, but I do run google's styling in my IDE)
- [ ] I have added comments to my code in more complex areas. (irrelevant)
- [X] I have tested the code in both development and production environments.
