### PR TITLE
Fixed chams leaking polygon offset state when an entity render is cancelled

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/LivingEntityRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/LivingEntityRendererMixin.java
@@ -98,7 +98,10 @@ public abstract class LivingEntityRendererMixin<T extends LivingEntity, S extend
         Entity entity = ((IEntityRenderState) state).meteor$getEntity();
         if (!(entity instanceof LivingEntity livingEntity)) return;
 
-        if (Modules.get().get(NoRender.class).noDeadEntities() && livingEntity.isDeadOrDying()) ci.cancel();
+        if (Modules.get().get(NoRender.class).noDeadEntities() && livingEntity.isDeadOrDying()) {
+            ci.cancel();
+            return;
+        }
 
         if (chams.shouldRender(entity)) {
             glEnable(GL_POLYGON_OFFSET_FILL);


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

In `LivingEntityRendererMixin#render$Head`:

```java
if (Modules.get().get(NoRender.class).noDeadEntities() && livingEntity.isDeadOrDying()) ci.cancel();

if (chams.shouldRender(entity)) {
    glEnable(GL_POLYGON_OFFSET_FILL);
    glPolygonOffset(1.0f, -1100000.0f);
}
```

`ci.cancel()` does not return, so the chams block still runs and enables the polygon offset. But
cancelling means `submit` never reaches its tail, so the `@At("TAIL")` injection that turns the
offset back off never runs. The offset stays enabled with a -1100000 bias for the rest of the
frame and everything drawn after that entity gets pulled through geometry.

Needs NoRender's dead entities option and Chams on at the same time, which is a common enough
combination on servers with a lot of corpses lying around.

## Related issues

None that I found.

# How Has This Been Tested?

Not reproduced in game yet. `ci.cancel()` skips the tail injection that restores the offset, so
the state cannot be unwound once the head has enabled it. Builds clean against current master.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [ ] I have tested the code in both development and production environments.