### PR TITLE
fix: support two-component Minecraft versions

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/MeteorClient.java
+++ b/src/main/java/meteordevelopment/meteorclient/MeteorClient.java
@@ -46,8 +46,6 @@ import org.spongepowered.asm.mixin.MixinEnvironment;
 
 import java.io.File;
 import java.lang.invoke.MethodHandles;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class MeteorClient implements ClientModInitializer {
     public static final String MOD_ID = "meteor-client";
@@ -71,9 +69,9 @@ public class MeteorClient implements ClientModInitializer {
         LOG = LoggerFactory.getLogger(NAME);
 
         String versionString = MOD_META.getVersion().getFriendlyString();
-        Matcher matcher = Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)").matcher(versionString);
+        if (versionString.contains("-")) versionString = versionString.split("-")[0];
         // When building and running through IntelliJ and not Gradle it doesn't replace the version so just use a dummy
-        versionString = !matcher.find() ? "0.0.0" : "%s.%s.%s".formatted(matcher.group(1), matcher.group(2), matcher.group(3));
+        if (versionString.equals("${version}")) versionString = "0.0.0";
 
         VERSION = new Version(versionString);
         BUILD_NUMBER = MOD_META.getCustomValue(MeteorClient.MOD_ID + ":build_number").getAsString();

--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/Version.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/Version.java
@@ -14,9 +14,11 @@ public class Version {
         this.numbers = new int[3];
 
         String[] split = string.split("\\.");
-        if (split.length != 3) throw new IllegalArgumentException("Version string needs to have 3 numbers.");
+        if (split.length < 2 || split.length > 3) {
+            throw new IllegalArgumentException("Version string needs to have 2 or 3 numbers.");
+        }
 
-        for (int i = 0; i < 3; i++) {
+        for (int i = 0; i < split.length; i++) {
             try {
                 numbers[i] = Integer.parseInt(split[i]);
             } catch (NumberFormatException _) {


### PR DESCRIPTION
## Type of change

* [x] Bug fix
* [ ] New feature

## Description

The version parsing logic was made overly restrictive by requiring exactly three numeric version components.

Minecraft release versions can contain either two or three components, such as `26.1`, `26.2`, and `26.2.1`. 
The stricter parsing caused valid two-component versions to be rejected and `MeteorClient.VERSION` to fall back to `0.0.0`.

This change restores the previous build-version handling in `MeteorClient` while updating `Version` to correctly accept both two- and three-component versions. 
A missing third component is represented internally as `0` for version comparisons, while the original version string is preserved.

## Related issues

Closes https://github.com/MeteorDevelopment/meteor-client/issues/6620.

# How Has This Been Tested?

Tested by building and running Meteor with a two-component Minecraft version (26.2) and verifying that the Meteor version is correctly reported instead of `0.0.0`.

# Checklist:

* [x] My code follows the style guidelines of this project.
* [x] I have added comments to my code in more complex areas.
* [x] I have tested the code in both development and production environments.
