### PR TITLE
Fixed KillAura ignoring the passive mob age filter

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/KillAura.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/combat/KillAura.java
@@ -437,7 +437,7 @@ public class KillAura extends Module {
             }
             // Passive mobs with baby variants (animals, villagers)
             if (entity instanceof AgeableMob && (!(entity instanceof Frog || entity instanceof Parrot))) {
-                passiveMobAgeFilter.get().test(livingEntity);
+                return passiveMobAgeFilter.get().test(livingEntity);
             }
         }
         return true;


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

`KillAura.entityCheck()` never applies `passive-mob-age-filter`. The passive branch calls the predicate and throws the result away:

```java
// Passive mobs with baby variants (animals, villagers)
if (entity instanceof AgeableMob && (!(entity instanceof Frog || entity instanceof Parrot))) {
    passiveMobAgeFilter.get().test(livingEntity);
}
```

Execution always falls through to the trailing `return true;`, so every ageable mob is accepted regardless of the setting. The hostile branch immediately above it returns its result correctly, which is why `hostile-mob-age-filter` still works.

This is a regression from the 26.2 update (#6439), which moved the age logic onto `EntityAgeTest.test()`. Before that commit the branch read:

```java
return switch (passiveMobAgeFilter.get()) {
    case Baby -> livingEntity.isBaby();
    case Adult -> !livingEntity.isBaby();
    case Both -> true;
};
```

The `return` was dropped in the refactor. `EntityAgeTest.test()` is semantically identical to the old switch, so adding the `return` back restores the original behaviour exactly.

I also checked the other consumer of the enum, `AutoBreed`, which uses the result correctly - `KillAura` is the only affected call site.

## Related issues

Closes #6608

# How Has This Been Tested?

`./gradlew compileJava` passes.

The failure is deterministic and readable from the control flow: with `passive-mob-age-filter` set to `Adult`, a baby cow reaches the discarded `test()` call and then `return true`, so it is targeted. With the fix the method returns `!livingEntity.isBaby()` and the baby is skipped. `Frog` and `Parrot` are excluded from the branch and are unaffected either way.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
