### PR TITLE
Fixed elytra fly bounce recasting when any living entity stops gliding

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/LivingEntityMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/LivingEntityMixin.java
@@ -92,6 +92,8 @@ public abstract class LivingEntityMixin extends Entity {
 
     @Inject(method = "isFallFlying", at = @At("TAIL"), cancellable = true)
     public void recastOnLand(CallbackInfoReturnable<Boolean> cir) {
+        if ((Object) this != mc.player) return;
+
         boolean elytra = cir.getReturnValue();
         ElytraFly elytraFly = Modules.get().get(ElytraFly.class);
         if (previousElytra && !elytra && elytraFly.isActive() && elytraFly.flightMode.get() == ElytraFlightModes.Bounce) {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

`LivingEntityMixin#recastOnLand` is injected into `isFallFlying`, which every `LivingEntity`
calls, but it has no check that the entity is the local player. `isGlidingHook` right above it
does exactly that check.

So when any remote player or mob stops gliding, the injection calls
`Bounce.recastElytra(mc.player)`, which sends a `START_FALL_FLYING` for *you*, and then feeds
that result back as the other entity's `isFallFlying` return value with
`cir.setReturnValue(...)`.

Adding the same guard the rest of the file uses keeps the recast on the local player where it
belongs.

## Related issues

None that I found.

# How Has This Been Tested?

Not reproduced in game yet, this is a missing guard rather than something I caught happening.
`isFallFlying` runs for every living entity and the injection above it already guards on
`mc.player`. Builds clean against current master.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [ ] I have tested the code in both development and production environments.