### PR TITLE
Fixed hud text width counting the shadow offset twice

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/hud/HudRenderer.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/hud/HudRenderer.java
@@ -175,7 +175,7 @@ public class HudRenderer {
 
         if (hud.hasCustomFont()) {
             double width = getFont(scale).getWidth(text, text.length());
-            return (width + (shadow ? 1 : 0)) * (scale == -1 ? hud.getTextScale() : scale) + (shadow ? 1 : 0);
+            return width * (scale == -1 ? hud.getTextScale() : scale) + (shadow ? 1 : 0);
         }
 
         VanillaTextRenderer.INSTANCE.scale = (scale == -1 ? hud.getTextScale() : scale) * 2;


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

`HudRenderer#textWidth` adds the shadow twice:

```java
return (width + (shadow ? 1 : 0)) * (scale == -1 ? hud.getTextScale() : scale) + (shadow ? 1 : 0);
```

once inside the multiply and once after it. `text()` draws the shadow at `x + 1`, an offset in
the same space as `x`, so the shadow only ever adds one unscaled pixel to the drawn width. The
reported width is `scale` px too wide, which shows up as extra padding on the right of every
shadowed hud element and grows with the text scale.

## Related issues

None that I found.

# How Has This Been Tested?

Not measured in game yet. `text()` offsets the shadow by one unscaled pixel, so the extra
`* scale` term in `textWidth` has nothing behind it. Builds clean against current master.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [ ] I have tested the code in both development and production environments.