### PR TITLE
Fixed a failed font load leaving the text renderer destroyed

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/renderer/Fonts.java
+++ b/src/main/java/meteordevelopment/meteorclient/renderer/Fonts.java
@@ -59,14 +59,12 @@ public class Fonts {
     }
 
     public static void load(FontFace fontFace) {
-        if (RENDERER != null) {
-            if (RENDERER.fontFace.equals(fontFace)) return;
-            else RENDERER.destroy();
-        }
+        if (RENDERER != null && RENDERER.fontFace.equals(fontFace)) return;
+
+        CustomTextRenderer renderer;
 
         try {
-            RENDERER = new CustomTextRenderer(fontFace);
-            MeteorClient.EVENT_BUS.post(CustomFontChangedEvent.get());
+            renderer = new CustomTextRenderer(fontFace);
         } catch (Exception e) {
             if (fontFace.equals(DEFAULT_FONT)) {
                 throw new RuntimeException("Failed to load default font: " + fontFace, e);
@@ -74,7 +72,13 @@ public class Fonts {
 
             MeteorClient.LOG.error("Failed to load font: {}", fontFace, e);
             load(Fonts.DEFAULT_FONT);
+            return;
         }
+
+        if (RENDERER != null) RENDERER.destroy();
+        RENDERER = renderer;
+
+        MeteorClient.EVENT_BUS.post(CustomFontChangedEvent.get());
 
         if (mc.gui.screen() instanceof WidgetScreen widgetScreen && Config.get().customFont.get()) {
             widgetScreen.invalidate();


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

`Fonts#load` destroys the current renderer before it has a replacement:

```java
if (RENDERER != null) {
    if (RENDERER.fontFace.equals(fontFace)) return;
    else RENDERER.destroy();
}

try {
    RENDERER = new CustomTextRenderer(fontFace);
```

If the constructor throws, the catch falls back to `load(DEFAULT_FONT)`. That recursive call
sees `RENDERER != null` and compares `RENDERER.fontFace` against `DEFAULT_FONT`. `FontFace` does
not override `equals` and `FontFamily#get` hands back the same stored instance, so when the font
you were already on was the default, that check passes and the call returns immediately.
`RENDERER` is left pointing at the renderer that was destroyed a few lines earlier, with all
five of its textures closed.

Every Meteor text draw after that throws out of `CustomTextRenderer#end` when
`getTextureView()` is called on a closed texture, so the whole gui is unusable until a restart.
`CustomFontChangedEvent` is never posted either, so anything caching a font holder keeps the
dead one.

Hitting it only takes picking a system font whose file has been moved or deleted since the
startup scan, which is normal enough after a font package update.

Building the new renderer first and only destroying the old one once that succeeded also makes
the early return correct rather than dangerous: on the fallback path `RENDERER` is still the
live renderer, so returning early because it is already the default font is exactly right.

## Related issues

None that I found.

# How Has This Been Tested?

Not reproduced in game yet. The path is easy to follow though: the recursive `load(DEFAULT_FONT)`
hits the identity check against a renderer that was already destroyed, since `FontFace` does not
override `equals`. Builds clean against current master.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [ ] I have tested the code in both development and production environments.