### PR TITLE
Clear the enchantment name cache when resource packs reload

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/utils/misc/Names.java
+++ b/src/main/java/meteordevelopment/meteorclient/utils/misc/Names.java
@@ -60,6 +60,7 @@ public class Names {
         statusEffectNames.clear();
         itemNames.clear();
         blockNames.clear();
+        enchantmentKeyNames.clear();
         enchantmentEntryNames.clear();
         entityTypeNames.clear();
         particleTypesNames.clear();


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

`Names#onResourcePacksReloaded` clears seven of the eight caches. `enchantmentKeyNames` is the
one it misses, so enchantment names stay in the old language after a language change or a
resource pack reload. It is a `WeakHashMap`, but the registry holds the `ResourceKey`s, so the
entries are not going anywhere on their own.

## Related issues

None that I found.

# How Has This Been Tested?

Not reproduced in game yet, it is just the one cache missing from the reload handler that clears
the other seven. Builds clean against current master.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [ ] I have tested the code in both development and production environments.