### PR TITLE
Stopped Nuker overwriting the range setting every tick

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/Nuker.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/Nuker.java
@@ -351,10 +351,9 @@ public class Nuker extends Module {
         double rangeSq = Math.pow(range.get(), 2);
         BlockPos playerBlockPos = mc.player.blockPosition();
 
-        if (shape.get() == Shape.UniformCube) range.set((double) Math.round(range.get()));
-
         double pX_ = pX;
         double pZ_ = pZ;
+        // Uniform cube works on whole blocks, so round the range locally instead of writing it back to the setting
         int r = (int) Math.round(range.get());
 
         if (shape.get() == Shape.UniformCube) {
@@ -410,7 +409,7 @@ public class Nuker extends Module {
                         return;
                 }
                 case UniformCube -> {
-                    if (chebyshevDist(playerBlockPos.getX(), playerBlockPos.getY(), playerBlockPos.getZ(), blockPos.getX(), blockPos.getY(), blockPos.getZ()) >= range.get())
+                    if (chebyshevDist(playerBlockPos.getX(), playerBlockPos.getY(), playerBlockPos.getZ(), blockPos.getX(), blockPos.getY(), blockPos.getZ()) >= r)
                         return;
                 }
                 case Cube -> {

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/world/Nuker.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/world/Nuker.java
@@ -356,12 +356,19 @@ public class Nuker extends Module {
         // Uniform cube works on whole blocks, so round the range locally instead of writing it back to the setting
         int r = (int) Math.round(range.get());
 
+        // How far the block iterator has to reach to cover the shape
+        int horizontalRange, verticalRange;
+
         if (shape.get() == Shape.UniformCube) {
             pX_ += 1; // weird position stuff
             pos1.set(pX_ - r, pY - r + 1, pZ - r + 1); // down
             pos2.set(pX_ + r - 1, pY + r, pZ + r); // up
             maxh = 0;
             maxv = 0;
+
+            // The chebyshev check below uses the rounded radius, so anything past it would only be thrown away
+            horizontalRange = r + 1;
+            verticalRange = r;
         } else {
             // Only change me if you want to mess with 3D rotations:
             // I messed with it
@@ -393,6 +400,9 @@ public class Nuker extends Module {
             // get largest horizontal
             maxh = 1 + Math.max(Math.max(Math.max(range_back.get(), range_right.get()), range_forward.get()), range_left.get());
             maxv = 1 + Math.max(range_up.get(), range_down.get());
+
+            horizontalRange = (int) Math.ceil(range.get() + 1);
+            verticalRange = (int) Math.ceil(range.get());
         }
 
         // Flatten
@@ -401,7 +411,7 @@ public class Nuker extends Module {
         AABB box = new AABB(Vec3.atCenterOf(pos1), Vec3.atCenterOf(pos2));
 
         // Find blocks to break
-        BlockIterator.register(Math.max((int) Math.ceil(range.get() + 1), maxh), Math.max((int) Math.ceil(range.get()), maxv), (blockPos, blockState) -> {
+        BlockIterator.register(Math.max(horizontalRange, maxh), Math.max(verticalRange, maxv), (blockPos, blockState) -> {
             Vec3 center = Vec3.atCenterOf(blockPos);
             switch (shape.get()) {
                 case Sphere -> {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

`Nuker.onTickPre()` rounds the `range` setting by writing back to it:

```java
if (shape.get() == Shape.UniformCube) range.set((double) Math.round(range.get()));
```

Two problems with doing this from the tick handler:

- It mutates the user's config. A range of `4.4` typed into the slider is silently rewritten to `4.0` and saved that way, so switching the shape back to Sphere or Cube leaves the user with a value they never chose.
- It runs 20 times a second for as long as Nuker is enabled. `Setting#set` has no equality check, so `onChanged` fires on every tick even when the value is already rounded, and the value fights the slider while it is being dragged.

The rounded value is already computed three lines later as `int r`, which the uniform cube branch uses for `pos1`/`pos2`. This drops the `set()` call and compares the chebyshev distance against `r` instead of `range.get()`, so the break shape is unchanged while the setting is left alone.

The `BlockIterator.register()` extents also had to move off the raw `range`. They are the reach of the shared iterator, and the uniform cube filter only accepts blocks within the rounded `r`, so a fractional range would have made the iterator walk a larger volume purely to throw the extra blocks away - `4.4` would grow it from 11x11x9 to 13x13x11, and because the radii are shared, any other module registered that tick would have been dragged along. The extents are now computed per shape alongside the existing `maxh`/`maxv`, which keeps the iteration footprint identical to the old rounded behaviour.

## Related issues

Closes #6609

# How Has This Been Tested?

`./gradlew compileJava` passes.

With shape set to `UniformCube` and range `4`, `r` is `4` both before and after the change, the iterator radii are `5`/`4` as before, and the same blocks are selected. The visible difference is that a fractional range now stays in the settings screen instead of snapping on the next tick.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
