### PR TITLE
Fixed esp fade distance being squared twice

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/render/ESP.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/render/ESP.java
@@ -390,9 +390,9 @@ public class ESP extends Module {
 
     private double getFadeAlpha(Entity entity) {
         double dist = PlayerUtils.squaredDistanceToCamera(entity.getX(), entity.getY() + entity.getEyeHeight(entity.getPose()), entity.getZ());
-        double fadeDist = Math.pow(fadeDistance.get(), 2);
+        double fadeDist = fadeDistance.get();
         double alpha = 1;
-        if (dist <= fadeDist * fadeDist) alpha = (float) (Math.sqrt(dist) / fadeDist);
+        if (dist <= fadeDist * fadeDist) alpha = Math.sqrt(dist) / fadeDist;
         if (alpha <= 0.075) alpha = 0;
         return alpha;
     }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

`ESP#getFadeAlpha` squares the fade distance and then treats the result as if it were still a
plain distance:

```java
double dist = PlayerUtils.squaredDistanceToCamera(...);
double fadeDist = Math.pow(fadeDistance.get(), 2);
if (dist <= fadeDist * fadeDist) alpha = (float) (Math.sqrt(dist) / fadeDist);
```

`dist` is squared, so the comparison is against the fade distance to the fourth power, and the
ramp divides a real distance by a squared one. With the default of 3 the fade starts at 9 blocks
instead of 3, and an entity sitting exactly at the fade distance comes out at alpha 0.33 instead
of 1. The setting description says the distance where the colour begins to fade, which is not
what you get.

Comparing squared against squared and dividing distance by distance is all it needs.

## Related issues

None that I found.

# How Has This Been Tested?

Not measured in game yet. The units do not line up in the source: `dist` is squared and it is
compared against `fadeDist * fadeDist` where `fadeDist` is already squared. Builds clean against
current master.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [ ] I have tested the code in both development and production environments.