### PR TITLE
Fixed ambience lightning using the segment index as an x coordinate

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/LightningBoltRendererMixin.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/LightningBoltRendererMixin.java
@@ -29,8 +29,8 @@ public abstract class LightningBoltRendererMixin {
             Color color = ambience.lightningColor.get();
 
             buffer.addVertex(pose, xo0 + (px1 ? rr2 : -rr2), (float) (h * 16), zo0 + (pz1 ? rr2 : -rr2)).setColor(color.r / 255f, color.g / 255f, color.b / 255f, 0.3F);
-            buffer.addVertex(pose, h + (px1 ? rr1 : -rr1), (float) ((h + 1) * 16), zo1 + (pz1 ? rr1 : -rr1)).setColor(color.r / 255f, color.g / 255f, color.b / 255f, 0.3F);
-            buffer.addVertex(pose, h + (px2 ? rr1 : -rr1), (float) ((h + 1) * 16), zo1 + (pz2 ? rr1 : -rr1)).setColor(color.r / 255f, color.g / 255f, color.b / 255f, 0.3F);
+            buffer.addVertex(pose, xo1 + (px1 ? rr1 : -rr1), (float) ((h + 1) * 16), zo1 + (pz1 ? rr1 : -rr1)).setColor(color.r / 255f, color.g / 255f, color.b / 255f, 0.3F);
+            buffer.addVertex(pose, xo1 + (px2 ? rr1 : -rr1), (float) ((h + 1) * 16), zo1 + (pz2 ? rr1 : -rr1)).setColor(color.r / 255f, color.g / 255f, color.b / 255f, 0.3F);
             buffer.addVertex(pose, xo0 + (px2 ? rr2 : -rr2), (float) (h * 16), zo0 + (pz2 ? rr2 : -rr2)).setColor(color.r / 255f, color.g / 255f, color.b / 255f, 0.3F);
 
             ci.cancel();


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

The recoloured lightning quad in `LightningBoltRendererMixin` uses `h` where the x offset
belongs:

```java
buffer.addVertex(pose, h + (px1 ? rr1 : -rr1), (float) ((h + 1) * 16), zo1 + (pz1 ? rr1 : -rr1))
```

`h` is the segment index, it is already being used for the y coordinate as `h * 16`. The top two
vertices take `zo1` for z, so they should take `xo1` for x, and `xo1` is otherwise never read in
the method. The top of every segment ends up pinned near x = 0..7 instead of following the bolt,
so with Ambience's lightning colour on the bolts are visibly skewed compared to vanilla ones.

## Related issues

None that I found.

# How Has This Been Tested?

Not compared side by side in game yet. `xo1` being unused while `h` appears in an x slot is
clear enough from the method on its own. Builds clean against current master.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [ ] I have tested the code in both development and production environments.