### PR TITLE
Fixed the map hud element being scaled down by the gui scale twice

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/MapHud.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/elements/MapHud.java
@@ -152,7 +152,6 @@ public class MapHud extends HudElement {
 
             Matrix3x2fStack matrices = renderer.graphics.pose();
             matrices.pushMatrix();
-            matrices.scale(1f / mc.getWindow().getGuiScale());
             matrices.translate(this.x, this.y);
             matrices.scale(scale.get().floatValue());
             renderer.graphics.map(renderState);


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Since e43739752 ("26.2 update", #6439), `HudRenderer#begin` pushes the gui scale onto the pose
itself:

```java
graphics.pose().pushMatrix();
graphics.pose().scale(1.0f / mc.getWindow().getGuiScale());
```

and `end()` runs the post tasks *before* it pops that matrix, so the scale is still live inside
them. `MapHud` applies `1f / getGuiScale()` a second time inside its own post task, which was
correct when the element was added in ac05a1ac1 (#5950) because `begin(DrawContext)` did not
touch the pose back then.

The result is that both the map and the `translate(this.x, this.y)` that positions it get
divided by the gui scale twice. At gui scale 3 the map draws at roughly 43x43 px in the corner
of a 128x128 box, and the background quad and the hud editor outline are still drawn in real
pixels at the right place, so the element cannot be lined up with anything.

Dropping the extra scale leaves the post task in the same coordinate space every other element
already uses.

## Related issues

None that I found.

# How Has This Been Tested?

Not reproduced in game yet, this came out of reading the render path: `begin()` pushes
`scale(1 / guiScale)` and `end()` runs the post tasks before it pops that matrix, so the element
is scaled twice. Builds clean against current master.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [ ] I have tested the code in both development and production environments.