### PR TITLE
Fixed bold italic fonts not being restored on restart

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/settings/FontFaceSetting.java
+++ b/src/main/java/meteordevelopment/meteorclient/settings/FontFaceSetting.java
@@ -66,24 +66,19 @@ public class FontFaceSetting extends Setting<FontFace> {
     @Override
     protected FontFace load(CompoundTag tag) {
         String family = tag.getStringOr("family", "");
-        FontInfo.Type type;
+        FontInfo.Type type = FontInfo.Type.fromString(tag.getStringOr("type", ""));
 
-        try {
-            type = FontInfo.Type.valueOf(tag.getStringOr("type", ""));
-        } catch (IllegalArgumentException _) {
-            set(Fonts.DEFAULT_FONT);
-            return get();
-        }
-
-        boolean changed = false;
         for (FontFamily fontFamily : Fonts.FONT_FAMILIES) {
-            if (fontFamily.getName().equals(family)) {
-                set(fontFamily.get(type));
-                changed = true;
+            if (!fontFamily.getName().equals(family)) continue;
+
+            FontFace face = fontFamily.get(type);
+            if (face != null) {
+                set(face);
+                return get();
             }
         }
-        if (!changed) set(Fonts.DEFAULT_FONT);
 
+        set(Fonts.DEFAULT_FONT);
         return get();
     }
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

`FontFaceSetting` saves the font type with `toString()` and loads it with `valueOf`.
`FontInfo.Type` overrides `toString` so `BoldItalic` writes out as `"Bold Italic"` with a space,
and `valueOf("Bold Italic")` throws, so the catch quietly resets you to the default font.

Picking a Bold Italic face therefore never survives a restart. There is already a
`FontInfo.Type#fromString` that handles both `"Bold Italic"` and `"BoldItalic"`, the load path
just was not using it.

Also null checks the face before setting it, since `FontFamily#get` returns null for a type the
family does not have, and moved the default fallback to a single exit instead of the `changed`
flag.

## Related issues

None that I found.

# How Has This Been Tested?

Not reproduced in game yet. `FontInfo.Type#toString` returns `"Bold Italic"` with a space and
`valueOf` only accepts `BoldItalic`, so the load always throws for that one type. Builds clean
against current master.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [ ] I have tested the code in both development and production environments.